### PR TITLE
UNITY-786 - FOV gizmos

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Leap.Controller.InternalFrameReady, LeapInternalFrame is never dispatched
 - HandUI example scene panel exists after hand lost
 - ChangeTrackingMode and GetTrackingMode on LeapServiceProvider fail when in disabled multi-device mode
+- FOV Gizmos are not visible when opening an example scene containing a Service Provider in multiDeviceMode = disabled.
+- FOV Gizmos are not visible when changing render pipelines
 
 ## [5.13.0] - 21/07/2022
 

--- a/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
@@ -1203,12 +1203,12 @@ namespace Leap.Unity
 
         private void DetectConnectedDevice(Transform targetTransform)
         {
-            if (_leapController != null && _leapController.Devices?.Count >= 1)
+            if (GetLeapController() != null && GetLeapController().Devices?.Count >= 1)
             {
                 Device currentDevice = _currentDevice;
                 if (currentDevice == null || (_multipleDeviceMode == LeapServiceProvider.MultipleDeviceMode.Specific && currentDevice.SerialNumber != _specificSerialNumber))
                 {
-                    foreach (Device d in _leapController.Devices)
+                    foreach (Device d in GetLeapController().Devices)
                     {
                         if (d.SerialNumber.Contains(_specificSerialNumber))
                         {
@@ -1216,6 +1216,11 @@ namespace Leap.Unity
                             break;
                         }
                     }
+                }
+
+                if (currentDevice == null && _multipleDeviceMode == MultipleDeviceMode.Disabled)
+                {
+                    currentDevice = GetLeapController().Devices[0];
                 }
 
                 if (currentDevice == null || (_multipleDeviceMode == LeapServiceProvider.MultipleDeviceMode.Specific && currentDevice.SerialNumber != _specificSerialNumber))


### PR DESCRIPTION
## Pull Request Templates

Switch template by going to preview and clicking the link - note it not work if you've made any changes to the description.

- [default.md](?expand=1) - for contributions to stable packages.
- [lightweight.md](?expand=1&template=lightweight.md) - for contributions to pre-release/preview packages use the lightweight merge request template. The quality threshold for reviewing is lower - it prioritizes a lean review process.
- [release.md](?expand=1&template=release.md) - for release merge requests.

**You are currently using: default.md**

Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.

## Summary

Fix for controller not created when drawing fov gizmos. This should fix the FOV gizmos, when first opening a scene that has a service provider with multiDeviceMode = disabled.

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [x] Pair review with a member of the QA team.
- [x] Add any release testing considerations to the MR for the next release.
- [x] Check any relevant CHANGELOG files have been updated.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.
- [x] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [ ] Checked and agree with release testing considerations added to MR for the next release.

## Closes JIRA Issue

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_

Closes UNITY-786