### PR TITLE
Rework dependencies-libtrack into an advisory check

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -173,7 +173,7 @@ check-plugins:
     ## Validate our versions
     - $NewLeapVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo("$WINDOWS_ARTIFACTS_PATH/LeapC.dll").FileVersion
     - $CurrentLeapVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo("$PACKAGE_PATH_Tracking/Core/Runtime/Plugins/x86_64/LeapC.dll").FileVersion
-    - if (-not ($NewLeapVersion -eq $CurrentLeapVersion)) { echo "Plugin version in UnityPlugin: $CurrentLeapVersion"; echo "Plugin version on Libtrack stable: $NewLeapVersion"; exit 1; }
+    - if (-not ($NewLeapVersion -eq $CurrentLeapVersion)) { echo "Plugin version in UnityPlugin - $CurrentLeapVersion"; echo "Plugin version on Libtrack stable - $NewLeapVersion"; exit 1; }
 
   artifacts:
     name: "$ARTIFACTS_NAME-libtrack-dependencies"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -218,10 +218,6 @@ export-unitypackages:
   extends: .base
   stage: build
 
-  needs:
-   - job: dependencies-libtrack
-     artifacts: true
-
   variables:
     # Path to UnityPlugin within a unity project
     # Changing this will change the root where all generated .unitypackages import to in a project
@@ -246,19 +242,7 @@ export-unitypackages:
     EXAMPLES_SUBPATH_Tracking_OpenXR:          "Examples~"
     UNITYPACKAGE_OUTPUT_PATH_Tracking_OpenXR:  "$UNITYPACKAGES_OUTPUT_PATH/Tracking OpenXR.unitypackage"
 
-    LEAPC_SOURCE_PATH: "$ARTIFACTS_PATH/Windows/LeapC.dll"
-    LEAPC_DESTINATION_PATH: "$PLUGIN_LIBS_PATH/x86_64/LeapC.dll"
-
   script:
-    # We only replace libtrack dependencies if there is an upstream branch ref or we are explicitly using the latest stable artifacts.
-    # Upstream branch ref takes precedence, see the libtrack dependencies job.
-    - $REPLACE_LIBTRACK_DEPENDENCIES = "$UPSTREAM_UPSTREAM_BRANCH_REF" -or "$USE_LIBTRACK_STABLE"
-
-    #  Copy libs from libtrack dependencies, overwritting anything already there
-    #- if ($REPLACE_LIBTRACK_DEPENDENCIES) { Copy-Item "$ARTIFACTS_PATH/Android/libLeapC.so" -Destination "$PLUGIN_LIBS_PATH/Android/libLeapC.so" -Force
-    #- if ($REPLACE_LIBTRACK_DEPENDENCIES) { Copy-Item "$ARTIFACTS_PATH/Android/UltraleapTrackingServiceBinder.aar" -Destination "$PLUGIN_LIBS_PATH/Android/libs/UltraleapTrackingServiceBinder.aar" -Force }
-    - if ($REPLACE_LIBTRACK_DEPENDENCIES) { Copy-Item "$LEAPC_SOURCE_PATH" -Destination "$LEAPC_DESTINATION_PATH" -Force }
-
     - New-Item -Path "$UNITYPACKAGES_OUTPUT_PATH" -ItemType Directory -Force
 
     # Import functions required below by calling script to define global functions

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -173,7 +173,7 @@ check-plugins:
     ## Validate our versions
     - $NewLeapVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo("$WINDOWS_ARTIFACTS_PATH/LeapC.dll").FileVersion
     - $CurrentLeapVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo("$PACKAGE_PATH_Tracking/Core/Runtime/Plugins/x86_64/LeapC.dll").FileVersion
-    - if (-not ($NewLeapVersion -eq $CurrentLeapVersion)) exit 1;
+    - if (-not ($NewLeapVersion -eq $CurrentLeapVersion)) { echo "Plugin version in UnityPlugin: $CurrentLeapVersion"; echo "Plugin version on Libtrack stable: $NewLeapVersion"; exit 1; }
 
   artifacts:
     name: "$ARTIFACTS_NAME-libtrack-dependencies"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -293,7 +293,7 @@ consolidate:
     - job: check-formatting
       artifacts: true
       optional: true
