### PR TITLE
Make the Physics Hand grasp helper passive if required

### DIFF
--- a/Packages/Tracking Preview/PhysicsHands/Editor/PhysicsProviderEditor.cs
+++ b/Packages/Tracking Preview/PhysicsHands/Editor/PhysicsProviderEditor.cs
@@ -26,6 +26,7 @@ namespace Leap.Unity.Interaction.PhysicsHands
         SerializedProperty _handTeleportDistance, _handGraspTeleportDistance;
 
         SerializedProperty _enableHelpers;
+        SerializedProperty _helperMovesObjects;
         SerializedProperty _interpolateMass, _maxMass;
 
 
@@ -55,6 +56,7 @@ namespace Leap.Unity.Interaction.PhysicsHands
             _handGraspTeleportDistance = serializedObject.FindProperty("_handGraspTeleportDistance");
 
             _enableHelpers = serializedObject.FindProperty("_enableHelpers");
+            _helperMovesObjects = serializedObject.FindProperty("_helperMovesObjects");
             _interpolateMass = serializedObject.FindProperty("_interpolateMass");
             _maxMass = serializedObject.FindProperty("_maxMass");
 
@@ -198,6 +200,7 @@ namespace Leap.Unity.Interaction.PhysicsHands
             EditorGUILayout.PropertyField(_enableHelpers);
             if (_enableHelpers.boolValue)
             {
+                EditorGUILayout.PropertyField(_helperMovesObjects);
                 EditorGUILayout.PropertyField(_interpolateMass);
                 if (_interpolateMass.boolValue)
                 {

--- a/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsGraspHelper.cs
+++ b/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsGraspHelper.cs
@@ -234,10 +234,12 @@ namespace Leap.Unity.Interaction.PhysicsHands
         public void ReleaseObject()
         {
             GraspState = State.Idle;
-            Debug.DrawRay(_rigid.position, Vector3.down, Color.blue, 0.2f);
             _releaseTimer = GRAB_COOLDOWNTIME;
-            _rigid.isKinematic = _oldKinematic;
-            _rigid.useGravity = _oldGravity;
+            if (Manager.HelperMovesObjects)
+            {
+                _rigid.isKinematic = _oldKinematic;
+                _rigid.useGravity = _oldGravity;
+            }
         }
 
         public State UpdateHelper()
@@ -276,7 +278,10 @@ namespace Leap.Unity.Interaction.PhysicsHands
                     if (_graspingHands.Count > 0)
                     {
                         UpdateHandPositions();
-                        MoveObject();
+                        if (Manager.HelperMovesObjects)
+                        {
+                            MoveObject();
+                        }
                         _justGrasped = false;
                     }
                     else
@@ -347,7 +352,7 @@ namespace Leap.Unity.Interaction.PhysicsHands
                     }
                     if (c == 2)
                     {
-                        if (_graspingHands.Count == 0)
+                        if (Manager.HelperMovesObjects && _graspingHands.Count == 0)
                         {
                             _rigid.useGravity = false;
                             _rigid.isKinematic = false;

--- a/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsProvider.cs
+++ b/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsProvider.cs
@@ -74,6 +74,10 @@ namespace Leap.Unity.Interaction.PhysicsHands
             "This includes large and very small objects, as well as kinematic objects.")]
         private bool _enableHelpers = true;
 
+        [SerializeField, Tooltip("Disabling this will allow for the grasp helper to report heuristical \"grab\" information, but will not move the objects.")]
+        private bool _helperMovesObjects = true;
+        public bool HelperMovesObjects => _helperMovesObjects;
+
         [SerializeField, Tooltip("Enabling this will cause the hand to move more slowly when grasping objects of higher weights.")]
         private bool _interpolateMass = true;
         public bool InterpolatingMass => _interpolateMass;


### PR DESCRIPTION
- Allows the user to toggle movement on/off in the Physics Provider.
  - Means you can still get the heuristics but perform your own logic on top.