### PR TITLE
Populate DeviceID, Timestamp and FPS for OpenXR frames

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -8,14 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [NEXT] - unreleased
 
-### Added
-- 
-
-### Changed
-- 
-
 ### Fixed
-- 
+- Fixed `DeviceID`, `Timestamp` and `CurrentFramesPerSecond` for `Frames` from the OpenXR Provider
 
 ### Known issues 
 - Offset between skeleton hand wrist and forearm in sample scenes

--- a/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
+++ b/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
@@ -87,6 +87,9 @@ namespace Ultraleap.Tracking.OpenXR
         {
             leapFrame.Hands.Clear();
             leapFrame.Id = _frameId++;
+            leapFrame.DeviceID = 0;
+            leapFrame.Timestamp = (long)(Time.realtimeSinceStartup * 1000000f);
+            leapFrame.CurrentFramesPerSecond = 1.0f / Time.smoothDeltaTime;
 
             if (PopulateLeapHandFromOpenXRJoints(HandTracker.Left, ref _leftHand))
             {


### PR DESCRIPTION
## Summary

This adds explicit `DeviceID`, `Timestamp` and `FramesPerSecond` for `Frames` from the OpenXR provider.

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [x] Pair review with a member of the QA team.
- [x] Add any release testing considerations to the MR for the next release.
- [x] Check any relevant CHANGELOG files have been updated.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.
- [x] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [x] Checked and agree with release testing considerations added to MR for the next release.
- [x] Check that `Timestamp` is usable as it would be expected in existing code.
- [x] Check that `DeviceID` being `0` doesn't cause issues anywhere.
- [x] Check that `CurrentFramesPerSecond` is sensible for all above usage.

## Closes JIRA Issue

Closes UNITY-903