### PR TITLE
Fix physics hands arm rotation and make ignores apply on re-entry checks

### DIFF
--- a/Packages/Tracking Preview/PhysicsHands/README.md
+++ b/Packages/Tracking Preview/PhysicsHands/README.md
@@ -15,3 +15,4 @@ This approach relies heavily on the physics simulation and will work with any ri
 - Re-assign the other hands within your scene to have the PhysicsProvider as their Leap Provider.
 - Change your physics settings to the following:
   - Solver Type: Temporal Gauss Seidel
+- Ensure your rigidbodies have their Collision Detection set to either to Discrete or Continuous Speculative

--- a/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsHand.cs
+++ b/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsHand.cs
@@ -520,6 +520,10 @@ namespace Leap.Unity.Interaction.PhysicsHands
             int overlappingColliders = Physics.OverlapSphereNonAlloc(_physicsHand.palmBody.worldCenterOfMass, radius, _teleportColliders, _layerMask, QueryTriggerInteraction.Ignore);
             for (int i = 0; i < overlappingColliders; i++)
             {
+                if (_teleportColliders[i].attachedRigidbody != null && _teleportColliders[i].attachedRigidbody.TryGetComponent<PhysicsIgnoreHelpers>(out var temp))
+                {
+                    continue;
+                }
                 if (_physicsHand.gameObject != _teleportColliders[i].gameObject && !_physicsHand.jointBodies.Select(x => x.gameObject).Contains(_teleportColliders[i].gameObject))
                 {
                     found = true;
@@ -535,6 +539,10 @@ namespace Leap.Unity.Interaction.PhysicsHands
             overlappingColliders = Physics.OverlapSphereNonAlloc(_originalLeapHand.PalmPosition.ToVector3(), radius, _teleportColliders, _layerMask, QueryTriggerInteraction.Ignore);
             for (int i = 0; i < overlappingColliders; i++)
             {
+                if (_teleportColliders[i].attachedRigidbody != null && _teleportColliders[i].attachedRigidbody.TryGetComponent<PhysicsIgnoreHelpers>(out var temp))
+                {
+                    continue;
+                }
                 if (_physicsHand.gameObject != _teleportColliders[i].gameObject && !_physicsHand.jointBodies.Select(x => x.gameObject).Contains(_teleportColliders[i].gameObject))
                 {
                     found = true;

--- a/Packages/Tracking Preview/PhysicsHands/Runtime/Utils/PhysicsHandsUtils.cs
+++ b/Packages/Tracking Preview/PhysicsHands/Runtime/Utils/PhysicsHandsUtils.cs
@@ -562,6 +562,7 @@ namespace Leap.Unity.Interaction.PhysicsHands
 
             leapHand.Arm.NextJoint = leapHand.WristPosition;
             leapHand.Arm.Direction = (leapHand.WristPosition - leapHand.Arm.PrevJoint).Normalized;
+            leapHand.Arm.Rotation = Quaternion.LookRotation(leapHand.Arm.Direction.ToVector3(), -leapHand.PalmNormal.ToVector3()).ToLeapQuaternion();
 
             leapHand.PalmWidth = physicsHand.palmCollider.size.y;
             leapHand.Confidence = originalHand.Confidence;

--- a/Packages/Tracking Preview/PhysicsHands/Runtime/Utils/PhysicsHandsUtils.cs
+++ b/Packages/Tracking Preview/PhysicsHands/Runtime/Utils/PhysicsHandsUtils.cs
@@ -276,7 +276,7 @@ namespace Leap.Unity.Interaction.PhysicsHands
             palm.solverVelocityIterations = solverVelocity;
             palm.angularDamping = angularDamping;
             palm.useGravity = false;
-            palm.collisionDetectionMode = CollisionDetectionMode.ContinuousDynamic;
+            palm.collisionDetectionMode = CollisionDetectionMode.ContinuousSpeculative;
         }
 
         public static void SetupBoneBody(ArticulationBody bone, float boneMass = 0.6f, int solverIterations = 50, int solverVelocity = 20, float maxAngularVelocity = 1.75f, float maxDepenetrationVelocity = 3f)
@@ -292,7 +292,7 @@ namespace Leap.Unity.Interaction.PhysicsHands
             bone.maxAngularVelocity = maxAngularVelocity;
             bone.maxDepenetrationVelocity = maxDepenetrationVelocity;
             bone.useGravity = false;
-            bone.collisionDetectionMode = CollisionDetectionMode.ContinuousDynamic;
+            bone.collisionDetectionMode = CollisionDetectionMode.ContinuousSpeculative;
         }
 
         public static void SetupKnuckleDrives(ArticulationBody knuckle, int fingerIndex, float stiffness, float forceLimit, float strength)


### PR DESCRIPTION
- Corrects the rotation of the arms when using physics hands.
- Prevents ignored objects from being checked against when hands re-enter the frame.