### PR TITLE
Feature/GitHub pr templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default.md
@@ -1,0 +1,38 @@
+## This Merge Request Template
+
+This merge request template is the default and should be used when contributing any changes to stable packages.
+
+For contributions to pre-release/preview packages use the lightweight merge request template.
+
+For release merge requests, use the release template.
+
+## Summary
+
+_Summary of the purpose of this merge request._
+
+## Contributor Tasks
+
+_These tasks are for the merge request creator to tick off when creating a merge request._
+
+- [ ] Pair review with a member of the QA team.
+- [ ] Add any release testing considerations to the MR for the next release.
+- [ ] Check any relevant CHANGELOG files have been updated.
+- [ ] Ensure documentation requirements are met e.g., public API is commented.
+- [ ] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
+- [ ] Add any relevant labels such as `breaking` to this MR.
+- [ ] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.
+
+## Reviewer Tasks
+
+_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._
+
+[Use emojis in review threads to communicate intent and help contributors.](CONTRIBUTING.md#review-threads)
+
+- [ ] Code reviewed.
+- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
+- [ ] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
+- [ ] Checked and agree with release testing considerations added to MR for the next release.
+
+## Closes JIRA Issue
+
+_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_

--- a/.github/PULL_REQUEST_TEMPLATE/lightweight.md
+++ b/.github/PULL_REQUEST_TEMPLATE/lightweight.md
@@ -1,0 +1,30 @@
+## This Merge Request Template
+
+This merge request template is for contributing to pre-release/preview packages and has fewer tasks to complete. The quality threshold for reviewing these merge requests is lower - prioritize a lean review process.
+
+## Summary
+
+_Summary of the purpose of this merge request._
+
+## Contributor Tasks
+
+_These tasks are for the merge request creator to tick off when creating a merge request._
+
+- [ ] Pair review with a member of the QA team.
+- [ ] Add any release testing considerations to the MR for the next release.
+- [ ] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
+- [ ] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.
+
+## Reviewer Tasks
+
+_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._
+
+[Use emojis in review threads to communicate intent and help contributors.](CONTRIBUTING.md#review-threads)
+
+- [ ] Code reviewed.
+- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
+- [ ] Checked and agree with release testing considerations added to MR for the next release.
+
+## Closes JIRA Issue
+
+_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_

--- a/.github/PULL_REQUEST_TEMPLATE/lightweight.md
+++ b/.github/PULL_REQUEST_TEMPLATE/lightweight.md
@@ -1,6 +1,14 @@
-## This Merge Request Template
+## Pull Request Templates
 
-This merge request template is for contributing to pre-release/preview packages and has fewer tasks to complete. The quality threshold for reviewing these merge requests is lower - prioritize a lean review process.
+Switch template by going to preview and clicking the link - note it not work if you've made any changes to the description.
+
+- [default.md](?expand=1) - for contributions to stable packages.
+- [lightweight.md](?expand=1&template=lightweight.md) - for contributions to pre-release/preview packages use the lightweight merge request template. The quality threshold for reviewing is lower - it prioritizes a lean review process.
+- [release.md](?expand=1&template=release.md) - for release merge requests.
+
+**You are currently using: lightweight.md**
+
+Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.
 
 ## Summary
 
@@ -19,7 +27,7 @@ _These tasks are for the merge request creator to tick off when creating a merge
 
 _Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._
 
-[Use emojis in review threads to communicate intent and help contributors.](CONTRIBUTING.md#review-threads)
+[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)
 
 - [ ] Code reviewed.
 - [ ] Non-code assets e.g. Unity assets/scenes reviewed.

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,0 +1,24 @@
+## This Merge Request Template
+
+This merge request template is for release merge requests.
+
+## Release Tasks
+
+_These tasks are for the merge request creator to tick off when creating a merge request._
+
+- [ ] Run through the pre-release steps on [Confluence](https://ultrahaptics.atlassian.net/wiki/spaces/SV/pages/3665625233). The rest of the process continues after this merge request is merged.
+- [ ] Check any relevant CHANGELOG files have been updated.
+- [ ] Ensure documentation requirements are met e.g., public API is commented.
+- [ ] Ensure package.json files are updated with new package versions and any changes dependency versions.
+- [ ] If this is a major release, action any `Obsolete` items and other breaking considerations.
+- [ ] Check that additional release tasks for each MR contributing to this release have been considered.
+
+### Additional Release Tasks
+
+_This task list should be populated from MRs contributing to this release. Can include functionality tests and regression tests such as tests for integration of multiple features as well as any other tasks that should be performed during the release._
+
+- [ ] 
+
+## JIRA Release
+
+_Link to the Jira release for this version. See the [releases page](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page)._

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,6 +1,14 @@
-## This Merge Request Template
+## Pull Request Templates
 
-This merge request template is for release merge requests.
+Switch template by going to preview and clicking the link - note it not work if you've made any changes to the description.
+
+- [default.md](?expand=1) - for contributions to stable packages.
+- [lightweight.md](?expand=1&template=lightweight.md) - for contributions to pre-release/preview packages use the lightweight merge request template. The quality threshold for reviewing is lower - it prioritizes a lean review process.
+- [release.md](?expand=1&template=release.md) - for release merge requests.
+
+**You are currently using: release.md**
+
+Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.
 
 ## Release Tasks
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,14 @@
-## This Merge Request Template
+## Pull Request Templates
 
-This merge request template is the default and should be used when contributing any changes to stable packages.
+Switch template by going to preview and clicking the link - note it not work if you've made any changes to the description.
 
-For contributions to pre-release/preview packages use the lightweight merge request template.
+- [default.md](?expand=1) - for contributions to stable packages.
+- [lightweight.md](?expand=1&template=lightweight.md) - for contributions to pre-release/preview packages use the lightweight merge request template. The quality threshold for reviewing is lower - it prioritizes a lean review process.
+- [release.md](?expand=1&template=release.md) - for release merge requests.
 
-For release merge requests, use the release template.
+**You are currently using: default.md**
+
+Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.
 
 ## Summary
 
@@ -26,7 +30,7 @@ _These tasks are for the merge request creator to tick off when creating a merge
 
 _Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._
 
-[Use emojis in review threads to communicate intent and help contributors.](CONTRIBUTING.md#review-threads)
+[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)
 
 - [ ] Code reviewed.
 - [ ] Non-code assets e.g. Unity assets/scenes reviewed.


### PR DESCRIPTION
Adds PR templates for GitHub.
Note any PRs on GitHub into main/develop will currently be clobbered by push mirroring.
- [x] Finalize any work being done on the GitLab repo and turn off push mirroring before merging