### PR TITLE
Move AndroidManifest utility to be be public

### DIFF
--- a/Packages/Tracking OpenXR/Editor/Scripts/AndroidManifest.cs
+++ b/Packages/Tracking OpenXR/Editor/Scripts/AndroidManifest.cs
@@ -4,131 +4,128 @@ using System.Xml.Linq;
 
 namespace Ultraleap.Tracking.OpenXR
 {
-    public partial class HandTrackingFeatureBuildHooks
+    public class AndroidManifest
     {
-        private class AndroidManifest
+        private readonly string _manifestPath;
+        private readonly XDocument _manifest;
+        private readonly XNamespace _android;
+
+        [PublicAPI]
+        public AndroidManifest(string path)
         {
-            private readonly string _manifestPath;
-            private readonly XDocument _manifest;
-            private readonly XNamespace _android;
+            _manifestPath = path;
+            _manifest = XDocument.Load(_manifestPath);
+            _android = @"http://schemas.android.com/apk/res/android";
+        }
 
-            [PublicAPI]
-            public AndroidManifest(string path)
+        [PublicAPI]
+        public void Save()
+        {
+            _manifest.Save(_manifestPath);
+        }
+
+        [PublicAPI]
+        public void SaveAs(string path)
+        {
+            _manifest.Save(path);
+        }
+
+        [PublicAPI]
+        public void AddQueriesPackage(string packageName)
+        {
+            // Get the queries element, creating it if it doesn't exist.
+            var queries = _manifest.Root!.Element("queries");
+            if (queries == null)
             {
-                _manifestPath = path;
-                _manifest = XDocument.Load(_manifestPath);
-                _android = @"http://schemas.android.com/apk/res/android";
+                queries = new XElement("queries");
+                _manifest.Root!.Add(queries);
             }
 
-            [PublicAPI]
-            public void Save()
+            // Check for the package statement and create it if doesn't exist
+            if (queries.Elements("package").All(el => el.Attribute(_android + "name")?.Name != packageName))
             {
-                _manifest.Save(_manifestPath);
-            }
-
-            [PublicAPI]
-            public void SaveAs(string path)
-            {
-                _manifest.Save(path);
-            }
-
-            [PublicAPI]
-            public void AddQueriesPackage(string packageName)
-            {
-                // Get the queries element, creating it if it doesn't exist.
-                var queries = _manifest.Root!.Element("queries");
-                if (queries == null)
-                {
-                    queries = new XElement("queries");
-                    _manifest.Root!.Add(queries);
-                }
-
-                // Check for the package statement and create it if doesn't exist
-                if (queries.Elements("package").All(el => el.Attribute(_android + "name")?.Name != packageName))
-                {
-                    queries.Add(
-                        new XElement("package", new XAttribute(_android + "name", packageName))
-                    );
-                }
-            }
-
-            [PublicAPI]
-            public void AddQueriesIntentAction(string name)
-            {
-                // Get the queries element, creating it if it doesn't exist.
-                var queries = _manifest.Root!.Element("queries");
-                if (queries == null)
-                {
-                    queries = new XElement("queries");
-                    _manifest.Root!.Add(queries);
-                }
-
-                // Refactor later if required
                 queries.Add(
-                    new XElement("intent",
-                        new XElement("action",
-                            new XAttribute(_android + "name", name))));
+                    new XElement("package", new XAttribute(_android + "name", packageName))
+                );
+            }
+        }
+
+        [PublicAPI]
+        public void AddQueriesIntentAction(string name)
+        {
+            // Get the queries element, creating it if it doesn't exist.
+            var queries = _manifest.Root!.Element("queries");
+            if (queries == null)
+            {
+                queries = new XElement("queries");
+                _manifest.Root!.Add(queries);
             }
 
-            [PublicAPI]
-            public void AddUsesPermission(string name)
+            // Refactor later if required
+            queries.Add(
+                new XElement("intent",
+                    new XElement("action",
+                        new XAttribute(_android + "name", name))));
+        }
+
+        [PublicAPI]
+        public void AddUsesPermission(string name)
+        {
+            // Check if the uses-permission is already there, and create it if not.
+            if (_manifest.Root!.Elements("uses-permission")
+                .All(el => el.Attribute(_android + "name")?.Name != name))
             {
-                // Check if the uses-permission is already there, and create it if not.
-                if (_manifest.Root!.Elements("uses-permission")
-                    .All(el => el.Attribute(_android + "name")?.Name != name))
-                {
-                    _manifest.Root!.Add(
-                        new XElement("uses-permission", new XAttribute(_android + "name", name))
-                    );
-                }
+                _manifest.Root!.Add(
+                    new XElement("uses-permission", new XAttribute(_android + "name", name))
+                );
             }
+        }
 
-            [PublicAPI]
-            public void AddUsesFeature(string name, bool required)
+        [PublicAPI]
+        public void AddUsesFeature(string name, bool required)
+        {
+            // Check if the uses-feature is already there.
+            var feature = _manifest.Root!
+                .Elements("uses-feature")
+                .FirstOrDefault(el => el.Attribute(_android + "name")?.Name == name);
+
+            // Add if it doesn't exist, or upgrade to required if it does and required was declared.
+            if (feature == null)
             {
-                // Check if the uses-feature is already there.
-                var feature = _manifest.Root!
-                    .Elements("uses-feature")
-                    .FirstOrDefault(el => el.Attribute(_android + "name")?.Name == name);
-
-                // Add if it doesn't exist, or upgrade to required if it does and required was declared.
-                if (feature == null)
-                {
-                    _manifest.Root!.Add(
-                        new XElement("uses-feature",
-                            new XAttribute(_android + "name", name),
-                            new XAttribute(_android + "required", required)
-                        )
-                    );
-                }
-                else if (required)
-                {
-                    feature.SetAttributeValue(_android + "required", true);
-                }
+                _manifest.Root!.Add(
+                    new XElement("uses-feature",
+                        new XAttribute(_android + "name", name),
+                        new XAttribute(_android + "required", required)
+                    )
+                );
             }
-
-            [PublicAPI]
-            public void AddMetadata(string name, string value)
+            else if (required)
             {
-                // Get the application element.
-                var application = _manifest.Root!.Element("application")!;
-                var metaData = application
-                    .Elements("meta-data")
-                    .FirstOrDefault(el => el.Attribute(_android + "name")?.Name == name);
+                feature.SetAttributeValue(_android + "required", true);
+            }
+        }
 
-                // Check for the meta-data element and create it if doesn't exist, or update if it does.
-                if (metaData == null)
-                {
-                    application.Add(
-                        new XElement("meta-data",
-                            new XAttribute(_android + "name", name),
-                            new XAttribute(_android + "value", value))
-                    );
-                }
-                else
-                {
-                    metaData.SetAttributeValue(_android + "value", value);
-                }
+        [PublicAPI]
+        public void AddMetadata(string name, string value)
+        {
+            // Get the application element.
+            var application = _manifest.Root!.Element("application")!;
+            var metaData = application
+                .Elements("meta-data")
+                .FirstOrDefault(el => el.Attribute(_android + "name")?.Name == name);
+
+            // Check for the meta-data element and create it if doesn't exist, or update if it does.
+            if (metaData == null)
+            {
+                application.Add(
+                    new XElement("meta-data",
+                        new XAttribute(_android + "name", name),
+                        new XAttribute(_android + "value", value))
+                );
+            }
+            else
+            {
+                metaData.SetAttributeValue(_android + "value", value);
             }
         }
     }


### PR DESCRIPTION
## Summary

Changes the `AndroidManifest` utility class to be public so that other packages can depend on and use its functionality. It should have been public in the original PR and this is correcting an oversight.

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [x] Pair review with a member of the QA team.
- [ ] Add any release testing considerations to the MR for the next release.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] Checked and agree with release testing considerations added to MR for the next release.