-    - job: check-libtrack
+    - job: check-plugins
       artifacts: true
       optional: true
     - job: generate-api-docs

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,6 @@ workflow:
       when: never
     - when: always
 
-
 variables:
   UNITY_HUB: "C:/Program Files/Unity Hub/Unity Hub.exe"
   
@@ -49,8 +48,10 @@ stages:
 # Formatting
 # -----------------------------------------------------------------------------
 #
-# This job checks formatting of source code against the rules defined in .editorconfig.
-# The job will not make changes on it's own - failure will produce a diff artifact which can be applied in a later commit.
+# This job checks:
+#   - Formatting of source code against the rules defined in .editorconfig
+#   - Copyright headers to ensure they match the correct date
+# If any checks fail, a diff artifact will be produced, which can be manually applied.
 #
 check-formatting:
   extends: .base
@@ -58,11 +59,9 @@ check-formatting:
   allow_failure: true
   needs: []
   variables:
-
     DOTNET_FORMAT_RESULTS: "$ARTIFACTS_PATH/dotnet_format_results.diff"
     
   script:
-
     # Run dotnet format from location where .editorconfig is defined
     - dotnet-format -f --exclude ".git $CI_PATH Markdown"
     
@@ -88,17 +87,16 @@ check-formatting:
     name: "$ARTIFACTS_NAME-format-diff"
     paths:
       - "$ARTIFACTS_PATH/"
-
     when: on_failure
 
 # -----------------------------------------------------------------------------
 # Unity Builds
 # -----------------------------------------------------------------------------
 #
-# This job will trigger various apps to build using the plugin commit that started this pipeline.
+# This job will trigger various test apps to build using the plugin commit that started this pipeline.
 # A failure in a build likely represents a breaking plugin change and should be addressed, but will not fail the whole pipeline.
 #
-unity-builds:
+check-unity-builds:
   stage: test
   allow_failure: true
   needs: []
@@ -112,46 +110,16 @@ unity-builds:
     PLUGIN_COMMIT_HASH: $CI_COMMIT_SHA
 
 # -----------------------------------------------------------------------------
-# Generate API Documentation
+# Libtrack Version Check
 # -----------------------------------------------------------------------------
 #
-# This job runs doxygen to generate xml artifacts required by the [documentation repository](https://gitlab.ultrahaptics.com/marcom/ultraleap-api-docs).
-# Html artifacts are also generated for quick visualization purposes.
+# This job validates that libtrack artifacts in the UnityPlugin match current stable.
+# If a version mismatch is detected, this job will fail - however it will not fail the pipeline.
 #
-generate-api-docs:
+check-plugins:
   extends: .base
-  stage: build
-  needs: []
-  variables:
-
-    XML_ARTIFACTS_PATH: "$ARTIFACTS_PATH/unity_xml"
-    HTML_ARTIFACTS_PATH: "$ARTIFACTS_PATH/unity_html"
-
-  script:
-
-    - doxygen
-    - Move-Item -Path docs/xml -Destination $XML_ARTIFACTS_PATH
-    - Move-Item -Path docs/html -Destination $HTML_ARTIFACTS_PATH
-
-  artifacts:
-    name: "$ARTIFACTS_NAME-api-docs"
-    paths:
-      - "$ARTIFACTS_PATH/"
-
-    when: always
-    expire_in: never
-
-# -----------------------------------------------------------------------------
-# Libtrack Dependency
-# -----------------------------------------------------------------------------
-#
-# This job retrieves artifacts from the libtrack repository and selects files required for the UnityPlugin.
-# Not based on the .unity-template as it only needs run once for any amount of unity projects.
-# Output is artifacts which can be consumed by later jobs in specific unity projects.
-#
-dependencies-libtrack:
-  extends: .base
-  stage: build
+  allow_failure: true
+  stage: test
   needs: []
 
   variables:
