### PR TITLE
Hand Rays visuals refactored to reduce logic duplication in example assets

### DIFF
--- a/Packages/Tracking Preview/Examples~/HandRays/Hand Rays.unity
+++ b/Packages/Tracking Preview/Examples~/HandRays/Hand Rays.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.16368926, g: 0.2050146, b: 0.28483808, a: 1}
+  m_IndirectSpecularColor: {r: 0.44131893, g: 0.490125, b: 0.57017505, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -152,7 +152,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1009217017}
   m_RootOrder: 0
@@ -169,7 +168,6 @@ TrailRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
   m_MotionVectors: 0
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
@@ -285,7 +283,6 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -7, y: 1.2, z: 0.1}
   m_LocalScale: {x: 2, y: 1, z: 6}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 158656705}
   m_RootOrder: 2
@@ -314,7 +311,6 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -379,7 +375,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1281262284}
   - {fileID: 246309801}
@@ -415,7 +410,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 889679136}
   m_Father: {fileID: 1727789600}
@@ -432,7 +426,6 @@ LineRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
   m_MotionVectors: 0
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
@@ -532,12 +525,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe3a36fbd282d0d45a80f5fd5f4127d6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _handRay: {fileID: 2032573003}
+  _lineRenderer: {fileID: 211112612}
+  _trailRendererTransform: {fileID: 889679136}
+  _trailRendererYOffset: 0.04
+  _layersToIgnore: []
+  OnRayUpdate:
+    m_PersistentCalls:
+      m_Calls: []
   projectionScale: 10
   handMergeDistance: 0.7
-  handRay: {fileID: 2032573003}
-  lineRenderer: {fileID: 211112612}
-  trailRendererTransform: {fileID: 889679136}
-  trailRendererYOffset: 0.04
 --- !u!1 &246309800
 GameObject:
   m_ObjectHideFlags: 0
@@ -567,7 +564,6 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -5, y: 0.6, z: 0.1}
   m_LocalScale: {x: 2, y: 1, z: 6}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 158656705}
   m_RootOrder: 1
@@ -596,7 +592,6 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -664,7 +659,6 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -3, y: 0, z: 0}
   m_LocalScale: {x: 2, y: 1, z: 6}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 903211671}
   m_RootOrder: 0
@@ -693,7 +687,6 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -761,7 +754,6 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -5, y: 0.6, z: 0.1}
   m_LocalScale: {x: 2, y: 1, z: 6}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 903211671}
   m_RootOrder: 1
@@ -790,7 +782,6 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -858,7 +849,6 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -5, y: 0.6, z: 0.1}
   m_LocalScale: {x: 2, y: 1, z: 6}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1629277934}
   m_RootOrder: 1
@@ -887,7 +877,6 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -1005,7 +994,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 1.374, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -1039,7 +1027,6 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -3, y: 0, z: 0}
   m_LocalScale: {x: 2, y: 1, z: 6}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1629277934}
   m_RootOrder: 0
@@ -1068,7 +1055,6 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -1136,7 +1122,6 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -3, y: 0, z: 0}
   m_LocalScale: {x: 2, y: 1, z: 6}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 927946742}
   m_RootOrder: 0
@@ -1165,7 +1150,6 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -1231,7 +1215,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 211112611}
   m_RootOrder: 0
@@ -1248,7 +1231,6 @@ TrailRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
   m_MotionVectors: 0
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
@@ -1361,7 +1343,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0.7071068, z: -0, w: -0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 247345774}
   - {fileID: 623298239}
@@ -1395,7 +1376,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 760519060}
   - {fileID: 1376187621}
@@ -1431,7 +1411,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 112595639}
   m_Father: {fileID: 1727789600}
