### PR TITLE
fix path for vertex offset shader

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -23,7 +23,7 @@ If you have any concerns about this, please contact us on [Github Discussions](h
 - 
  
 ### Fixed 
-- 
+- VertexOffsetShader displays errors in Unity 2021 due to invalid path
 
 ### Known issues 
 - Scenes containing the infrared viewer render incorrectly on systems using single pass stereo with the XR plugin system - e.g. Windows Mixed Reality headsets. SteamVR headsets may also default to single pass stereo, showing the same issue. However in this case, the OpenVR settings can be changed to multipass which resolves the problem. 

--- a/Packages/Tracking/Core/Runtime/Shaders/VertexOffsetShader.shader
+++ b/Packages/Tracking/Core/Runtime/Shaders/VertexOffsetShader.shader
@@ -12,7 +12,7 @@
 
 		  CGPROGRAM
 		  #pragma surface surf Standard fullforwardshadows vertex:vert
-		  #include "Assets/Plugins/LeapMotion/Core/Resources/LeapCG.cginc"
+		  #include "../Resources/LeapCG.cginc"
 		  #pragma target 3.0
 
 		  int _isLeftHand;


### PR DESCRIPTION
## Pull Request Templates

Switch template by going to preview and clicking the link - note it not work if you've made any changes to the description.

- [default.md](?expand=1) - for contributions to stable packages.
- [lightweight.md](?expand=1&template=lightweight.md) - for contributions to pre-release/preview packages use the lightweight merge request template. The quality threshold for reviewing is lower - it prioritizes a lean review process.
- [release.md](?expand=1&template=release.md) - for release merge requests.

**You are currently using: default.md**

Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.

## Summary

Fixes the path for vertex offset shader so it no longer throws errors in 2021 when importing

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [ ] Pair review with a member of the QA team.
- [x] Add any release testing considerations to the MR for the next release.
- [x] Check any relevant CHANGELOG files have been updated.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.
- [ ] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [x] Checked and agree with release testing considerations added to MR for the next release.