### PR TITLE
Add XR validation warning for not targeting Android 29 when using OpenXR

### DIFF
--- a/Packages/Tracking OpenXR/CHANGELOG.md
+++ b/Packages/Tracking OpenXR/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added OpenXR validation check for ensuring applications target Android SDK 29 as per the [OpenXR recommendations] (https://registry.khronos.org/OpenXR/specs/1.0/loader.html#android-active-runtime-location).
+
 ### Changed
 
 ### Fixed

--- a/Packages/Tracking OpenXR/Runtime/Scripts/HandTrackingFeature.cs
+++ b/Packages/Tracking OpenXR/Runtime/Scripts/HandTrackingFeature.cs
@@ -144,10 +144,34 @@ namespace Ultraleap.Tracking.OpenXR
 #if UNITY_EDITOR
         protected override void GetValidationChecks(List<ValidationRule> rules, BuildTargetGroup targetGroup)
         {
+            // If building for Android, check that we are targeting Android API 29 for maximum compatibility.
+            rules.Add(new ValidationRule(this)
+            {
+                message = "Android target SDK version is not set to 29",
+                helpLink = "https://registry.khronos.org/OpenXR/specs/1.0/loader.html#android-active-runtime-location",
+                helpText = "OpenXR applications should not target API levels higher than 29 for maximum compatibility," +
+                           "as runtimes may need to query and load classes from their own packages, which are" +
+                           "necessarily not listed in the <queries> tag above.",
+                checkPredicate = () => PlayerSettings.Android.targetSdkVersion == AndroidSdkVersions.AndroidApiLevel29,
+                error = false,
+                fixItAutomatic = true,
+                fixItMessage = "Set the Android target SDK version to 29",
+                fixIt = () =>
+                {
+                    if (PlayerSettings.Android.minSdkVersion > AndroidSdkVersions.AndroidApiLevel29)
+                    {
+                        PlayerSettings.Android.minSdkVersion = AndroidSdkVersions.AndroidApiLevel29;
+                    }
+                    PlayerSettings.Android.targetSdkVersion = AndroidSdkVersions.AndroidApiLevel29;
+                },
+
+            });
+
             // Check the active input handling supports New (for OpenXR) and Legacy (for Ultraleap Plugin support).
             rules.Add(new ValidationRule(this)
             {
-                message = "Active Input Handling is not set to Both. While New is required for OpenXR, Both is recommended as the Ultraleap Unity Plugin does not fully support the New Input System.",
+                message = "Active Input Handling is not set to Both. While New is required for OpenXR, Both is" +
+                          "recommended as the Ultraleap Unity Plugin does not fully support the New Input System.",
                 error = false,
 #if !ENABLE_LEGACY_INPUT_MANAGER || !ENABLE_INPUT_SYSTEM
                 checkPredicate = () => false,
@@ -162,7 +186,8 @@ namespace Ultraleap.Tracking.OpenXR
             // Check that the Main camera has a suitable near clipping plane for hand-tracking.
             rules.Add(new ValidationRule(this)
             {
-                message = "Main camera near clipping plane is further than recommend and tracked hands may show visual clipping artifacts.",
+                message = "Main camera near clipping plane is further than recommend and tracked hands may show visual" +
+                          "clipping artifacts.",
                 error = false,
                 checkPredicate = () => Camera.main == null || Camera.main.nearClipPlane <= 0.01,
                 fixItAutomatic = true,

--- a/Packages/Tracking OpenXR/Runtime/Scripts/HandTrackingFeature.cs
+++ b/Packages/Tracking OpenXR/Runtime/Scripts/HandTrackingFeature.cs
@@ -147,6 +147,7 @@ namespace Ultraleap.Tracking.OpenXR
 #if UNITY_EDITOR
         protected override void GetValidationChecks(List<ValidationRule> rules, BuildTargetGroup targetGroup)
         {
+#if UNITY_ANDROID
             // If building for Android, check that we are targeting Android API 29 for maximum compatibility.
             rules.Add(new ValidationRule(this)
             {
@@ -170,6 +171,7 @@ namespace Ultraleap.Tracking.OpenXR
                     PlayerSettings.Android.targetSdkVersion = AndroidSdkVersions.AndroidApiLevel29;
                 },
             });
+#endif
 
             // Check the active input handling supports New (for OpenXR) and Legacy (for Ultraleap Plugin support).
             rules.Add(new ValidationRule(this)

--- a/Packages/Tracking OpenXR/Runtime/Scripts/HandTrackingFeature.cs
+++ b/Packages/Tracking OpenXR/Runtime/Scripts/HandTrackingFeature.cs
@@ -25,7 +25,7 @@ namespace Ultraleap.Tracking.OpenXR
         Category = FeatureCategory.Feature,
         Required = false,
         OpenxrExtensionStrings = "XR_EXT_hand_tracking XR_ULTRALEAP_hand_tracking_forearm",
-        BuildTargetGroups = new[] {BuildTargetGroup.Standalone, BuildTargetGroup.Android}
+        BuildTargetGroups = new[] { BuildTargetGroup.Standalone, BuildTargetGroup.Android }
     )]
 #endif
     public class HandTrackingFeature : OpenXRFeature
@@ -125,14 +125,17 @@ namespace Ultraleap.Tracking.OpenXR
             }
         }
 
-        internal bool LocateHandJoints(Handedness handedness, FrameTime frameTime, HandJointLocation[] handJointLocations)
+        internal bool LocateHandJoints(Handedness handedness, FrameTime frameTime,
+            HandJointLocation[] handJointLocations)
         {
-            int result = Native.LocateHandJoints(handedness, frameTime, out uint isActive, handJointLocations, (uint)handJointLocations.Length);
+            int result = Native.LocateHandJoints(handedness, frameTime, out uint isActive, handJointLocations,
+                (uint)handJointLocations.Length);
             if (IsResultFailure(result))
             {
                 Debug.LogError($"Failed to locate hand-joints: {Native.ResultToString(result)}");
                 return false;
             }
+
             return Convert.ToBoolean(isActive);
         }
 
@@ -147,11 +150,12 @@ namespace Ultraleap.Tracking.OpenXR
             // If building for Android, check that we are targeting Android API 29 for maximum compatibility.
             rules.Add(new ValidationRule(this)
             {
-                message = "Android target SDK version is not set to 29",
+                message = "Android target SDK version is not set to 29, hand-tracking may not work on devices " +
+                          "running Android 11 or higher",
                 helpLink = "https://registry.khronos.org/OpenXR/specs/1.0/loader.html#android-active-runtime-location",
-                helpText = "OpenXR applications should not target API levels higher than 29 for maximum compatibility," +
-                           "as runtimes may need to query and load classes from their own packages, which are" +
-                           "necessarily not listed in the <queries> tag above.",
+                helpText = "OpenXR applications should not target API levels higher than 29 for maximum " +
+                           "compatibility, as runtimes may need to query and load classes from their own packages, " +
+                           "which are necessarily not listed in the <queries> tag above.",
                 checkPredicate = () => PlayerSettings.Android.targetSdkVersion == AndroidSdkVersions.AndroidApiLevel29,
                 error = false,
                 fixItAutomatic = true,
@@ -162,9 +166,9 @@ namespace Ultraleap.Tracking.OpenXR
                     {
                         PlayerSettings.Android.minSdkVersion = AndroidSdkVersions.AndroidApiLevel29;
                     }
+
                     PlayerSettings.Android.targetSdkVersion = AndroidSdkVersions.AndroidApiLevel29;
                 },
-
             });
 
             // Check the active input handling supports New (for OpenXR) and Legacy (for Ultraleap Plugin support).
@@ -186,8 +190,8 @@ namespace Ultraleap.Tracking.OpenXR
             // Check that the Main camera has a suitable near clipping plane for hand-tracking.
             rules.Add(new ValidationRule(this)
             {
-                message = "Main camera near clipping plane is further than recommend and tracked hands may show visual" +
-                          "clipping artifacts.",
+                message = "Main camera near clipping plane is further than recommend and tracked hands may show " +
+                          "visual clipping artifacts.",
                 error = false,
                 checkPredicate = () => Camera.main == null || Camera.main.nearClipPlane <= 0.01,
                 fixItAutomatic = true,


### PR DESCRIPTION
## Summary

Adds an XR validation step to ensure an application is targeting Android 29, as per the OpenXR recommendations, if OpenXR is being used for a project.

This ensures that the tracking service can be correctly connected to despite Android 11's package visibility changes.

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [x] Pair review with a member of the QA team.
- [x] Add any release testing considerations to the MR for the next release.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] Checked and agree with release testing considerations added to MR for the next release.
- [x] Ensure that if an Android SDK version greater than 29 is listed, there is a warning in OpenXR validation.
- [x] Ensure that if the "Fix" button is clicked, it automatically adjusts the target, and the minimum SDK level if it was higher than 29.

## Closes JIRA Issue

Relates to OXR-190 (and is a warning to ensure the workaround continues to operate correctly).