### PR TITLE
Add static AndroidServiceBinder that manages itself on application quit

### DIFF
--- a/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
@@ -536,71 +536,18 @@ namespace Leap.Unity
         #region Android Support
 
 #if UNITY_ANDROID
-        private AndroidJavaObject _serviceBinder;
-        AndroidJavaClass unityPlayer;
-        AndroidJavaObject activity;
-        AndroidJavaObject context;
-        ServiceCallbacks serviceCallbacks;
 
         protected virtual void OnEnable()
         {
-            EnsureAndroidBinding();
+            AndroidServiceBinder.Bind();
         }
 
         [Obsolete("Intended to be internal function, will be removed in next breaking version")]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool CreateAndroidBinding() => EnsureAndroidBinding();
-
-        private bool EnsureAndroidBinding()
-        {
-            bool success;
-            try
-            {
-                bool isServiceBound = _serviceBinder?.Call<bool>("isBound") ?? false;
-                if (isServiceBound) return true; // Already bound
-
-                _serviceBinder = null;
-
-                //Get activity and context
-                if (unityPlayer == null)
-                {
-                    Debug.Log("CreateAndroidBinding - Getting activity and context");
-                    unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer");
-                    activity = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity");
-                    context = activity.Call<AndroidJavaObject>("getApplicationContext");
-                    serviceCallbacks = new ServiceCallbacks();
-                }
-
-                //Create a new service binding
-                Debug.Log("CreateAndroidBinding - Creating a new service binder");
-                _serviceBinder = new AndroidJavaObject("com.ultraleap.tracking.service_binder.ServiceBinder", context, serviceCallbacks);
-                success = _serviceBinder.Call<bool>("bind");
-                if (success)
-                {
-                    Debug.Log("CreateAndroidBinding - Binding of service binder complete");
-                }
-                else
-                {
-                    Debug.LogWarning("CreateAndroidBinding - service binder bind call failed");
-                }
-            }
-            catch (Exception e)
-            {
-                Debug.LogWarning("CreateAndroidBinding - Failed to bind service: " + e.Message);
-                _serviceBinder = null;
-                success = false;
-            }
-
-            return success;
-        }
+        public bool CreateAndroidBinding() => AndroidServiceBinder.Bind();
 
         protected virtual void OnDisable()
         {
-            if (_serviceBinder != null)
-            {
-                Debug.Log("ServiceBinder.unbind...");
-                _serviceBinder.Call("unbind");
-            }
         }
 
 #else