@@ -201,165 +169,44 @@ dependencies-libtrack:
     
     - Expand-Archive -Path "temp.zip" -DestinationPath "temp/"
     - Copy-Item "temp/VisualizerDependencies/LeapC.dll" -Destination "$WINDOWS_ARTIFACTS_PATH/LeapC.dll" -Force
+    
+    ## Validate our versions
+    - $NewLeapVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo("$WINDOWS_ARTIFACTS_PATH/LeapC.dll").FileVersion
+    - $CurrentLeapVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo("$PACKAGE_PATH_Tracking/Core/Runtime/Plugins/x86_64/LeapC.dll").FileVersion
+    - if (-not ($NewLeapVersion -eq $CurrentLeapVersion)) exit 1;
 
   artifacts:
     name: "$ARTIFACTS_NAME-libtrack-dependencies"
     paths:
       - "$ARTIFACTS_PATH/"
-
-    when: on_success
-
-
+    when: on_failure
 
 # -----------------------------------------------------------------------------
-# Unity Project Job Templates & Usages
+# Generate API Documentation
 # -----------------------------------------------------------------------------
 #
-# This template is intended to be used for jobs that require a unity project.
+# This job runs doxygen to generate xml artifacts required by the [documentation repository](https://gitlab.ultrahaptics.com/marcom/ultraleap-api-docs).
+# Html artifacts are also generated for quick visualization purposes.
 #
-# Usage:
-#   Create a derived template extending this template to implement job behaviour
-#   Create a job extending the derived template and set the "UNITY_PROJECT_FOLDER" variable to a Unity project folder within CI_UNITY_PROJECTS_PATH
-#   
-#
-.unity-template:
+generate-api-docs:
   extends: .base
-
+  stage: build
+  needs: []
   variables:
+    XML_ARTIFACTS_PATH: "$ARTIFACTS_PATH/unity_xml"
+    HTML_ARTIFACTS_PATH: "$ARTIFACTS_PATH/unity_html"
 
-    UNITY_PROJECT_FOLDER: "" # This must be set by derived jobs to one of the folders within CI_UNITY_PROJECTS_PATH
+  script:
+    - doxygen
+    - Move-Item -Path docs/xml -Destination $XML_ARTIFACTS_PATH
+    - Move-Item -Path docs/html -Destination $HTML_ARTIFACTS_PATH
 
-    # Relative path from project directory to artifacts folder for this unity project
-    ARTIFACTS_PATH_UNITY_PROJECT: "$ARTIFACTS_PATH/$UNITY_PROJECT_FOLDER"
-    
-    # Relative path from project directory to the project this job matches
-    UNITY_PROJECT_PATH: "$CI_UNITY_PROJECTS_PATH/$UNITY_PROJECT_FOLDER"
-
-  cache:
-    key: "$CACHE_LIBRARY_KEY"
+  artifacts:
+    name: "$ARTIFACTS_NAME-api-docs"
     paths:
-      - $UNITY_PROJECT_PATH/Library/
+      - "$ARTIFACTS_PATH/"
     when: always
