### PR TITLE
Feature/unity 816 move leap to unity conversion earlier

### DIFF
--- a/Packages/Tracking Preview/PhysicsHands/Runtime/Utils/PhysicsHandsUtils.cs
+++ b/Packages/Tracking Preview/PhysicsHands/Runtime/Utils/PhysicsHandsUtils.cs
@@ -30,7 +30,7 @@ namespace Leap.Unity.Interaction.PhysicsHands
 
             palmGameObject.name = $"{(handedness == Chirality.Left ? "Left" : "Right")} Palm";
 
-            Leap.Hand leapHand = TestHandFactory.MakeTestHand(isLeft: handedness == Chirality.Left ? true : false, pose: TestHandFactory.TestHandPose.HeadMountedB, unitType: TestHandFactory.UnitType.UnityUnits);
+            Leap.Hand leapHand = TestHandFactory.MakeTestHand(isLeft: handedness == Chirality.Left ? true : false, pose: TestHandFactory.TestHandPose.HeadMountedB);
 
             Transform palmTransform = palmGameObject.GetComponent<Transform>();
             palmTransform.position = leapHand.PalmPosition;

--- a/Packages/Tracking Preview/XRControllerSupport/ControllersAsHands/Runtime/Scripts/ControllerPostProcess/ControllerHand.cs
+++ b/Packages/Tracking Preview/XRControllerSupport/ControllersAsHands/Runtime/Scripts/ControllerPostProcess/ControllerHand.cs
@@ -437,7 +437,7 @@ namespace Leap.Unity.Controllers
         {
             //TODO: this could do with being changed so it doesn't generate each time.
             // annoying to do because finger positions are in world space, meaning transforms are hard to carry between frames.
-            Hand h = TestHandFactory.MakeTestHand(_chirality == Chirality.Left, unitType: TestHandFactory.UnitType.UnityUnits);
+            Hand h = TestHandFactory.MakeTestHand(_chirality == Chirality.Left);
             SetFingerSizes(ref h, 0.013f);
 
             // Thumb

--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/CopyFromLeapCExtensions.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/CopyFromLeapCExtensions.cs
@@ -22,13 +22,6 @@ namespace LeapInternal
             hand.Transform(leapTransform);
         }
 
