### PR TITLE
Added events to interaction slider when horizontal/vertical slider pe…

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Detector null reference error when creating a detector at runtime
 - XRServiceProvider does not scale when the player scales
+- InteractionSlider now raises event for value changes when setting values via the Horizontal and Vertical Percent properties
 
 ### Known issues 
 - Offset between skeleton hand wrist and forearm in sample scenes

--- a/Packages/Tracking/Interaction Engine/Runtime/Scripts/UI/InteractionSlider.cs
+++ b/Packages/Tracking/Interaction Engine/Runtime/Scripts/UI/InteractionSlider.cs
@@ -174,6 +174,7 @@ namespace Leap.Unity.Interaction
                 localPhysicsPosition.x = Mathf.Lerp(initialLocalPosition.x + horizontalSlideLimits.x, initialLocalPosition.x + horizontalSlideLimits.y, _horizontalSliderPercent);
                 physicsPosition = transform.parent.TransformPoint(localPhysicsPosition);
                 rigidbody.position = physicsPosition;
+                HorizontalSlideEvent(HorizontalSliderValue);
             }
         }
 
@@ -195,6 +196,7 @@ namespace Leap.Unity.Interaction
                 localPhysicsPosition.y = Mathf.Lerp(initialLocalPosition.y + verticalSlideLimits.x, initialLocalPosition.y + verticalSlideLimits.y, _verticalSliderPercent);
                 physicsPosition = transform.parent.TransformPoint(localPhysicsPosition);
                 rigidbody.position = physicsPosition;
+                VerticalSlideEvent(VerticalSliderValue);
             }
         }
 


### PR DESCRIPTION
## Summary

Addresses a bug found in the Test App. If a value is set on an InteractionSlider using the VerticalSliderPercent property, clients using the VerticalSlideEvent event will now be notified of a change. Also made the same change for the HorizontalSliderPercent.

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [x] Pair review with a member of the QA team.
- [x] Add any release testing considerations to the MR for the next release.
- [x] Check any relevant CHANGELOG files have been updated.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.
- [x] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [x] Checked and agree with release testing considerations added to MR for the next release.

## Closes JIRA Issue

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_