### PR TITLE
Add Create Menu options for all 3 LeapServiceProvider prefabs

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added a low poly hand model with an arm
+- Added create menu options for LeapServiceProviders via GameObject/Ultrealeap/Service Provider (X)
 
 ### Changed
 - Cleaned up the image retriever and LeapServiceProvider Execution order, reducing unnecessary service and log messages

--- a/Packages/Tracking/Core/Editor/Scripts/PrefabCreateMenu.cs
+++ b/Packages/Tracking/Core/Editor/Scripts/PrefabCreateMenu.cs
@@ -14,7 +14,6 @@ namespace Leap
 {
     public class PrefabCreateMenu
     {
-        [MenuItem("GameObject/Ultraleap")]
         [MenuItem("GameObject/Ultraleap/Service Provider (Desktop)")]
         public static void CreateServiceProviderDesktop()
         {

--- a/Packages/Tracking/Core/Editor/Scripts/PrefabCreateMenu.cs
+++ b/Packages/Tracking/Core/Editor/Scripts/PrefabCreateMenu.cs
@@ -34,17 +34,15 @@ namespace Leap
 
         public static void CreatePrefab(string prefabName)
         {
-            GameObject newObject = null;
+            var guids = AssetDatabase.FindAssets(prefabName);
+            string assetPath = AssetDatabase.GUIDToAssetPath(guids[0]);
 
-            if(newObject == null)
+            GameObject newObject = (GameObject)AssetDatabase.LoadAssetAtPath(assetPath, typeof(GameObject));
+
+            if (newObject != null)
             {
-                var guids = AssetDatabase.FindAssets(prefabName);
-                string assetPath = AssetDatabase.GUIDToAssetPath(guids[0]);
-
-                newObject = (GameObject)AssetDatabase.LoadAssetAtPath(assetPath, typeof(GameObject));
+                HandleObjectCreation(newObject);
             }
-
-            HandleObjectCreation(newObject);
         }
 
         static void HandleObjectCreation(GameObject gameObject)

--- a/Packages/Tracking/Core/Editor/Scripts/PrefabCreateMenu.cs
+++ b/Packages/Tracking/Core/Editor/Scripts/PrefabCreateMenu.cs
@@ -14,19 +14,20 @@ namespace Leap
 {
     public class PrefabCreateMenu
     {
-        [MenuItem("GameObject/Ultraleap/Service Provider (Desktop)", false, 1)]
+        [MenuItem("GameObject/Ultraleap")]
+        [MenuItem("GameObject/Ultraleap/Service Provider (Desktop)")]
         public static void CreateServiceProviderDesktop()
         {
             CreatePrefab("Service Provider (Desktop)");
         }
 
-        [MenuItem("GameObject/Ultraleap/Service Provider (Screentop)", false, 2)]
+        [MenuItem("GameObject/Ultraleap/Service Provider (Screentop)")]
         public static void CreateServiceProviderScreentop()
         {
             CreatePrefab("Service Provider (Screentop)");
         }
 
-        [MenuItem("GameObject/Ultraleap/Service Provider (XR)", false, 3)]
+        [MenuItem("GameObject/Ultraleap/Service Provider (XR)")]
         public static void CreateServiceProviderXR()
         {
             CreatePrefab("Service Provider (XR)");

--- a/Packages/Tracking/Core/Editor/Scripts/PrefabCreateMenu.cs
+++ b/Packages/Tracking/Core/Editor/Scripts/PrefabCreateMenu.cs
@@ -1,0 +1,70 @@
+/******************************************************************************
+ * Copyright (C) Ultraleap, Inc. 2011-2021.                                   *
+ *                                                                            *
+ * Use subject to the terms of the Apache License 2.0 available at            *
+ * http://www.apache.org/licenses/LICENSE-2.0, or another agreement           *
+ * between Ultraleap and you, your company or other organization.             *
+ ******************************************************************************/
+
+using UnityEditor;
+using UnityEngine;
+using UnityEditor.SceneManagement;
+
+namespace Leap
+{
+    public class PrefabCreateMenu
+    {
+        [MenuItem("GameObject/Ultraleap/Service Provider (Desktop)", false, 1)]
+        public static void CreateServiceProviderDesktop()
+        {
+            CreatePrefab("Service Provider (Desktop)");
+        }
+
+        [MenuItem("GameObject/Ultraleap/Service Provider (Screentop)", false, 1)]
+        public static void CreateServiceProviderScreentop()
+        {
+            CreatePrefab("Service Provider (Screentop)");
+        }
+
+        [MenuItem("GameObject/Ultraleap/Service Provider (XR)", false, 1)]
+        public static void CreateServiceProviderXR()
+        {
+            CreatePrefab("Service Provider (XR)");
+        }
+
+        public static void CreatePrefab(string prefabName)
+        {
+            GameObject newObject = null;
+
+            if(newObject == null)
+            {
+                var guids = AssetDatabase.FindAssets(prefabName);
+                string assetPath = AssetDatabase.GUIDToAssetPath(guids[0]);
+
+                newObject = (GameObject)AssetDatabase.LoadAssetAtPath(assetPath, typeof(GameObject));
+            }
+
+            HandleObjectCreation(newObject);
+        }
+
+        static void HandleObjectCreation(GameObject gameObject)
+        {
+            gameObject = PrefabUtility.InstantiatePrefab(gameObject) as GameObject;
+
+            // Find location
+            SceneView lastView = SceneView.lastActiveSceneView;
+            gameObject.transform.position = lastView ? lastView.pivot : Vector3.zero;
+
+            // Make sure we place the object in the proper scene, with a relevant name
+            StageUtility.PlaceGameObjectInCurrentStage(gameObject);
+            GameObjectUtility.EnsureUniqueNameForSibling(gameObject);
+
+            // Record undo, and select
+            Undo.RegisterCreatedObjectUndo(gameObject, $"Create Object: {gameObject.name}");
+            Selection.activeGameObject = gameObject;
+
+            // For prefabs, let's mark the scene as dirty for saving
+            EditorSceneManager.MarkSceneDirty(EditorSceneManager.GetActiveScene());
+        }
+    }
+}

--- a/Packages/Tracking/Core/Editor/Scripts/PrefabCreateMenu.cs
+++ b/Packages/Tracking/Core/Editor/Scripts/PrefabCreateMenu.cs
@@ -20,13 +20,13 @@ namespace Leap
             CreatePrefab("Service Provider (Desktop)");
         }
 
-        [MenuItem("GameObject/Ultraleap/Service Provider (Screentop)", false, 1)]
+        [MenuItem("GameObject/Ultraleap/Service Provider (Screentop)", false, 2)]
         public static void CreateServiceProviderScreentop()
         {
             CreatePrefab("Service Provider (Screentop)");
         }
 
-        [MenuItem("GameObject/Ultraleap/Service Provider (XR)", false, 1)]
+        [MenuItem("GameObject/Ultraleap/Service Provider (XR)", false, 3)]
         public static void CreateServiceProviderXR()
         {
             CreatePrefab("Service Provider (XR)");
@@ -59,6 +59,12 @@ namespace Leap
 
             // Record undo, and select
             Undo.RegisterCreatedObjectUndo(gameObject, $"Create Object: {gameObject.name}");
+
+            if (Selection.activeGameObject != null)
+            {
+                gameObject.transform.parent = Selection.activeGameObject.transform;
+            }
+
             Selection.activeGameObject = gameObject;
 
             // For prefabs, let's mark the scene as dirty for saving

--- a/Packages/Tracking/Core/Editor/Scripts/PrefabCreateMenu.cs.meta
+++ b/Packages/Tracking/Core/Editor/Scripts/PrefabCreateMenu.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 3c4ae3b79edac3c4f881ed321ca6c12e
+timeCreated: 1516225007
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

Add Create Menu options for all 3 LeapServiceProvider prefabs to make it easier to add hand tracking to a scene

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [ ] Pair review with a member of the QA team.
- [ ] Add any release testing considerations to the MR for the next release.
- [x] Check any relevant CHANGELOG files have been updated.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.
- [ ] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [x] Checked and agree with release testing considerations added to MR for the next release.
- [ ] Make sure this works when the package in in /Packages/ as well as /Assets/ (via UPM and via .unitypackage)

## Closes JIRA Issue

Closes UNITY-781