-
-  before_script:
-
-    # Check UNITY_PROJECT_PATH is set to an existing project and yell otherwise
-    - if (-not ($UNITY_PROJECT_FOLDER)) { echo "UNITY_PROJECT_FOLDER variable has not been set for this job"; exit 1; }
-    - if (-not (Test-Path "$UNITY_PROJECT_PATH")) { echo "Specified Unity project folder '$UNITY_PROJECT_PATH' not found"; exit 1; }
-    - echo "Using Unity project at '$UNITY_PROJECT_PATH'"
-
-    # Ensure job artifacts folder exists
-    - echo "Creating Unity project artifacts path at '$ARTIFACTS_PATH_UNITY_PROJECT'"
-    - New-Item -Path "$ARTIFACTS_PATH_UNITY_PROJECT" -ItemType Directory -Force
-
-    # Get Unity version and changeset from the project.
-    - $line = Get-Content $UNITY_PROJECT_PATH/ProjectSettings/ProjectVersion.txt | Select -Index 1
-    - $UNITY_VERSION = $line -Split " " | Select -Index 1
-    - $UNITY_CHANGESET = $line -Match '\((.+)\)' | ForEach-Object { $Matches[1] }
-    - echo "UNITY_VERSION - $UNITY_VERSION"
-    - echo "UNITY_CHANGESET - $UNITY_CHANGESET"
-
-    # Set up some variables commonly used by derived scripts
-    - $UNITY_PATH = "C:/Unity/$UNITY_VERSION/Editor/Unity.exe"
-    - $UNITY_LOG_FILE = "$CI_PROJECT_DIR/$ARTIFACTS_PATH_UNITY_PROJECT/${CI_JOB_NAME}_unity.log"
-    - echo "UNITY_PATH - $UNITY_PATH"
-    - echo "UNITY_LOG_FILE - $UNITY_LOG_FILE"
-
-    # Check whether the required Unity version is installed. If not, install it.
-    - $editors = "unity_hub_stdout.txt"
-    - Start-Process -Wait -RedirectStandardOutput "$editors" -FilePath "$UNITY_HUB" -ArgumentList "-- --headless editors --installed"
-    - Get-Content "$editors"
-    - Start-Process -Wait -RedirectStandardOutput "$editors" -FilePath "$UNITY_HUB" -ArgumentList "-- --headless install-path --set C:/Unity"
-    - Get-Content "$editors"
-    - if (-not (Test-Path "C:/Unity/$UNITY_VERSION")) { Start-Process -Wait -RedirectStandardOutput "$editors" -FilePath "$UNITY_HUB" -ArgumentList "-- --headless install --version $UNITY_VERSION --changeset $UNITY_CHANGESET" }
-    - Get-Content "$editors"
-
-# -----------------------------------------------------------------------------
-# Tests Template
-# -----------------------------------------------------------------------------
-# This job is responsible for running all automated tests defined within the project using the Unity test runner framework (based on NUnit).
-#
-# .run-tests:
-
-#   extends: .unity-template
-#   stage: test
-#   allow_failure: true
-#   needs: []
-#   variables:
-
-#     UNITY_TEST_RESULTS_NUNIT: "$CI_PROJECT_DIR/$ARTIFACTS_PATH_UNITY_PROJECT/unity_test_results_nunit.xml"
-#     UNITY_TEST_RESULTS_JUNIT: "$CI_PROJECT_DIR/$ARTIFACTS_PATH_UNITY_PROJECT/unity_test_results_junit.xml"
-#     CONVERTER_XSLT_PATH: "$CI_PROJECT_DIR/$CI_PATH/nunit-to-junit/nunit3-junit.xslt"
-
-#   script:
-
-#     # Run tests
-#     - echo "Running tests - log file outputting to '$UNITY_LOG_FILE'"
-#     - echo "Running tests - test report outputting to '$UNITY_TEST_RESULTS_NUNIT'"
-#     - $process = Start-Process -Wait -PassThru -FilePath "$UNITY_PATH" -ArgumentList "-runTests -batchmode -logFile `"$UNITY_LOG_FILE`" -projectPath `"$UNITY_PROJECT_PATH`" -testResults `"$UNITY_TEST_RESULTS_NUNIT`" -testPlatform EditMode"
-#     - echo $process.ExitCode
-#     - if (-not ($process.ExitCode -eq 0)) { exit $process.ExitCode }
-#     - if ( -not (Test-Path "$UNITY_TEST_RESULTS_NUNIT")) { echo "Error generating test report"; exit 1; }
-
-#     - $xslt = New-Object System.Xml.Xsl.XslCompiledTransform;
-#     - $xslt.Load("$CONVERTER_XSLT_PATH");
-#     - $xslt.Transform("$UNITY_TEST_RESULTS_NUNIT", "$UNITY_TEST_RESULTS_JUNIT");
-
-#   artifacts:
-#     name: "$ARTIFACTS_NAME-test-results"
-#     paths:
-#       - "$ARTIFACTS_PATH/"
-#     reports:
-#       junit: "$UNITY_TEST_RESULTS_JUNIT"
-
-#     when: always
-    
-# -----------------------------------------------------------------------------
-# License Headers Template
-# -----------------------------------------------------------------------------
-#
-# This job checks for the presence of license headers conforming to the format defined in AutoCopywriteHeader.cs
-# The job will not make changes on it's own - failure will produce a diff artifact which can be applied in a later commit.
-#
-# TODO: Update this job
-#
-# .license-headers:
-#   extends: .unity-template
-
-#   stage: test
-#   allow_failure: true
-#   needs: []
-#   rules:
-#     - if: '$CI_PIPELINE_SOURCE == "merge_request_event" || $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "develop"'
-#       when: always
-#       allow_failure: false
-
-#     - if: $CI_PIPELINE_SOURCE == "pipeline" || $CI_COMMIT_BRANCH
-#       when: manual
-#       allow_failure: true
-
-#   script:
-
-#     # Build the project, output requires absolute path
-#     - $process = Start-Process -Wait -PassThru -FilePath "$UNITY_PATH" -ArgumentList "-batchmode -quit -logFile $UNITY_LOG_FILE -projectPath `"$UNITY_PROJECT_PATH`" -executeMethod `"AutoCopywriteHeader.PopulateAutoHeaders`""
-#     - if ($UNITY_LOG_FILE) { echo "Moving $UNITY_LOG_FILE to $CI_PROJECT_DIR/$ARTIFACTS_PATH_UNITY_PROJECT/${OUTPUT_NAME}_headers.log..."; Move-Item $UNITY_LOG_FILE $CI_PROJECT_DIR/$ARTIFACTS_PATH_UNITY_PROJECT/${OUTPUT_NAME}_headers.log }
-
-#     - Push-Location $UNITYPLUGIN_ASSETS_PATH
-#     - git status
-
-#     - $CHANGES = git diff --cached --numstat | Measure-Object -Line
-#     - if(-not ($CHANGES.lines -eq 0)) { echo "$CHANGES files without valid headers, please update all headers and retry"; cmd /c "git diff > $CI_PROJECT_DIR/$ARTIFACTS_PATH_UNITY_PROJECT/${OUTPUT_NAME}_headers.diff"; exit 1 }
-
-#     - Pop-Location
-
-#   artifacts:
-#     name: "$ARTIFACTS_NAME-header-results"
-#     paths:
-#       - "$UNITY_LOG_FILE" 
-#       - "$ARTIFACTS_PATH_UNITY_PROJECT/${OUTPUT_NAME}_headers.log"
-#       - "$ARTIFACTS_PATH_UNITY_PROJECT/${OUTPUT_NAME}_headers.diff"
-
-#     when: on_failure
+    expire_in: never
 
 # -----------------------------------------------------------------------------
 # Exports all .unitypackages