-        public static void TransformToLeapUnits(this Hand hand)
-        {
-            LeapTransform leapTransform = new LeapTransform(Vector3.zero, Quaternion.identity, new Vector3(1/MM_TO_M, 1/MM_TO_M, 1/MM_TO_M));
-            leapTransform.MirrorZ();
-
-            hand.Transform(leapTransform);
-        }
 
         /**
          * Copies the data from an internal tracking message into a frame.

--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/CopyFromLeapCExtensions.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/CopyFromLeapCExtensions.cs
@@ -12,6 +12,23 @@ namespace LeapInternal
     using UnityEngine;
     public static class CopyFromLeapCExtensions
     {
+        public static readonly float MM_TO_M = 1e-3f;
+
+        public static void TransformToUnityUnits(this Hand hand)
+        {
+            LeapTransform leapTransform = new LeapTransform(Vector3.zero, Quaternion.identity, new Vector3(MM_TO_M, MM_TO_M, MM_TO_M));
+            leapTransform.MirrorZ();
+
+            hand.Transform(leapTransform);
+        }
+
+        public static void TransformToLeapUnits(this Hand hand)
+        {
+            LeapTransform leapTransform = new LeapTransform(Vector3.zero, Quaternion.identity, new Vector3(1/MM_TO_M, 1/MM_TO_M, 1/MM_TO_M));
+            leapTransform.MirrorZ();
+
+            hand.Transform(leapTransform);
+        }
 
         /**
          * Copies the data from an internal tracking message into a frame.
@@ -69,6 +86,8 @@ namespace LeapInternal
             hand.Fingers[2].CopyFrom(leapHand.middle, Leap.Finger.FingerType.TYPE_MIDDLE, hand.Id, hand.TimeVisible);
             hand.Fingers[3].CopyFrom(leapHand.ring, Leap.Finger.FingerType.TYPE_RING, hand.Id, hand.TimeVisible);
             hand.Fingers[4].CopyFrom(leapHand.pinky, Leap.Finger.FingerType.TYPE_PINKY, hand.Id, hand.TimeVisible);
+
+            hand.TransformToUnityUnits();
 
             return hand;
         }

--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/LeapTransform.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/LeapTransform.cs
@@ -44,11 +44,9 @@ namespace Leap
         /// <param name="t">Unity Transform</param>
         public LeapTransform(Transform t) : this()
         {
-            float MM_TO_M = 1e-3f;
-            _scale = new Vector3(t.lossyScale.x * MM_TO_M, t.lossyScale.y * MM_TO_M, t.lossyScale.z * MM_TO_M);
+            _scale = t.lossyScale;
             this.translation = t.position;
             this.rotation = t.rotation;
-            this.MirrorZ(); // Unity is left handed.
         }
 
         /// <summary>

--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/LeapTransform.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/LeapTransform.cs
@@ -32,7 +32,7 @@ namespace Leap
         public LeapTransform(Vector3 translation, Quaternion rotation, Vector3 scale) :
           this()
         {
-            _scale = scale;
+            this.scale = scale;
             // these are non-trival setters.
             this.translation = translation;
             this.rotation = rotation; // Calls validateBasis
@@ -44,7 +44,7 @@ namespace Leap
         /// <param name="t">Unity Transform</param>
         public LeapTransform(Transform t) : this()
         {
-            _scale = t.lossyScale;
+            this.scale = t.lossyScale;
             this.translation = t.position;
             this.rotation = t.rotation;
         }

--- a/Packages/Tracking/Core/Runtime/Scripts/Hands/HandModelBase.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Hands/HandModelBase.cs
@@ -294,8 +294,7 @@ namespace Leap.Unity
                         //If we still have a null hand, construct one manually
                         if (hand == null)
                         {
-                            hand = TestHandFactory.MakeTestHand(Handedness == Chirality.Left, unitType: TestHandFactory.UnitType.LeapUnits);
-                            hand.Transform(new LeapTransform(transform));
+                            hand = TestHandFactory.MakeTestHand(Handedness == Chirality.Left);
                         }
                     }
                     else

--- a/Packages/Tracking/Core/Runtime/Scripts/Hands/TestHandFactory.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Hands/TestHandFactory.cs
@@ -11,6 +11,8 @@ namespace Leap
     using System;
     using System.Collections.Generic;
     using UnityEngine;
+    using LeapInternal;
+
     public static class TestHandFactory
     {
 
@@ -29,17 +31,16 @@ namespace Leap
         public static Frame MakeTestFrame(int frameId,
                                           bool includeLeftHand = true,
                                           bool includeRightHand = true,
-                                          TestHandPose handPose = TestHandPose.HeadMountedA,
-                                          UnitType unitType = UnitType.LeapUnits)
+                                          TestHandPose handPose = TestHandPose.HeadMountedA)
         {
 
             var testFrame = new Frame(frameId, 0, 120.0f,
                                       new List<Hand>());
 
             if (includeLeftHand)
-                testFrame.Hands.Add(MakeTestHand(true, handPose, frameId, 10, unitType));
+                testFrame.Hands.Add(MakeTestHand(true, handPose, frameId, 10));
             if (includeRightHand)
-                testFrame.Hands.Add(MakeTestHand(false, handPose, frameId, 20, unitType));
+                testFrame.Hands.Add(MakeTestHand(false, handPose, frameId, 20));
 
             return testFrame;
         }
@@ -51,8 +52,7 @@ namespace Leap
         /// left and right hands.
         /// </summary>
         public static Hand MakeTestHand(bool isLeft, LeapTransform leftHandTransform,
-                                        int frameId = 0, int handId = 0,
-                                        UnitType unitType = UnitType.LeapUnits)
+                                        int frameId = 0, int handId = 0)
         {
 
             // Apply the appropriate mirroring if this is a right hand.
@@ -74,12 +74,9 @@ namespace Leap
                          .Transform(leftHandTransform);
 
             var transformedHand = hand.Transform(new LeapTransform(Vector3.zero,
-                                                                   Quaternion.Euler(90f, 0f, 180f)));
+                  Quaternion.Euler(90f, 0f, 180f)));
 
-            if (unitType == UnitType.UnityUnits)
-            {
-                transformedHand.TransformToUnityUnits();
-            }
+            transformedHand.TransformToUnityUnits();
 
             return transformedHand;
         }
@@ -88,22 +85,19 @@ namespace Leap
         /// Returns a test Hand object.
         /// </summary>
         public static Hand MakeTestHand(bool isLeft,
-                                        int frameId = 0, int handId = 0,
-                                        UnitType unitType = UnitType.LeapUnits)
+                                        int frameId = 0, int handId = 0)
         {
-            return MakeTestHand(isLeft, LeapTransform.Identity, frameId, handId, unitType);
+            return MakeTestHand(isLeft, LeapTransform.Identity, frameId, handId);
         }
 
         /// <summary>
         /// Returns a test Leap Hand object in the argument TestHandPose.
         /// </summary>
         public static Hand MakeTestHand(bool isLeft, TestHandPose pose,
-                                        int frameId = 0, int handId = 0,
-                                        UnitType unitType = UnitType.LeapUnits)
+                                        int frameId = 0, int handId = 0)
         {
             return MakeTestHand(isLeft, GetTestPoseLeftHandTransform(pose),
-                                frameId, handId,
-                                unitType);
+                                frameId, handId);
         }
 
         #endregion
@@ -316,27 +310,5 @@ namespace Leap
 
         #endregion
 
-    }
-
-    // Note: The fact that this class needs to exist is ridiculous
-    // TODO: Look into automatically returning things in Unity units? Would require changes
-    // for everything that uses the TestHandFactory.
-    public static class LeapTestProviderExtensions
-    {
-
-        public static readonly float MM_TO_M = 1e-3f;
-
-        public static LeapTransform GetLeapTransform(Vector3 position, Quaternion rotation)
-        {
-            Vector3 scale = new Vector3(MM_TO_M, MM_TO_M, MM_TO_M); // Leap units -> Unity units.
-            LeapTransform transform = new LeapTransform(position, rotation, scale);
-            transform.MirrorZ(); // Unity is left handed.
-            return transform;
-        }
-
-        public static void TransformToUnityUnits(this Hand hand)
-        {
-            hand.Transform(GetLeapTransform(Vector3.zero, Quaternion.identity));
-        }
     }
 }

--- a/Packages/Tracking/Core/Runtime/Scripts/LeapXRServiceProvider.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/LeapXRServiceProvider.cs
@@ -526,7 +526,6 @@ namespace Leap.Unity
             {
                 //By default, use the camera transform matrix to transform the frame into 
                 leapTransform = new LeapTransform(mainCamera.transform);
-                leapTransform.scale = Vector3.one * 1e-3f;
 
                 //If the application is playing then we can try to use temporal warping
                 if (Application.isPlaying)
@@ -609,20 +608,16 @@ namespace Leap.Unity
             {
                 leapTransform = new LeapTransform(
                   mainCamera.transform.parent.TransformPoint(warpedPosition),
-                  mainCamera.transform.parent.TransformRotation(warpedRotation),
-                  Vector3.one * 1e-3f
-                );
+                  mainCamera.transform.parent.TransformRotation(warpedRotation)
+                  );
             }
             else
             {
                 leapTransform = new LeapTransform(
                   warpedPosition,
-                  warpedRotation,
-                  Vector3.one * 1e-3f
-                );
+                  warpedRotation
+                  );
             }
-
-            leapTransform.MirrorZ();
 
             return leapTransform;
         }


### PR DESCRIPTION
## Pull Request Templates

Switch template by going to preview and clicking the link - note it not work if you've made any changes to the description.

- [default.md](?expand=1) - for contributions to stable packages.
- [lightweight.md](?expand=1&template=lightweight.md) - for contributions to pre-release/preview packages use the lightweight merge request template. The quality threshold for reviewing is lower - it prioritizes a lean review process.
- [release.md](?expand=1&template=release.md) - for release merge requests.

**You are currently using: default.md**

Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.

## Summary

This PR moves the conversion from MM to M back to the initial point that we get tracking data. This means it removes all conversions later in the stack and will be a breaking change for users that have been expecting units in MM and are manually converting to M

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [ ] Pair review with a member of the QA team.
- [ ] Add any release testing considerations to the MR for the next release.
- [x] Check any relevant CHANGELOG files have been updated.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.
- [ ] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [ ] Checked and agree with release testing considerations added to MR for the next release.
- [x] Test all uses of hands where possible, this change may have some niche paths that have not been covered

## Closes JIRA Issue

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_

Closes UNITY-816