### PR TITLE
add ifdef to avoid editor-only code from breaking builds

### DIFF
--- a/Packages/Tracking/Core/Runtime/Scripts/Attachments/AttachmentHand.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Attachments/AttachmentHand.cs
@@ -381,6 +381,7 @@ namespace Leap.Unity.Attachments
             var pointBehaviour = GetBehaviourForPoint(singlePoint);
             if (pointBehaviour != null)
             {
+#if UNITY_EDITOR
                 if (!Application.isPlaying)
                 {
                     if (PrefabUtility.IsPartOfPrefabInstance(pointBehaviour.gameObject))
@@ -393,6 +394,7 @@ namespace Leap.Unity.Attachments
                     DestroyImmediate(pointBehaviour.gameObject);
                 }
                 else
+#endif
                 {
                     Destroy(pointBehaviour.gameObject);
                 }


### PR DESCRIPTION
## Summary

Ensure editor code added in a previous merge is marked under a #if EDITOR to avoid build errors

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [ ] Pair review with a member of the QA team.
- [ ] Add any release testing considerations to the MR for the next release.
- [x] Check any relevant CHANGELOG files have been updated.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.
- [x] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [ ] Checked and agree with release testing considerations added to MR for the next release.

## Closes JIRA Issue

Closes UNITY-852