@@ -1448,7 +1427,6 @@ LineRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
   m_MotionVectors: 0
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
@@ -1548,11 +1526,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5ab29bf4f6c25824db2353b21d5fe02a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  lineRendererDistance: 12
-  handRay: {fileID: 2032573002}
-  lineRenderer: {fileID: 1009217018}
-  trailRendererTransform: {fileID: 112595639}
-  trailRendererYOffset: 0.04
+  _handRay: {fileID: 2032573002}
+  _lineRenderer: {fileID: 1009217018}
+  _trailRendererTransform: {fileID: 112595639}
+  _trailRendererYOffset: 0.04
+  _layersToIgnore: []
+  OnRayUpdate:
+    m_PersistentCalls:
+      m_Calls: []
+  lineRendererDistance: 50
 --- !u!1 &1081353337
 GameObject:
   m_ObjectHideFlags: 0
@@ -1582,7 +1564,6 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -7, y: 1.2, z: 0.1}
   m_LocalScale: {x: 2, y: 1, z: 6}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1629277934}
   m_RootOrder: 2
@@ -1611,7 +1592,6 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -1679,7 +1659,6 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -7, y: 1.2, z: 0.1}
   m_LocalScale: {x: 2, y: 1, z: 6}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 927946742}
   m_RootOrder: 2
@@ -1708,7 +1687,6 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -1776,7 +1754,6 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -3, y: 0, z: 0}
   m_LocalScale: {x: 2, y: 1, z: 6}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 158656705}
   m_RootOrder: 0
@@ -1805,7 +1782,6 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -1873,7 +1849,6 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -5, y: 0.6, z: 0.1}
   m_LocalScale: {x: 2, y: 1, z: 6}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 927946742}
   m_RootOrder: 1
@@ -1902,7 +1877,6 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -1970,7 +1944,6 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -7, y: 1.2, z: 0.1}
   m_LocalScale: {x: 2, y: 1, z: 6}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 903211671}
   m_RootOrder: 2
@@ -1999,7 +1972,6 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -2150,7 +2122,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 748803188}
   - {fileID: 623925576}
@@ -2184,7 +2155,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 211112611}
   - {fileID: 1009217017}
@@ -2217,7 +2187,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4798925283064757}
   - {fileID: 4319164155740633}
@@ -2460,7 +2429,6 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0.1}
   m_LocalScale: {x: 4.5, y: 0.2, z: 4.5}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1847459433}
   m_RootOrder: 2
@@ -2489,7 +2457,6 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -2572,7 +2539,6 @@ Transform:
   m_LocalRotation: {x: -0.042339254, y: -0.74973154, z: 0.36331177, w: 0.55146587}
   m_LocalPosition: {x: 0, y: 2, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1847459433}
   m_RootOrder: 1
@@ -2587,7 +2553,6 @@ Transform:
   m_LocalRotation: {x: 0.43769792, y: -0.32756114, z: 0.59360814, w: 0.5905537}
   m_LocalPosition: {x: 0, y: 2, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1847459433}
   m_RootOrder: 0

--- a/Packages/Tracking Preview/Examples~/HandRays/Scripts/HandRayParabolicLineRenderer.cs
+++ b/Packages/Tracking Preview/Examples~/HandRays/Scripts/HandRayParabolicLineRenderer.cs
@@ -6,8 +6,6 @@
  * between Ultraleap and you, your company or other organization.             *
  ******************************************************************************/
 
-using Leap.Unity.Interaction;
-using Leap.Unity.Interaction.PhysicsHands;
 using Leap.Unity.Preview.HandRays;
 using System.Collections.Generic;
 using UnityEngine;

--- a/Packages/Tracking Preview/Examples~/HandRays/Scripts/HandRayParabolicLineRenderer.cs
+++ b/Packages/Tracking Preview/Examples~/HandRays/Scripts/HandRayParabolicLineRenderer.cs
@@ -6,13 +6,15 @@
  * between Ultraleap and you, your company or other organization.             *
  ******************************************************************************/
 
