### PR TITLE
Fix OpenXR LossyScale transform

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Detector null reference error when creating a detector at runtime
-- XRServiceProvider does not scale when the player scales
+- XRServiceProvider and OpenXRLeapProvider do not scale when the player scales
 
 ### Known issues 
 - Offset between skeleton hand wrist and forearm in sample scenes

--- a/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
+++ b/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
@@ -53,13 +53,13 @@ namespace Ultraleap.Tracking.OpenXR
         {
             PopulateLeapFrame(ref _updateFrame);
 
-            Pose trackerTransform = new Pose(Vector3.zero, Quaternion.identity);
+            LeapTransform trackerTransform = new LeapTransform(Vector3.zero, Quaternion.identity, Vector3.one);
 
             // Adjust for relative transform if it's in use.
             var trackedPoseDriver = mainCamera.GetComponent<UnityEngine.SpatialTracking.TrackedPoseDriver>();
             if (trackedPoseDriver != null && trackedPoseDriver.UseRelativeTransform)
             {
-                trackerTransform.position += trackedPoseDriver.originPose.position;
+                trackerTransform.translation += trackedPoseDriver.originPose.position;
                 trackerTransform.rotation *= trackedPoseDriver.originPose.rotation;
             }
 
@@ -67,13 +67,16 @@ namespace Ultraleap.Tracking.OpenXR
             var parentTransform = mainCamera.transform.parent;
             if (parentTransform != null)
             {
-                trackerTransform.position += parentTransform.position;
+                trackerTransform.translation += parentTransform.position;
                 trackerTransform.rotation *= parentTransform.rotation;
+                trackerTransform.scale = parentTransform.lossyScale;
+            }
+            else
+            {
+                trackerTransform.scale = transform.lossyScale;
             }
 
-            _currentFrame = _updateFrame.TransformedCopy(new LeapTransform(
-                trackerTransform.position,
-                trackerTransform.rotation));
+            _currentFrame = _updateFrame.TransformedCopy(trackerTransform);
 
             DispatchUpdateFrameEvent(_currentFrame);
         }


### PR DESCRIPTION
## Summary

OpenXR Provider now uses the lossyscale of the camera parent to match the XRServiceProvider implementation

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [ ] Pair review with a member of the QA team.
- [ ] Add any release testing considerations to the MR for the next release.
- [x] Check any relevant CHANGELOG files have been updated.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.
- [x] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [x] Checked and agree with release testing considerations added to MR for the next release.

## Closes JIRA Issue

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_