@@ -376,7 +223,6 @@ export-unitypackages:
      artifacts: true
 
   variables:
-  
     # Path to UnityPlugin within a unity project
     # Changing this will change the root where all generated .unitypackages import to in a project
     UNITYPLUGIN_ASSETS_PATH: "Assets/ThirdParty/Ultraleap"
@@ -404,7 +250,6 @@ export-unitypackages:
     LEAPC_DESTINATION_PATH: "$PLUGIN_LIBS_PATH/x86_64/LeapC.dll"
 
   script:
-
     # We only replace libtrack dependencies if there is an upstream branch ref or we are explicitly using the latest stable artifacts.
     # Upstream branch ref takes precedence, see the libtrack dependencies job.
     - $REPLACE_LIBTRACK_DEPENDENCIES = "$UPSTREAM_UPSTREAM_BRANCH_REF" -or "$USE_LIBTRACK_STABLE"
@@ -448,25 +293,7 @@ export-unitypackages:
     name: "$ARTIFACTS_NAME-unitypackage"
     paths:
       - "$ARTIFACTS_PATH/"
-
     when: always
-
-# -----------------------------------------------------------------------------
-# 2019.4 Project Jobs
-# -----------------------------------------------------------------------------
-#
-# These are the jobs generated using all the templates above for the 2019.4 unity project.
-#
-.unity-project-2019.4:
-  variables:
-    UNITY_PROJECT_FOLDER: "2019.4"
-
-# It's important to extend from the specific job templates first! Otherwise the empty UNITY_PROJECT_FOLDER variable in .unity-template will overwrite the one from here.
-# run-tests-2019.4:
-#   extends: ['.run-tests', '.unity-project-2019.4']
-#license-headers-2019.4:
-#  extends: ['.license-headers', '.unity-project-2019.4']
-
 
 # -----------------------------------------------------------------------------
 # Consolidate artifacts