+using Leap.Unity.Interaction;
+using Leap.Unity.Interaction.PhysicsHands;
 using Leap.Unity.Preview.HandRays;
 using System.Collections.Generic;
 using UnityEngine;
 
 namespace Leap.Unity
 {
-    public class HandRayParabolicLineRenderer : MonoBehaviour
+    public class HandRayParabolicLineRenderer : HandRayRenderer
     {
         [Tooltip("The scale of the projection of any hand distance from the approximated "
                + "shoulder beyond the handMergeDistance.")]
@@ -24,88 +26,16 @@ namespace Leap.Unity
         [Range(0f, 1f)]
         public float handMergeDistance = 0.7f;
 
-        public HandRay handRay;
+        private List<Vector3> _parabolaPositions = new List<Vector3>();
 
-        [SerializeField] private LineRenderer lineRenderer;
-        [SerializeField] private Transform trailRendererTransform;
-        [SerializeField] private float trailRendererYOffset = 0.04f;
-
-        private TrailRenderer trailRenderer;
-        private List<Vector3> parabolaPositions = new List<Vector3>();
-
-        void Start()
+        Vector3 evaluateParabola(Vector3 position, Vector3 velocity, Vector3 acceleration, float time)
         {
-            if (lineRenderer == null)
-            {
-                lineRenderer = GetComponentInChildren<LineRenderer>();
-                if (lineRenderer == null)
-                {
-                    Debug.LogWarning("HandRayParabolicLineRenderer needs a lineRenderer");
-                }
-            }
-
-            if (trailRendererTransform != null)
-            {
-                trailRenderer = trailRendererTransform.GetComponentInChildren<TrailRenderer>();
-                if (trailRenderer == null)
-                {
-                    Debug.LogWarning("The trail renderer transform reference does not have a trailRenderer attached");
-                }
-            }
-            lineRenderer.enabled = false;
+            return position + (velocity * time) + (0.5f * acceleration * (time * time));
         }
 
-        private void OnEnable()
+        protected override bool UpdateLineRendererLogic(HandRayDirection handRayDirection, out RaycastHit raycastResult)
         {
-            if (handRay == null)
-            {
-                handRay = FindObjectOfType<WristShoulderFarFieldHandRay>();
-                if (handRay == null)
-                {
-                    Debug.LogWarning("HandRayParabolicLineRenderer needs a HandRay");
-                    return;
-                }
-            }
-            handRay.OnHandRayFrame += UpdateLineRenderer;
-            handRay.OnHandRayEnable += EnableLineRenderer;
-            handRay.OnHandRayDisable += DisableLineRenderer;
-        }
-
-        private void OnDisable()
-        {
-            if (handRay == null)
-            {
-                return;
-            }
-
-            handRay.OnHandRayFrame -= UpdateLineRenderer;
-            handRay.OnHandRayEnable -= EnableLineRenderer;
-            handRay.OnHandRayDisable -= DisableLineRenderer;
-        }
-
-        void EnableLineRenderer(HandRayDirection farFieldDirection)
-        {
-            lineRenderer.enabled = true;
-
-            if (trailRendererTransform != null)
-            {
-                trailRenderer.enabled = true;
-                trailRenderer.Clear();
-            }
-        }
-
-        void DisableLineRenderer(HandRayDirection farFieldDirection)
-        {
-            lineRenderer.enabled = false;
-            if (trailRendererTransform != null)
-            {
-                trailRenderer.enabled = false;
-            }
-        }
-
-        void UpdateLineRenderer(HandRayDirection handRayDirection)
-        {
-            parabolaPositions.Clear();
+            _parabolaPositions.Clear();
 
             // Calculate the projection of the hand if it extends beyond the handMergeDistance.
             Vector3 handProjection = handRayDirection.Direction;
@@ -113,65 +43,30 @@ namespace Leap.Unity
             float projectionDistance = Mathf.Max(0.0f, handShoulderDist - handMergeDistance);
             float projectionAmount = (projectionDistance + 0.15f) * projectionScale;
 
+            raycastResult = new RaycastHit();
+            bool hit = false;
             if (projectionDistance > 0f)
             {
-                bool hit = false;
                 Vector3 startPos = handRayDirection.AimPosition;
-                parabolaPositions.Add(handRayDirection.VisualAimPosition);
+                _parabolaPositions.Add(handRayDirection.VisualAimPosition);
                 Vector3 velocity = handProjection * projectionAmount;
-                Vector3 segmentEnd = Vector3.zero;
                 for (float i = 0; i < 8f; i += 0.1f)
                 {
                     Vector3 segmentStart = evaluateParabola(startPos, velocity, Physics.gravity * 0.25f, i);
-                    segmentEnd = evaluateParabola(startPos, velocity, Physics.gravity * 0.25f, i + 0.1f);
-                    parabolaPositions.Add(segmentEnd);
-                    RaycastHit hitInfo;
-                    if (Physics.Raycast(new Ray(segmentStart, segmentEnd - segmentStart), out hitInfo, Vector3.Distance(segmentStart, segmentEnd)))
+                    Vector3 segmentEnd = evaluateParabola(startPos, velocity, Physics.gravity * 0.25f, i + 0.1f);
+                    _parabolaPositions.Add(segmentEnd);
+                    if (Physics.Raycast(new Ray(segmentStart, segmentEnd - segmentStart), out raycastResult, Vector3.Distance(segmentStart, segmentEnd), _layerMask))
                     {
                         hit = true;
-                        segmentEnd = hitInfo.point;
+                        _parabolaPositions.Add(raycastResult.point);
                     }
 
                     if (hit) { break; }
                 }
-
-                if (hit)
-                {
-                    if (trailRenderer != null)
-                    {
-                        UpdateTrailRenderer(segmentEnd);
-                    }
-                }
-            }
-            UpdateLineRenderer();
-        }
-
-        Vector3 evaluateParabola(Vector3 position, Vector3 velocity, Vector3 acceleration, float time)
-        {
-            return position + (velocity * time) + (0.5f * acceleration * (time * time));
-        }
-
-        void UpdateLineRenderer()
-        {
-            if (lineRenderer == null)
-            {
-                return;
             }
 
-            lineRenderer.positionCount = parabolaPositions.Count;
-            lineRenderer.SetPositions(parabolaPositions.ToArray());
-        }
-
-        void UpdateTrailRenderer(Vector3 hitPoint)
-        {
-            if (trailRendererTransform == null)
-            {
-                return;
-            }
-
-            // Add a small vertical offset to the hit point in order to see the trail better
-            hitPoint.y += trailRendererYOffset;
-            trailRendererTransform.position = hitPoint;
+            UpdateLineRendererPositions(_parabolaPositions.Count, _parabolaPositions.ToArray(), hit);
+            return hit;
         }
     }
 }

