### PR TITLE
Added ability to set the main camera and leap provider on the UI Inpu…

### DIFF
--- a/Packages/Tracking Preview/UI Input/Runtime/Scripts/UIInputModule.cs
+++ b/Packages/Tracking Preview/UI Input/Runtime/Scripts/UIInputModule.cs
@@ -10,7 +10,6 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.EventSystems;
-using UnityEngine.XR;
 
 namespace Leap.Unity.InputModule
 {

--- a/Packages/Tracking Preview/UI Input/Runtime/Scripts/UIInputModule.cs
+++ b/Packages/Tracking Preview/UI Input/Runtime/Scripts/UIInputModule.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using UnityEngine.XR;
 
 namespace Leap.Unity.InputModule
 {
@@ -42,15 +43,29 @@ namespace Leap.Unity.InputModule
         [Tooltip("The main camera used for calculating interactions.")]
         [SerializeField]
         private Camera mainCamera;
-        public Camera MainCamera => mainCamera;
-        public void SetMainCamera(Camera c) { mainCamera = c; }
+
+        /// <summary>
+        /// The main camera reference
+        /// </summary>
+        public Camera MainCamera
+        {
+            get => mainCamera;
+            set => mainCamera = value;
+        }
 
         //The LeapProvider providing tracking data to the scene.
         [Tooltip("The current Leap Data Provider for the scene.")]
         [SerializeField]
         private LeapProvider leapDataProvider;
-        public LeapProvider LeapDataProvider => leapDataProvider;
-        public void SetLeapProvider(LeapProvider provider) { leapDataProvider = provider; }
+        
+        /// <summary>
+        /// A reference to the source of hand tracking data to use, the 'leap provider'
+        /// </summary>
+        public LeapProvider LeapDataProvider
+        {
+            get => leapDataProvider;
+            set => leapDataProvider = value;
+        }
 
         //Calibration Setup
 

--- a/Packages/Tracking Preview/UI Input/Runtime/Scripts/UIInputModule.cs
+++ b/Packages/Tracking Preview/UI Input/Runtime/Scripts/UIInputModule.cs
@@ -43,12 +43,14 @@ namespace Leap.Unity.InputModule
         [SerializeField]
         private Camera mainCamera;
         public Camera MainCamera => mainCamera;
+        public void SetMainCamera(Camera c) { mainCamera = c; }
 
         //The LeapProvider providing tracking data to the scene.
         [Tooltip("The current Leap Data Provider for the scene.")]
         [SerializeField]
         private LeapProvider leapDataProvider;
         public LeapProvider LeapDataProvider => leapDataProvider;
+        public void SetLeapProvider(LeapProvider provider) { leapDataProvider = provider; }
 
         //Calibration Setup
 


### PR DESCRIPTION
## Summary
Adds the ability to set the leap provider and main camera on the UI input module from the Editor - as request by Lynx for launch. They use the UI Input module for their launcher and are on 6.1.

I have not updated the example scene to set these as they are also populated at runtime.

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [ ] Pair review with a member of the QA team.
- [ ] Add any release testing considerations to the MR for the next release.
- [x] Check any relevant CHANGELOG files have been updated.
- [ ] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.
- [ ] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [ ] Checked and agree with release testing considerations added to MR for the next release.

## Closes JIRA Issue

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_