@@ -954,7 +901,7 @@ namespace Leap.Unity
         protected void createController()
         {
 #if SVR
-            var bindStatus = EnsureAndroidBinding();
+            var bindStatus =  AndroidServiceBinder.Bind();
             if (!bindStatus)
                 return;
 

--- a/Packages/Tracking/Core/Runtime/Scripts/Utils/AndroidServiceBinder.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Utils/AndroidServiceBinder.cs
@@ -1,0 +1,94 @@
+namespace Leap.Unity
+{
+    using System;
+    using UnityEngine;
+
+    public static class AndroidServiceBinder
+    {
+#if UNITY_ANDROID
+
+        private static bool isBound = false;
+        public static bool IsBound
+        { 
+            get { return isBound; }
+            private set { isBound = value; }
+        }
+        static AndroidJavaObject _serviceBinder;
+        static AndroidJavaClass unityPlayer;
+        static AndroidJavaObject activity;
+        static AndroidJavaObject context;
+        static ServiceCallbacks serviceCallbacks;
+
+        public static bool Bind()
+        {
+            bool isBound = _serviceBinder?.Call<bool>("isBound") ?? false;
+
+            if (!isBound)
+            {
+                isBound = TryBind();
+
+                Application.quitting -= OnApplicationQuitting;
+                Application.quitting += OnApplicationQuitting;
+            }
+
+            return isBound;
+        }
+
+        private static void OnApplicationQuitting()
+        {
+            Application.quitting -= OnApplicationQuitting;
+            Unbind();
+        }
+
+        private static bool TryBind()
+        {
+            bool success;
+            try
+            {
+                _serviceBinder = null;
+
+                //Get activity and context
+                if (unityPlayer == null)
+                {
+                    Debug.Log("CreateAndroidBinding - Getting activity and context");
+                    unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer");
+                    activity = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity");
+                    context = activity.Call<AndroidJavaObject>("getApplicationContext");
+                    serviceCallbacks = new ServiceCallbacks();
+                }
+
+                //Create a new service binding
+                Debug.Log("CreateAndroidBinding - Creating a new service binder");
+                _serviceBinder = new AndroidJavaObject("com.ultraleap.tracking.service_binder.ServiceBinder", context, serviceCallbacks);
+                success = _serviceBinder.Call<bool>("bind");
+                if (success)
+                {
+                    Debug.Log("CreateAndroidBinding - Binding of service binder complete");
+                }
+                else
+                {
+                    Debug.LogWarning("CreateAndroidBinding - service binder bind call failed");
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning("CreateAndroidBinding - Failed to bind service: " + e.Message);
+                _serviceBinder = null;
+                success = false;
+            }
+
+            return success;
+        }
+
+        private static void Unbind()
+        {
+            if (_serviceBinder != null)
+            {
+                Debug.Log("ServiceBinder.unbind...");
+                _serviceBinder.Call("unbind");
+                isBound = false;
+            }
+        }
+#endif
+    }
+}

--- a/Packages/Tracking/Core/Runtime/Scripts/Utils/AndroidServiceBinder.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Utils/AndroidServiceBinder.cs
@@ -1,3 +1,4 @@
+#if UNITY_ANDROID
 namespace Leap.Unity
 {
     using System;
@@ -5,14 +6,8 @@ namespace Leap.Unity
 
     public static class AndroidServiceBinder
     {
-#if UNITY_ANDROID
+        public static bool IsBound{ get; private set; }
 
-        private static bool isBound = false;
-        public static bool IsBound
-        { 
-            get { return isBound; }
-            private set { isBound = value; }
-        }
         static AndroidJavaObject _serviceBinder;
         static AndroidJavaClass unityPlayer;
         static AndroidJavaObject activity;
@@ -27,8 +22,11 @@ namespace Leap.Unity
             {
                 isBound = TryBind();
 
-                Application.quitting -= OnApplicationQuitting;
-                Application.quitting += OnApplicationQuitting;
+                if (isBound)
+                {
+                    Application.quitting -= OnApplicationQuitting;
+                    Application.quitting += OnApplicationQuitting;
+                }
             }
 
             return isBound;
@@ -84,11 +82,11 @@ namespace Leap.Unity
         {
             if (_serviceBinder != null)
             {
-                Debug.Log("ServiceBinder.unbind...");
+                Debug.Log("UnbindAndroidBinding - Unbinding of service binder complete");
                 _serviceBinder.Call("unbind");
-                isBound = false;
+                IsBound = false;
             }
         }
-#endif
     }
 }
+#endif

--- a/Packages/Tracking/Core/Runtime/Scripts/Utils/AndroidServiceBinder.cs.meta
+++ b/Packages/Tracking/Core/Runtime/Scripts/Utils/AndroidServiceBinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a6be8b02c80869b40b06b19cb0e4f140
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

Converts the android bind system to be static and only run when required and only quits when application quits. Avoids breaking changes.

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [ ] Pair review with a member of the QA team.
- [ ] Add any release testing considerations to the MR for the next release.
- [ ] Check any relevant CHANGELOG files have been updated.
- [ ] Ensure documentation requirements are met e.g., public API is commented.
- [ ] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [ ] Add any relevant labels such as `breaking` to this MR.
- [ ] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [ ] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [ ] Checked and agree with release testing considerations added to MR for the next release.

## Closes JIRA Issue

Closes UNITY-864