--- a/Packages/Tracking Preview/Examples~/HandRays/Scripts/HandRayRenderer.cs
+++ b/Packages/Tracking Preview/Examples~/HandRays/Scripts/HandRayRenderer.cs
@@ -1,0 +1,162 @@
+using Leap.Unity;
+using Leap.Unity.Interaction;
+using Leap.Unity.Interaction.PhysicsHands;
+using Leap.Unity.Preview.HandRays;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+
+public abstract class HandRayRenderer : MonoBehaviour
+{
+    [SerializeField] private HandRay _handRay;
+
+    [Header("Rendering")]
+    [SerializeField] private LineRenderer _lineRenderer;
+
+    [Header("Trail")]
+    [SerializeField] private Transform _trailRendererTransform;
+    [SerializeField] private float _trailRendererYOffset = 0.04f;
+    private TrailRenderer _trailRenderer;
+
+    [Tooltip("Note that the Interaction Engine and Physics Hands layers will be ignored automatically.")]
+    [Header("Layer Logic")]
+    [SerializeField] private List<SingleLayer> _layersToIgnore = new List<SingleLayer>();
+
+    protected LayerMask _layerMask;
+
+    [Header("Events")]
+    public UnityEvent<RaycastHit> OnRayUpdate;
+
+    private void Start()
+    {
+        _layerMask = -1;
+        InteractionManager interactionManager = FindObjectOfType<InteractionManager>();
+        if (interactionManager != null)
+        {
+            _layerMask ^= interactionManager.contactBoneLayer.layerMask;
+        }
+
+        PhysicsProvider physicsProvider = FindObjectOfType<PhysicsProvider>();
+        if (physicsProvider != null)
+        {
+            _layerMask ^= physicsProvider.HandsLayer.layerMask;
+            _layerMask ^= physicsProvider.HandsResetLayer.layerMask;
+        }
+
+        foreach (var layers in _layersToIgnore)
+        {
+            _layerMask ^= layers.layerMask;
+        }
+
+        if (_lineRenderer == null)
+        {
+            _lineRenderer = GetComponentInChildren<LineRenderer>();
+            if (_lineRenderer == null)
+            {
+                Debug.LogWarning("HandRayParabolicLineRenderer needs a lineRenderer");
+            }
+        }
+
+        if (_trailRendererTransform != null)
+        {
+            _trailRenderer = _trailRendererTransform.GetComponentInChildren<TrailRenderer>();
+            if (_trailRenderer == null)
+            {
+                Debug.LogWarning("The trail renderer transform reference does not have a trailRenderer attached");
+            }
+        }
+        _lineRenderer.enabled = false;
+    }
+
+    private void OnEnable()
+    {
+        if (_handRay == null)
+        {
+            _handRay = FindObjectOfType<WristShoulderFarFieldHandRay>();
+            if (_handRay == null)
+            {
+                Debug.LogWarning("HandRayParabolicLineRenderer needs a HandRay");
+                return;
+            }
+        }
+        _handRay.OnHandRayFrame += UpdateLineRenderer;
+        _handRay.OnHandRayEnable += EnableLineRenderer;
+        _handRay.OnHandRayDisable += DisableLineRenderer;
+    }
+
+    private void OnDisable()
+    {
+        if (_handRay == null)
+        {
+            return;
+        }
+
+        _handRay.OnHandRayFrame -= UpdateLineRenderer;
+        _handRay.OnHandRayEnable -= EnableLineRenderer;
+        _handRay.OnHandRayDisable -= DisableLineRenderer;
+    }
+
+    void EnableLineRenderer(HandRayDirection farFieldDirection)
+    {
+        _lineRenderer.enabled = true;
+
+        if (_trailRendererTransform != null)
+        {
+            _trailRenderer.enabled = true;
+            _trailRenderer.Clear();
+        }
+    }
+
+    void DisableLineRenderer(HandRayDirection farFieldDirection)
+    {
+        _lineRenderer.enabled = false;
+        if (_trailRendererTransform != null)
+        {
+            _trailRenderer.enabled = false;
+        }
+    }
+
+    private void UpdateLineRenderer(HandRayDirection handRayDirection)
+    {
+        if (UpdateLineRendererLogic(handRayDirection, out RaycastHit result))
+        {
+            OnRayUpdate?.Invoke(result);
+        }
+    }
+
+    protected abstract bool UpdateLineRendererLogic(HandRayDirection handRayDirection, out RaycastHit raycastResult);
+
+    protected void UpdateLineRendererPositions(int positionCount, Vector3[] positions, bool updateTrail = true)
+    {
+        _lineRenderer.positionCount = positionCount;
+        if (positions.Length > 0)
+        {
+            _lineRenderer.SetPositions(positions);
+            if (updateTrail)
+            {
+                UpdateTrailRenderer(positions[positions.Length - 1]);
+            }
+        }
+    }
+
+    private void UpdateTrailRenderer(Vector3 position)
+    {
+        if(_trailRendererTransform == null)
+        {
+            return;
+        }
+
+        // Add a small vertical offset to the hit point in order to see the trail better
+        position.y += _trailRendererYOffset;
+        _trailRendererTransform.position = position;
+    }
+
+    private void OnValidate()
+    {
+        if (_lineRenderer == null)
+        {
+            _lineRenderer = GetComponentInChildren<LineRenderer>();
+        }
+    }
+}

