### PR TITLE
Updates to downstream build pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -98,6 +98,7 @@ rad-builds:
     branch: main
   variables:
     PLUGIN_COMMIT_BRANCH: $CI_COMMIT_BRANCH
+    PLUGIN_COMMIT_HASH: $CI_COMMIT_SHA
 
 # -----------------------------------------------------------------------------
 # Generate API Documentation

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -81,13 +81,13 @@ check-formatting:
     when: on_failure
 
 # -----------------------------------------------------------------------------
-# RAD Builds
+# Unity Builds
 # -----------------------------------------------------------------------------
 #
-# This job will trigger various RAD apps to build with the current plugin branch.
-# A failure in any downstream jobs likely represents a breaking change and should be addressed, but will not fail the whole pipeline.
+# This job will trigger various apps to build using the plugin commit that started this pipeline.
+# A failure in a build likely represents a breaking plugin change and should be addressed, but will not fail the whole pipeline.
 #
-rad-builds:
+unity-builds:
   stage: test
   allow_failure: true
   needs: []


### PR DESCRIPTION
Updated the downstream RAD pipeline to become a more generic "Unity builds" pipeline which now not only gives the option to build the Control Panel and Hello World, but also two new test apps as requested by QA. These test apps are forks of Hello World, running on 2021.3.4f1 and 2020.3.21f1 respectively.

All downstream builds will now correctly sync the plugin in the project to the direct commit of the UnityPlugin pipeline that triggered it, meaning we can jump back in time on the same branch and create automatic builds correctly.

All build pipelines also now have unit test support enabled.