### PR TITLE
Automated builds in CI pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -141,45 +141,22 @@ dependencies-libtrack:
   needs: []
 
   variables:
-    LIBTRACK_ROOT_URL: "https://gitlab.ultrahaptics.com/api/v4/projects/leap-v5-platform%2Flibtrack"
-    ANDROID_JOB: "AndroidRelProdLTS"
-    WINDOWS_JOB: "WinRelDebProdLTS"
+    # XR group variables:
+    #  - LIBTRACK_ACCESS_TOKEN
+    #  - LIBTRACK_BRANCH
+    
+    LIBTRACK_URL: "https://gitlab.ultrahaptics.com/api/v4/projects/leap-v5-platform%2Flibtrack/jobs/artifacts/$LIBTRACK_BRANCH/raw"
+    LIBTRACK_ANDROID_JOB: "AndroidRelProdLTS"
+    LIBTRACK_WINDOWS_JOB: "WinRelDebProdLTS"
 
     ANDROID_ARTIFACTS_PATH: "$ARTIFACTS_PATH/Android"
     WINDOWS_ARTIFACTS_PATH: "$ARTIFACTS_PATH/Windows"
     VERSION_SUFFIX_PATH: "$ARTIFACTS_PATH/libtrack_version_suffix.txt"
-
-    # LIBTRACK upstream variables pass from RAD libtrack downstream trigger (see https://gitlab.ultrahaptics.com/xr/rad/triggers/libtrack/-/blob/main/.gitlab-ci.yml)
-    # UPSTREAM_UPSTREAM_BRANCH_REF
-    # UPSTREAM_UPSTREAM_WINDOWS_RELEASE_JOB_NAME
-    # UPSTREAM_UPSTREAM_ANDROID_RELEASE_JOB_NAME
-
-    # XR group variables
-    # LIBTRACK_ACCESS_TOKEN - Access token required to pull artifacts
-    # LIBTRACK_BRANCH - Fallback branch to pull artifacts from when UPSTREAM_UPSTREAM_BRANCH_REF isn't set
-
+    
   script:
-
     # Ensure artifact paths exist
     - New-Item -Path "$ANDROID_ARTIFACTS_PATH" -ItemType Directory -Force
     - New-Item -Path "$WINDOWS_ARTIFACTS_PATH" -ItemType Directory -Force
-
-    ## Work out where to pull Libtrack assets from
-    - | 
-      if($UPSTREAM_UPSTREAM_BRANCH_REF)
-      { $LIBTRACK_URL = "$LIBTRACK_ROOT_URL/jobs/artifacts/$UPSTREAM_UPSTREAM_BRANCH_REF/raw" }
-      else
-      { $LIBTRACK_URL = "$LIBTRACK_ROOT_URL/jobs/artifacts/$LIBTRACK_BRANCH/raw" }
-      
-      if($UPSTREAM_UPSTREAM_WINDOWS_RELEASE_JOB_NAME)
-      { $LIBTRACK_WINDOWS_JOB = $UPSTREAM_UPSTREAM_WINDOWS_RELEASE_JOB_NAME }
-      else
-      { $LIBTRACK_WINDOWS_JOB = $WINDOWS_JOB }
-      
-      if($UPSTREAM_UPSTREAM_ANDROID_RELEASE_JOB_NAME)
-      { $LIBTRACK_ANDROID_JOB = $UPSTREAM_UPSTREAM_ANDROID_RELEASE_JOB_NAME }
-      else
-      { $LIBTRACK_ANDROID_JOB = $ANDROID_JOB }
 
     ## Download version info
     - echo "$LIBTRACK_URL/VERSION_SUFFIX.txt?job=$LIBTRACK_ANDROID_JOB"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -81,6 +81,23 @@ check-formatting:
     when: on_failure
 
 # -----------------------------------------------------------------------------
+# RAD Builds
+# -----------------------------------------------------------------------------
+#
+# This job will trigger various RAD apps to build with the current plugin branch.
+# A failure in any downstream jobs likely represents a breaking change and should be addressed, but will not fail the whole pipeline.
+#
+rad-builds:
+  stage: test
+  allow_failure: true
+  needs: []
+  trigger:
+    project: xr/rad/triggers/unityplugin-tests
+    branch: main
+  variables:
+    PLUGIN_COMMIT_BRANCH: $CI_COMMIT_BRANCH
+
+# -----------------------------------------------------------------------------
 # Generate API Documentation
 # -----------------------------------------------------------------------------
 #


### PR DESCRIPTION
This MR adds a job to trigger a new downstream pipeline in the RAD group which causes various apps to build with the current UnityPlugin branch. You can see Unity build log outputs to validate warnings, and if builds fail due to breaking changes in the plugin. It also allows QA to test stack-heavy apps (such as the Control Panel) with the latest plugin revision without requiring devs to manually generate it.

Failure of the job is not considered a failure for the whole pipeline. All downstream build jobs are manual to prevent overloading the runners.

I've also removed the legacy libtrack downstream artifact pulling, as this has been deprecated by platforms.