### PR TITLE
Additional null check in fixedUpdateSoftContact

### DIFF
--- a/Packages/Tracking/Interaction Engine/Runtime/Scripts/InteractionController.cs
+++ b/Packages/Tracking/Interaction Engine/Runtime/Scripts/InteractionController.cs
@@ -1329,7 +1329,7 @@ namespace Leap.Unity.Interaction
                             //NotifySoftContactOverlap(contactBone, _softContactColliderBuffer[i]);
 
                             // If the rigidbody is null, the object may have been destroyed.
-                            if (_softContactColliderBuffer[i].attachedRigidbody == null) continue;
+                            if (_softContactColliderBuffer[i] == null || _softContactColliderBuffer[i].attachedRigidbody == null) continue;
                             IInteractionBehaviour intObj;
                             if (manager.interactionObjectBodies.TryGetValue(_softContactColliderBuffer[i].attachedRigidbody, out intObj))
                             {


### PR DESCRIPTION
Minor MR to add an additional null check in fixedUpdateSoftContact to solve an issue with grabbed block despawning we're seeing in Aurora.