### PR TITLE
Bug/unity 731 white lines in control panel

### DIFF
--- a/Packages/Tracking/Core/Runtime/Scripts/LeapImageRetriever.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/LeapImageRetriever.cs
@@ -153,7 +153,7 @@ namespace Leap.Unity
                 {
                     textureSizeFactors = new Vector4[MAX_NUMBER_OF_GLOBAL_TEXTURES];
                 }
-                textureSizeFactors[deviceID] = new Vector4((float)_combinedTexture.width / _globalRawTextures.width, (float)_combinedTexture.height / _globalRawTextures.height, 0, 0);
+                textureSizeFactors[deviceID] = new Vector4((float)(_combinedTexture.width - 1) / (_globalRawTextures.width - 1), (float)(_combinedTexture.height - 1) / (_globalRawTextures.height - 1), 0, 0);
                 Shader.SetGlobalVectorArray("_LeapGlobalTextureSizeFactor", textureSizeFactors);
 
                 Shader.SetGlobalVector(pixelSizeName, new Vector2(1.0f / image.Width, 1.0f / image.Height));

--- a/Packages/Tracking/Core/Runtime/Scripts/LeapImageRetriever.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/LeapImageRetriever.cs
@@ -156,7 +156,6 @@ namespace Leap.Unity
                 textureSizes[deviceID] = new Vector4((float)_combinedTexture.width, (float)_combinedTexture.height, (float)_globalRawTextures.width, (float)_globalRawTextures.height);
                 Shader.SetGlobalVectorArray("_LeapGlobalTextureSizes", textureSizes);
 
-                Debug.Log(Screen.width + " : " + Screen.height);
                 Shader.SetGlobalVector(pixelSizeName, new Vector2(1.0f / image.Width, 1.0f / image.Height));
             }
 

--- a/Packages/Tracking/Core/Runtime/Scripts/LeapImageRetriever.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/LeapImageRetriever.cs
@@ -148,14 +148,15 @@ namespace Leap.Unity
                 }
 
                 // set factors to multiply to uv coordinates, so that we sample from the globalRawTexture where it is actually filled with the _combinedTexture
-                Vector4[] textureSizeFactors = Shader.GetGlobalVectorArray("_LeapGlobalTextureSizeFactor");
-                if (textureSizeFactors == null)
+                Vector4[] textureSizes = Shader.GetGlobalVectorArray("_LeapGlobalTextureSizes");
+                if (textureSizes == null)
                 {
-                    textureSizeFactors = new Vector4[MAX_NUMBER_OF_GLOBAL_TEXTURES];
+                    textureSizes = new Vector4[MAX_NUMBER_OF_GLOBAL_TEXTURES];
                 }
-                textureSizeFactors[deviceID] = new Vector4((float)(_combinedTexture.width - 1) / (_globalRawTextures.width - 1), (float)(_combinedTexture.height - 1) / (_globalRawTextures.height - 1), 0, 0);
-                Shader.SetGlobalVectorArray("_LeapGlobalTextureSizeFactor", textureSizeFactors);
+                textureSizes[deviceID] = new Vector4((float)_combinedTexture.width, (float)_combinedTexture.height, (float)_globalRawTextures.width, (float)_globalRawTextures.height);
+                Shader.SetGlobalVectorArray("_LeapGlobalTextureSizes", textureSizes);
 
+                Debug.Log(Screen.width + " : " + Screen.height);
                 Shader.SetGlobalVector(pixelSizeName, new Vector2(1.0f / image.Width, 1.0f / image.Height));
             }
 

--- a/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
@@ -9,8 +9,8 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.ComponentModel;
+using System.Linq;
 using UnityEngine;
 
 namespace Leap.Unity


### PR DESCRIPTION
## Pull Request Templates

Switch template by going to preview and clicking the link - note it not work if you've made any changes to the description.

- [default.md](?expand=1) - for contributions to stable packages.
- [lightweight.md](?expand=1&template=lightweight.md) - for contributions to pre-release/preview packages use the lightweight merge request template. The quality threshold for reviewing is lower - it prioritizes a lean review process.
- [release.md](?expand=1&template=release.md) - for release merge requests.

**You are currently using: default.md**

Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.

## Summary

This removes the white lines that appear when using the distorted view shaders in the control panel. Additionally to the changes in the tooling, `PassthroughBackgorundBothEyesDistorted.shader` should be updated so that its frag method looks like this:

```
float4 frag (frag_in i) : COLOR {
      const float2 uv = i.screenPos.xy / i.screenPos.w;

      //remaps uv such that the x component becomes [0,0.5)->[0,1) and [0.5,1.0)->[0,1)
      return uv.x <= 0.5
        ? float4(LeapGetLeftColorDistorted (float2(uv.x * 2, uv.y * 0.5)), 1)
        : float4(LeapGetRightColorDistorted(float2((uv.x - 0.5) * 2, uv.y * 0.5 + 0.5)), 1);
    }
```

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [x] Pair review with a member of the QA team.
- [x] Add any release testing considerations to the MR for the next release.
- [x] Check any relevant CHANGELOG files have been updated.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR. -> Is it breaking to change a global shader variable?
- [x] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

-> needs to be tested in VR (in the normal Capsule Hands Infrared Example scene). Make sure that the hands still line up with the image

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [x] Checked and agree with release testing considerations added to MR for the next release.

## Closes JIRA Issue

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_

Closes UNITY-731