### PR TITLE
Additional null checks in IE contacts

### DIFF
--- a/Packages/Tracking/Interaction Engine/Runtime/Plugins/PhysicsUtility.cs
+++ b/Packages/Tracking/Interaction Engine/Runtime/Plugins/PhysicsUtility.cs
@@ -82,6 +82,8 @@ namespace Leap.Interaction.Internal.InteractionEngineUtility
 
         public static void generateBoxContact(BoxCollider box, int layerMask, Collider otherCollider, ref List<SoftContact> softContacts, ref Dictionary<Rigidbody, Velocities> originalVelocities, bool interpretAsEllipsoid = true)
         {
+            if (box == null || box.attachedRigidbody == null) return;
+
             Vector3 boxExtent = Vector3.Scale(box.size * 0.5f, box.transform.lossyScale);
             Vector3 boxCenter = Vector3.Scale(box.center, box.transform.lossyScale);
             Vector3 unrotatedOtherColliderPosition = Quaternion.Inverse(box.attachedRigidbody.rotation) * (otherCollider.attachedRigidbody.position - box.attachedRigidbody.position);
@@ -138,6 +140,7 @@ namespace Leap.Interaction.Internal.InteractionEngineUtility
             }
             Vector3 otherColliderPositionOnCapsule = capsule.transform.TransformPoint(otherColliderPosOnSegment + displacement + capsule.center);
 
+            if (capsule == null || capsule.attachedRigidbody == null) return;
             generateSphereContact(capsule.transform.TransformPoint(capsule.center), (capsule.transform.TransformPoint(capsule.center) - otherColliderPositionOnCapsule).magnitude, capsule.attachedRigidbody.GetPointVelocity(otherColliderPositionOnCapsule), layerMask, ref softContacts, ref originalVelocities, otherCollider, interpretAsEllipsoid);
         }
 

--- a/Packages/Tracking/Interaction Engine/Runtime/Scripts/InteractionController.cs
+++ b/Packages/Tracking/Interaction Engine/Runtime/Scripts/InteractionController.cs
@@ -1260,7 +1260,7 @@ namespace Leap.Unity.Interaction
                             //NotifySoftContactOverlap(contactBone, _softContactColliderBuffer[i]);
 
                             // If the rigidbody is null, the object may have been destroyed.
-                            if (_softContactColliderBuffer[i].attachedRigidbody == null) continue;
+                            if (_softContactColliderBuffer[i] == null || _softContactColliderBuffer[i].attachedRigidbody == null) continue;
                             IInteractionBehaviour intObj;
                             if (manager.interactionObjectBodies.TryGetValue(_softContactColliderBuffer[i].attachedRigidbody, out intObj))
                             {
@@ -1291,7 +1291,7 @@ namespace Leap.Unity.Interaction
                             //NotifySoftContactOverlap(contactBone, _softContactColliderBuffer[i]);
 
                             // If the rigidbody is null, the object may have been destroyed.
-                            if (_softContactColliderBuffer[i].attachedRigidbody == null) continue;
+                            if (_softContactColliderBuffer[i] == null || _softContactColliderBuffer[i].attachedRigidbody == null) continue;
                             IInteractionBehaviour intObj;
                             if (manager.interactionObjectBodies.TryGetValue(_softContactColliderBuffer[i].attachedRigidbody, out intObj))
                             {


### PR DESCRIPTION
An extension of #1208 - found a couple more places missing null checks which were causing console error spam in Aurora.