--- a/Packages/Tracking Preview/Examples~/HandRays/Scripts/HandRayRenderer.cs
+++ b/Packages/Tracking Preview/Examples~/HandRays/Scripts/HandRayRenderer.cs
@@ -2,7 +2,6 @@ using Leap.Unity;
 using Leap.Unity.Interaction;
 using Leap.Unity.Interaction.PhysicsHands;
 using Leap.Unity.Preview.HandRays;
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;
@@ -119,6 +118,14 @@ public abstract class HandRayRenderer : MonoBehaviour
 
     private void UpdateLineRenderer(HandRayDirection handRayDirection)
     {
+        if (!_lineRenderer.enabled)
+        {
+            _lineRenderer.enabled = true;
+        }
+        if(_trailRendererTransform != null)
+        {
+            _trailRenderer.enabled = true;
+        }
         if (UpdateLineRendererLogic(handRayDirection, out RaycastHit result))
         {
             OnRayUpdate?.Invoke(result);

--- a/Packages/Tracking Preview/Examples~/HandRays/Scripts/HandRayRenderer.cs.meta
+++ b/Packages/Tracking Preview/Examples~/HandRays/Scripts/HandRayRenderer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ea114e3660b60bb46b27086c50237b2f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/Tracking Preview/Examples~/HandRays/Scripts/HandRayStraightLineRenderer.cs
+++ b/Packages/Tracking Preview/Examples~/HandRays/Scripts/HandRayStraightLineRenderer.cs
@@ -5,124 +5,30 @@
  * http://www.apache.org/licenses/LICENSE-2.0, or another agreement           *
  * between Ultraleap and you, your company or other organization.             *
  ******************************************************************************/
+using Leap.Unity.Interaction;
+using Leap.Unity.Interaction.PhysicsHands;
 using Leap.Unity.Preview.HandRays;
 using UnityEngine;
 
-public class HandRayStraightLineRenderer : MonoBehaviour
+public class HandRayStraightLineRenderer : HandRayRenderer
 {
     public float lineRendererDistance = 50f;
-    public HandRay handRay;
 
-    [SerializeField] private LineRenderer lineRenderer;
-    [SerializeField] private Transform trailRendererTransform;
-    [SerializeField] private float trailRendererYOffset = 0.04f;
-    private TrailRenderer trailRenderer;
-
-    // Start is called before the first frame update
-    void Start()
-    {
-        if (lineRenderer == null)
-        {
-            lineRenderer = GetComponentInChildren<LineRenderer>();
-            if (lineRenderer == null)
-            {
-                Debug.LogWarning($"HandRayStraightLineRenderer needs a lineRenderer");
-            }
-        }
-
-        if (trailRendererTransform != null)
-        {
-            trailRenderer = trailRendererTransform.GetComponentInChildren<TrailRenderer>();
-            if (trailRenderer == null)
-            {
-                Debug.LogWarning("The trail renderer transform reference does not have a trailRenderer attached");
-            }
-        }
-
-        lineRenderer.positionCount = 2;
-        lineRenderer.enabled = false;
-    }
-
-    private void OnEnable()
-    {
-        if (handRay == null)
-        {
-            handRay = FindObjectOfType<WristShoulderFarFieldHandRay>();
-            if (handRay == null)
-            {
-                Debug.LogWarning("HandRayStraightLineRenderer needs a HandRay");
-                return;
-            }
-        }
-        handRay.OnHandRayFrame += UpdateLineRenderer;
-        handRay.OnHandRayEnable += EnableLineRenderer;
-        handRay.OnHandRayDisable += DisableLineRenderer;
-    }
-
-    private void OnDisable()
-    {
-        if (handRay == null)
-        {
-            return;
-        }
-
-        handRay.OnHandRayFrame -= UpdateLineRenderer;
-        handRay.OnHandRayEnable -= EnableLineRenderer;
-        handRay.OnHandRayDisable -= DisableLineRenderer;
-    }
-
-    void EnableLineRenderer(HandRayDirection farFieldDirection)
-    {
-        lineRenderer.enabled = true;
-
-        if (trailRendererTransform != null)
-        {
-            trailRenderer.enabled = true;
-            trailRenderer.Clear();
-        }
-    }
-
-    void DisableLineRenderer(HandRayDirection farFieldDirection)
-    {
-        lineRenderer.enabled = false;
-        if (trailRendererTransform != null)
-        {
-            trailRenderer.enabled = false;
-        }
-    }
-
-    void UpdateLineRenderer(HandRayDirection handRayDirection)
+    protected override bool UpdateLineRendererLogic(HandRayDirection handRayDirection, out RaycastHit raycastResult)
     {
         Vector3 lineRendererEndPos;
-        RaycastHit hitInfo;
-        if (Physics.Raycast(new Ray(handRayDirection.RayOrigin, handRayDirection.Direction), out hitInfo, lineRendererDistance))
+        raycastResult = new RaycastHit();
+        bool hit = false;
+        if (Physics.Raycast(new Ray(handRayDirection.RayOrigin, handRayDirection.Direction), out raycastResult, lineRendererDistance, _layerMask))
         {
-            Vector3 hitPoint = hitInfo.point;
-
-            // Add a small vertical offset to the hit point in order to see the trail better
-            hitPoint.y += trailRendererYOffset;
-            lineRendererEndPos = hitPoint;
+            hit = true;
+            lineRendererEndPos = raycastResult.point;
         }
         else
         {
             lineRendererEndPos = handRayDirection.RayOrigin + handRayDirection.Direction * lineRendererDistance;
         }
-
-        UpdateLineRendererPositions(lineRenderer, handRayDirection.VisualAimPosition, lineRendererEndPos);
-        if (trailRendererTransform != null)
-        {
-            UpdateTrailRendererPosition(lineRendererEndPos);
-        }
-    }
-
-    private void UpdateLineRendererPositions(LineRenderer lineRenderer, Vector3 start, Vector3 end)
-    {
-        lineRenderer.SetPosition(0, start);
-        lineRenderer.SetPosition(1, end);
-    }
-
-    private void UpdateTrailRendererPosition(Vector3 position)
-    {
-        trailRendererTransform.position = position;
+        UpdateLineRendererPositions(2, new Vector3[]{ handRayDirection.VisualAimPosition, lineRendererEndPos});
+        return hit;
     }
 }

--- a/Packages/Tracking Preview/Examples~/HandRays/Scripts/HandRayStraightLineRenderer.cs
+++ b/Packages/Tracking Preview/Examples~/HandRays/Scripts/HandRayStraightLineRenderer.cs
@@ -5,8 +5,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0, or another agreement           *
  * between Ultraleap and you, your company or other organization.             *
  ******************************************************************************/
-using Leap.Unity.Interaction;
-using Leap.Unity.Interaction.PhysicsHands;
 using Leap.Unity.Preview.HandRays;
 using UnityEngine;
 


### PR DESCRIPTION
## Summary

The principle here is so that the hand rays can be interchanged within a scene, while also passing through the logic that they do in the visuals back to the code. Means you don't need to reimplement the logic of the rays to get the raycasthit information.

- Refactors the hand ray visuals to use the same class (means you can interchange them)
- Adds an event when their raycasts return true
- Makes the rays ignore IE and Physics Hands by default
- User can pick layers that they want the ray to ignore.

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [x] Pair review with a member of the QA team.
- [x] Add any release testing considerations to the MR for the next release.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] Checked and agree with release testing considerations added to MR for the next release.