### PR TITLE
[DRAFT] OVRProvider - Oculus Quest Hand Tracking

### DIFF
--- a/Assets/Plugins/LeapMotion/Core/Scripts/Encoding/VectorHand.cs
+++ b/Assets/Plugins/LeapMotion/Core/Scripts/Encoding/VectorHand.cs
@@ -219,7 +219,7 @@ namespace Leap.Unity.Encoding {
     /// the camera-local hand rotation uses 4 bytes, and each joint position component is
     /// encoded in hand-local space using 3 bytes.
     /// </summary>
-    public int numBytesRequired { get { return 86; } }
+    public int numBytesRequired { get { return 92; } }
     public const int NUM_BYTES = 86;
     
     /// <summary>
@@ -248,7 +248,7 @@ namespace Leap.Unity.Encoding {
       // Palm position and rotation.
       for (int i = 0; i < 3; i++) {
         palmPos[i] = Convert.ToSingle(
-                       BitConverterNonAlloc.ToInt16(bytes, ref offset))
+                       BitConverterNonAlloc.ToInt32(bytes, ref offset))
                      / 4096f;
       }
       palmRot = Utils.DecompressBytesToQuat(bytes, ref offset);
@@ -287,7 +287,7 @@ namespace Leap.Unity.Encoding {
       
       // Palm position, each component compressed 
       for (int i = 0; i < 3; i++) {
-        BitConverterNonAlloc.GetBytes(Convert.ToInt16(palmPos[i] * 4096f),
+        BitConverterNonAlloc.GetBytes(Convert.ToInt32(palmPos[i] * 4096f),
                                       bytesToFill,
                                       ref offset);
       }

--- a/Assets/Plugins/LeapMotion/Core/Scripts/Encoding/VectorHand.cs
+++ b/Assets/Plugins/LeapMotion/Core/Scripts/Encoding/VectorHand.cs
@@ -185,7 +185,7 @@ namespace Leap.Unity.Encoding {
         grabStrength:           0.5f,
         grabAngle:              100f,
         pinchStrength:          0.5f,
-        pinchDistance:          50f,
+        pinchDistance:          (jointPositions[4] - jointPositions[9]).magnitude * 1000,
         palmWidth:              0.085f,
         isLeft:                 isLeft,
         timeVisible:            1f,

--- a/Assets/Plugins/LeapMotion/Core/Scripts/Encoding/VectorHand.cs
+++ b/Assets/Plugins/LeapMotion/Core/Scripts/Encoding/VectorHand.cs
@@ -114,6 +114,8 @@ namespace Leap.Unity.Encoding {
 
       // Fill fingers.
       for (int fingerIdx = 0; fingerIdx < 5; fingerIdx++) {
+        float fingerLength = 0f;
+
         for (int jointIdx = 0; jointIdx < 4; jointIdx++) {
           boneIdx   = fingerIdx * 4 + jointIdx;
           prevJoint = jointPositions[fingerIdx * 5 + jointIdx];
@@ -137,12 +139,15 @@ namespace Leap.Unity.Encoding {
           prevJoint = ToWorld(prevJoint, palmPos, palmRot);
           boneRot = palmRot * boneRot;
 
+          float length = (prevJoint - nextJoint).magnitude;
+          if (jointIdx != 0) fingerLength += length;
+
           intoHand.GetBone(boneIdx).Fill(
             prevJoint: prevJoint.ToVector(),
             nextJoint: nextJoint.ToVector(),
             center: ((nextJoint + prevJoint) / 2f).ToVector(),
             direction: (palmRot * Vector3.forward).ToVector(),
-            length: (prevJoint - nextJoint).magnitude,
+            length: length,
             width: 0.01f,
             type: (Bone.BoneType)jointIdx,
             rotation: boneRot.ToLeapQuaternion());
@@ -155,7 +160,7 @@ namespace Leap.Unity.Encoding {
           tipPosition: nextJoint.ToVector(),
           direction: (boneRot * Vector3.forward).ToVector(),
           width: 1f,
-          length: 1f,
+          length: fingerLength,
           isExtended: true,
           type: (Finger.FingerType)fingerIdx);
       }

--- a/Assets/Plugins/LeapMotion/Experimental/OVRProvider.meta
+++ b/Assets/Plugins/LeapMotion/Experimental/OVRProvider.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f830e7c96b6897e4fa928a1315711794
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/LeapMotion/Experimental/OVRProvider/Scripts.meta
+++ b/Assets/Plugins/LeapMotion/Experimental/OVRProvider/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: feb49706fce815244ad0b528b7aadbe9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/LeapMotion/Experimental/OVRProvider/Scripts/OVRLeapProvider.cs
+++ b/Assets/Plugins/LeapMotion/Experimental/OVRProvider/Scripts/OVRLeapProvider.cs
@@ -1,0 +1,134 @@
+using System.Collections.Generic;
+using UnityEngine;
+using Leap.Unity.Encoding;
+using OculusSampleFramework;
+
+namespace Leap.Unity {
+
+    /// <Summary>
+    /// A Leap provider that transforms hand data from Quest hand tracking to a Leap hand.
+    /// This allows to use Quest hand tracking with interactions built using the Leap Motion Unity Modules.
+    /// </Summary>
+  public class OVRLeapProvider : LeapProvider {
+    protected Frame _updateFrame = new Frame();
+    protected Frame _fixedFrame = new Frame();
+
+    private VectorHand _leftVHand = new VectorHand();
+    private VectorHand _rightVHand = new VectorHand();
+
+    private Hand _leftHand = new Hand();
+    private Hand _rightHand = new Hand();
+    private List<Hand> _hands = new List<Hand>();
+
+    private void OnEnable() {
+      Application.onBeforeRender += Application_onBeforeRender;
+    }
+
+    private void OnDisable() {
+      Application.onBeforeRender -= Application_onBeforeRender;
+    }
+
+    private void Application_onBeforeRender() {
+      // LeapServiceProvider would usually do interpolation here
+      FillLeapFrame(-1f, _updateFrame);
+      DispatchUpdateFrameEvent(_updateFrame);
+    }
+  
+    void FixedUpdate() {
+      // no interpolation here either
+      FillLeapFrame(-1f, _fixedFrame);
+      DispatchFixedFrameEvent(_fixedFrame);
+    }
+
+    /// <Summary>
+    /// Popuates the given Leap Frame with the most recent hand data
+    /// </Summary>
+    public void FillLeapFrame(float frameTime, Frame leapFrame) {
+      _hands.Clear();
+      if (FillLeapHandFromOvrHand(isLeft: true, frameTime, ref _leftVHand)) {
+        _leftVHand.Decode(_leftHand);
+        _hands.Add(_leftHand);
+      }
+      
+      if (FillLeapHandFromOvrHand(isLeft: false, frameTime, ref _rightVHand)) {
+        _rightVHand.Decode(_rightHand);
+        _hands.Add(_rightHand);
+      }
+      
+      leapFrame.Hands = _hands;
+    }
+
+    /// <Summary>
+    /// Read the most recent hand data from the Oculus hand tracking API and populate a given VectorHand with joint locations
+    /// </Summary>
+    private bool FillLeapHandFromOvrHand(bool isLeft, float frameTime, ref VectorHand vHand) {
+      OVRHand ovrHand = isLeft ? HandsManager.Instance.LeftHand : HandsManager.Instance.RightHand;
+      OVRSkeleton ovrSkeleton = isLeft ? HandsManager.Instance.LeftHandSkeleton : HandsManager.Instance.RightHandSkeleton;
+      bool isTracked = ovrHand.IsDataHighConfidence;
+      IList<OVRBone> bones = ovrSkeleton.Bones;
+      
+      if (bones.Count != 0 && isTracked) {
+        vHand.isLeft = isLeft;
+        
+        // oddly, Oculus' coordinate systems differ for right/left hand 
+        Vector3 rotation = isLeft ? new Vector3(0f, -90f, -180f) : new Vector3(0f, 90f, 0f);
+        Vector3 wristOffset = isLeft ? new Vector3(-0.07f, 0f, 0f) : new Vector3(0.07f, 0f, 0f);
+        
+        // Convert palm position/rotation to Leap coordinate system
+        Transform ovrPalm = bones[(int)OVRSkeleton.BoneId.Hand_WristRoot].Transform;
+        vHand.palmPos = ovrPalm.position + ovrPalm.TransformVector(wristOffset);
+        vHand.palmRot = ovrPalm.rotation * Quaternion.Euler(rotation);
+        
+        // need to infer carpal bone positions since Oculus doesn't provide them
+        Vector3 metaCarpalOffset = isLeft ? new Vector3(0f, 0f, 0.008f) : new Vector3(0f, 0f, -0.008f);
+        Vector3 indexMetacarpalOffset   = ovrPalm.TransformVector(metaCarpalOffset    );
+        Vector3 middleMetacarpalOffset  = ovrPalm.TransformVector(metaCarpalOffset * 2);
+        Vector3 ringMetacarpalOffset    = ovrPalm.TransformVector(metaCarpalOffset * 3);
+        Vector3 pinkyMetacarpalOffset   = ovrPalm.TransformVector(metaCarpalOffset * 4);
+        
+        vHand.jointPositions[ 0] = VectorHand.ToLocal( bones[ (int) OVRSkeleton.BoneId.Hand_Thumb0   ].Transform.position                           , vHand.palmPos, vHand.palmRot);   
+        vHand.jointPositions[ 1] = VectorHand.ToLocal( bones[ (int) OVRSkeleton.BoneId.Hand_Thumb1   ].Transform.position                           , vHand.palmPos, vHand.palmRot);
+        vHand.jointPositions[ 2] = VectorHand.ToLocal( bones[ (int) OVRSkeleton.BoneId.Hand_Thumb2   ].Transform.position                           , vHand.palmPos, vHand.palmRot);
+        vHand.jointPositions[ 3] = VectorHand.ToLocal( bones[ (int) OVRSkeleton.BoneId.Hand_Thumb3   ].Transform.position                           , vHand.palmPos, vHand.palmRot);
+        vHand.jointPositions[ 4] = VectorHand.ToLocal( bones[ (int) OVRSkeleton.BoneId.Hand_ThumbTip ].Transform.position                           , vHand.palmPos, vHand.palmRot);
+        vHand.jointPositions[ 5] = VectorHand.ToLocal( bones[ (int) OVRSkeleton.BoneId.Hand_Thumb0   ].Transform.position + indexMetacarpalOffset   , vHand.palmPos, vHand.palmRot);
+        vHand.jointPositions[ 6] = VectorHand.ToLocal( bones[ (int) OVRSkeleton.BoneId.Hand_Index1   ].Transform.position                           , vHand.palmPos, vHand.palmRot);
+        vHand.jointPositions[ 7] = VectorHand.ToLocal( bones[ (int) OVRSkeleton.BoneId.Hand_Index2   ].Transform.position                           , vHand.palmPos, vHand.palmRot);
+        vHand.jointPositions[ 8] = VectorHand.ToLocal( bones[ (int) OVRSkeleton.BoneId.Hand_Index3   ].Transform.position                           , vHand.palmPos, vHand.palmRot);
+        vHand.jointPositions[ 9] = VectorHand.ToLocal( bones[ (int) OVRSkeleton.BoneId.Hand_IndexTip ].Transform.position                           , vHand.palmPos, vHand.palmRot);
+        vHand.jointPositions[10] = VectorHand.ToLocal( bones[ (int) OVRSkeleton.BoneId.Hand_Thumb0   ].Transform.position + middleMetacarpalOffset  , vHand.palmPos, vHand.palmRot);
+        vHand.jointPositions[11] = VectorHand.ToLocal( bones[ (int) OVRSkeleton.BoneId.Hand_Middle1  ].Transform.position                           , vHand.palmPos, vHand.palmRot);
+        vHand.jointPositions[12] = VectorHand.ToLocal( bones[ (int) OVRSkeleton.BoneId.Hand_Middle2  ].Transform.position                           , vHand.palmPos, vHand.palmRot);
+        vHand.jointPositions[13] = VectorHand.ToLocal( bones[ (int) OVRSkeleton.BoneId.Hand_Middle3  ].Transform.position                           , vHand.palmPos, vHand.palmRot);
+        vHand.jointPositions[14] = VectorHand.ToLocal( bones[ (int) OVRSkeleton.BoneId.Hand_MiddleTip].Transform.position                           , vHand.palmPos, vHand.palmRot);
+        vHand.jointPositions[15] = VectorHand.ToLocal( bones[ (int) OVRSkeleton.BoneId.Hand_Thumb0   ].Transform.position + ringMetacarpalOffset    , vHand.palmPos, vHand.palmRot);
+        vHand.jointPositions[16] = VectorHand.ToLocal( bones[ (int) OVRSkeleton.BoneId.Hand_Ring1    ].Transform.position                           , vHand.palmPos, vHand.palmRot);
+        vHand.jointPositions[17] = VectorHand.ToLocal( bones[ (int) OVRSkeleton.BoneId.Hand_Ring2    ].Transform.position                           , vHand.palmPos, vHand.palmRot);
+        vHand.jointPositions[18] = VectorHand.ToLocal( bones[ (int) OVRSkeleton.BoneId.Hand_Ring3    ].Transform.position                           , vHand.palmPos, vHand.palmRot);
+        vHand.jointPositions[19] = VectorHand.ToLocal( bones[ (int) OVRSkeleton.BoneId.Hand_RingTip  ].Transform.position                           , vHand.palmPos, vHand.palmRot);
+        vHand.jointPositions[20] = VectorHand.ToLocal( bones[ (int) OVRSkeleton.BoneId.Hand_Thumb0   ].Transform.position + pinkyMetacarpalOffset   , vHand.palmPos, vHand.palmRot);
+        vHand.jointPositions[21] = VectorHand.ToLocal( bones[ (int) OVRSkeleton.BoneId.Hand_Pinky1   ].Transform.position                           , vHand.palmPos, vHand.palmRot);
+        vHand.jointPositions[22] = VectorHand.ToLocal( bones[ (int) OVRSkeleton.BoneId.Hand_Pinky2   ].Transform.position                           , vHand.palmPos, vHand.palmRot);
+        vHand.jointPositions[23] = VectorHand.ToLocal( bones[ (int) OVRSkeleton.BoneId.Hand_Pinky3   ].Transform.position                           , vHand.palmPos, vHand.palmRot);
+        vHand.jointPositions[24] = VectorHand.ToLocal( bones[ (int) OVRSkeleton.BoneId.Hand_PinkyTip ].Transform.position                           , vHand.palmPos, vHand.palmRot);
+      
+        return true;
+      }
+      else {
+        return false;
+      }
+    }
+
+    public override Frame CurrentFrame {
+      get {
+        return _updateFrame;
+      }
+    }
+
+    public override Frame CurrentFixedFrame {
+      get {
+        return _fixedFrame;
+      }
+    }
+  }
+}

--- a/Assets/Plugins/LeapMotion/Experimental/OVRProvider/Scripts/OVRLeapProvider.cs.meta
+++ b/Assets/Plugins/LeapMotion/Experimental/OVRProvider/Scripts/OVRLeapProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7cfab87162300c1448c647c0f2a44120
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/LeapMotion/Experimental/OVRProvider/readme.md
+++ b/Assets/Plugins/LeapMotion/Experimental/OVRProvider/readme.md
@@ -1,0 +1,17 @@
+# OVRProvider
+
+This is an experimental compatibility layer that allows to use Quest hand tracking with interactions built using the Leap Motion Unity Modules.
+
+## Requirements
+
+### Oculus Integration
+
+* Download the [Oculus Integration] (https://assetstore.unity.com/packages/tools/integration/oculus-integration-82022) from the Asset Store
+
+### Setup
+
+* Create a new Unity Project
+* Import the Unity Modules
+* Follow [these instructions] (https://developer.oculus.com/documentation/unity/unity-handtracking/) provided by Oculus to set up hand tracking in Unity 
+* Open one of the example scenes included with the Unity Modules and replace the traditional LeapServiceProvider/LeapXRServiceProvider with an OVRProvider
+* Assign the OVRProvider as to components that reference a LeapProvider (e.g. InteractioHands and HandModelManager)

--- a/Assets/Plugins/LeapMotion/Experimental/OVRProvider/readme.md.meta
+++ b/Assets/Plugins/LeapMotion/Experimental/OVRProvider/readme.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f6eba618964931a43ac5f9ce90179766
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Inspired by #1147 this PR adds a similar alternative implementation of a LeapServiceProvider that allows to use Quest hand tracking with the Leap Motion Unity Modules.

Open questions:

- [ ] The OVRProvider still needs to be wrapped in a plaform define in some way, because of the dependency to the Oculus Integration.
- [ ] Some scripts (like InteractionHands) already expose a property setter, which allows to assign a custom LeapProvider implementation (e.g. OpenXRProvider, OVRProvider, Networked provider implementations etc.). However in other scripts (like HandUtils.cs) the Provider is a bit more hard-coded using FindObjectOfType. Maybe there's an opportunity here to move the provider reference to a single place (e.g. HandUtils), thus allowing to easily switch between implementations, maybe even at runtime.