### PR TITLE
AttachmentHands untick bone in edit mode causes errors

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 
+- AttachmentHands untick bone in inspector UI causes looping error when deleting gameobject in edit mode
+
 ## [5.13.0] - 21/07/2022
 
 ### Announcements

--- a/Packages/Tracking/Core/Editor/Scripts/AttachmentHandsEditor.cs
+++ b/Packages/Tracking/Core/Editor/Scripts/AttachmentHandsEditor.cs
@@ -118,15 +118,19 @@ namespace Leap.Unity.Attachments
             }
             else
             {
-                if (!wouldFlagDeletionDestroyData(target, flag)
-                    || EditorUtility.DisplayDialog("Delete " + flag + " Attachment Point?",
+                if (!wouldFlagDeletionDestroyData(target, flag))
+                {
+
+                    target.attachmentPoints = attachmentPoints & (~flag); // Set flag bit to 0.
+                }
+                else if(EditorUtility.DisplayDialog("Delete " + flag + " Attachment Point?",
                                                    "Deleting the " + flag + " attachment point will destroy "
                                                  + "its GameObject and any of its non-Attachment-Point children, "
                                                  + "and will remove any components attached to it.",
                                                    "Delete " + flag + " Attachment Point", "Cancel"))
                 {
-
                     target.attachmentPoints = attachmentPoints & (~flag); // Set flag bit to 0.
+                    GUIUtility.ExitGUI();
                 }
             }
         }

--- a/Packages/Tracking/Core/Runtime/Scripts/Attachments/AttachmentHand.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Attachments/AttachmentHand.cs
@@ -381,11 +381,24 @@ namespace Leap.Unity.Attachments
             var pointBehaviour = GetBehaviourForPoint(singlePoint);
             if (pointBehaviour != null)
             {
-                Destroy(pointBehaviour.gameObject);
+                if (!Application.isPlaying)
+                {
+                    if (PrefabUtility.IsPartOfPrefabInstance(pointBehaviour.gameObject))
+                    {
+                        PrefabUtility.UnpackPrefabInstance(PrefabUtility.GetOutermostPrefabInstanceRoot(pointBehaviour.transform),
+                              PrefabUnpackMode.Completely,
+                              InteractionMode.AutomatedAction);
+                    }
+
+                    DestroyImmediate(pointBehaviour.gameObject);
+                }
+                else
+                {
+                    Destroy(pointBehaviour.gameObject);
+                }
+
                 setBehaviourForPoint(singlePoint, null);
-
                 pointBehaviour = null;
-
                 _attachmentPointsDirty = true;
 
 #if UNITY_EDITOR


### PR DESCRIPTION
## Pull Request Templates

Switch template by going to preview and clicking the link - note it not work if you've made any changes to the description.

- [default.md](?expand=1) - for contributions to stable packages.
- [lightweight.md](?expand=1&template=lightweight.md) - for contributions to pre-release/preview packages use the lightweight merge request template. The quality threshold for reviewing is lower - it prioritizes a lean review process.
- [release.md](?expand=1&template=release.md) - for release merge requests.

**You are currently using: default.md**

Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.

## Summary

This adds an editor-safe way to destroy gameobjects in the scene when unticking bones via the AttachmentHands inspector UI

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [ ] Pair review with a member of the QA team.
- [ ] Add any release testing considerations to the MR for the next release.
- [x] Check any relevant CHANGELOG files have been updated.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.
- [ ] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [ ] Checked and agree with release testing considerations added to MR for the next release.

## Closes JIRA Issue

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_

Closes UNITY-588