@@ -482,17 +309,12 @@ consolidate:
     - job: check-formatting
       artifacts: true
       optional: true
+    - job: check-libtrack
+      artifacts: true
+      optional: true
     - job: generate-api-docs
       artifacts: true
       optional: true
-    - job: dependencies-libtrack
-      artifacts: true
-    # - job: run-tests-2019.4
-    #   artifacts: true
-    #   optional: true
-    # - job: license-headers-2019.4
-    #   artifacts: true
-    #   optional: true
     - job: export-unitypackages
       artifacts: true
 
@@ -503,6 +325,5 @@ consolidate:
     name: "$ARTIFACTS_NAME-consolidated"
     paths:
       - "$ARTIFACTS_PATH/"
-
     when: always
     expire_in: 2 weeks

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -131,8 +131,8 @@ check-plugins:
     LIBTRACK_ANDROID_JOB: "AndroidRelProdLTS"
     LIBTRACK_WINDOWS_JOB: "WinRelDebProdLTS"
 
-    ANDROID_ARTIFACTS_PATH: "$ARTIFACTS_PATH/Android"
-    WINDOWS_ARTIFACTS_PATH: "$ARTIFACTS_PATH/Windows"
+    ANDROID_ARTIFACTS_PATH: "$ARTIFACTS_PATH/Android/libs"
+    WINDOWS_ARTIFACTS_PATH: "$ARTIFACTS_PATH/x86_64"
     VERSION_SUFFIX_PATH: "$ARTIFACTS_PATH/libtrack_version_suffix.txt"
     
   script:
@@ -145,7 +145,7 @@ check-plugins:
     - Invoke-RestMethod -Headers @{"PRIVATE-TOKEN"="$LIBTRACK_ACCESS_TOKEN"} -Uri "$LIBTRACK_URL/VERSION_SUFFIX.txt?job=$LIBTRACK_ANDROID_JOB" -OutFile "$VERSION_SUFFIX_PATH"
     - if ( -not (Test-Path "$VERSION_SUFFIX_PATH")) { echo "Error downloading version info"; exit 1; }
     - $VERSION_SUFFIX = Get-Content -Path "$VERSION_SUFFIX_PATH"
-    - echo $VERSION_SUFFIX
+    - Remove-Item "$VERSION_SUFFIX_PATH"
     
     ## Download libLeapC ZIP
     - if (-not (Test-Path -Path "LeapC/")) { echo "creating... LeapC"; New-Item "LeapC/" -Type Directory }

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -171,7 +171,7 @@ check-plugins:
     - Copy-Item "temp/VisualizerDependencies/LeapC.dll" -Destination "$WINDOWS_ARTIFACTS_PATH/LeapC.dll" -Force
     
     ## Validate our versions
-    - $NewLeapVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo("$WINDOWS_ARTIFACTS_PATH/LeapC.dll").FileVersion
+    - $NewLeapVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo("$CI_PROJECT_DIR/$WINDOWS_ARTIFACTS_PATH/LeapC.dll").FileVersion
     - $CurrentLeapVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo("$PACKAGE_PATH_Tracking/Core/Runtime/Plugins/x86_64/LeapC.dll").FileVersion
     - if (-not ($NewLeapVersion -eq $CurrentLeapVersion)) { echo "Plugin version in UnityPlugin - $CurrentLeapVersion"; echo "Plugin version on Libtrack stable - $NewLeapVersion"; exit 1; }
 


### PR DESCRIPTION
This reworks the legacy `dependencies-libtrack` job to be a useful `check-plugins` job in the test stage.

This new advisory job will fail if the version of libtrack in the UnityPlugin repo does not match the version of libtrack on its stable branch.

The job completes with artifacts which contain the libs for Android and Windows from stable, formatted for the Core plugins folder directory structure.