### PR TITLE
XRLeapProviderManager Automatic modes and explanations

### DIFF
--- a/Packages/Tracking/Core/Editor/Scripts/PrefabCreateMenu.cs
+++ b/Packages/Tracking/Core/Editor/Scripts/PrefabCreateMenu.cs
@@ -14,19 +14,31 @@ namespace Leap
 {
     public class PrefabCreateMenu
     {
-        [MenuItem("GameObject/Ultraleap/XR Leap Provider Manager")]
+        [MenuItem("GameObject/Ultraleap/XR/XR Leap Provider Manager", false, 0)]
         public static void CreateProviderXR()
         {
             CreatePrefab("XR Leap Provider Manager");
         }
 
-        [MenuItem("GameObject/Ultraleap/Service Provider (Desktop)")]
+        [MenuItem("GameObject/Ultraleap/XR/Service Provider (XR)", false, 11)]
+        public static void CreateServiceProviderXR()
+        {
+            CreatePrefab("Service Provider (XR)");
+        }
+
+        [MenuItem("GameObject/Ultraleap/XR/Service Provider (OpenXR)", false, 12)]
+        public static void CreateServiceProviderOpenXR()
+        {
+            CreatePrefab("Service Provider (OpenXR)");
+        }
+
+        [MenuItem("GameObject/Ultraleap/Non-XR/Service Provider (Desktop)", false, 23)]
         public static void CreateServiceProviderDesktop()
         {
             CreatePrefab("Service Provider (Desktop)");
         }
 
-        [MenuItem("GameObject/Ultraleap/Service Provider (Screentop)")]
+        [MenuItem("GameObject/Ultraleap/Non-XR/Service Provider (Screentop)", false, 24)]
         public static void CreateServiceProviderScreentop()
         {
             CreatePrefab("Service Provider (Screentop)");

--- a/Packages/Tracking/Core/Editor/Scripts/PrefabCreateMenu.cs
+++ b/Packages/Tracking/Core/Editor/Scripts/PrefabCreateMenu.cs
@@ -42,7 +42,7 @@ namespace Leap
         public static void CreateServiceProviderScreentop()
         {
             CreatePrefab("Service Provider (Screentop)");
-        }        
+        }
 
         public static void CreatePrefab(string prefabName)
         {

--- a/Packages/Tracking/Core/Editor/Scripts/XRLeapProviderManagerEditor.cs
+++ b/Packages/Tracking/Core/Editor/Scripts/XRLeapProviderManagerEditor.cs
@@ -1,0 +1,50 @@
+/******************************************************************************
+ * Copyright (C) Ultraleap, Inc. 2011-2022.                                   *
+ *                                                                            *
+ * Use subject to the terms of the Apache License 2.0 available at            *
+ * http://www.apache.org/licenses/LICENSE-2.0, or another agreement           *
+ * between Ultraleap and you, your company or other organization.             *
+ ******************************************************************************/
+
+using UnityEditor;
+using UnityEngine;
+
+namespace Leap.Unity
+{
+    [CustomEditor(typeof(XRLeapProviderManager))]
+    public class XRLeapProviderManagerEditor : CustomEditorBase<XRLeapProviderManager>
+    {
+        SerializedProperty serviceProviderProp;
+        SerializedProperty openXRProviderProp;
+        SerializedProperty trackingSourceProp;
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+
+            serviceProviderProp = serializedObject.FindProperty("leapXRServiceProvider");
+            openXRProviderProp = serializedObject.FindProperty("openXRLeapProvider");
+            trackingSourceProp = serializedObject.FindProperty("trackingSource");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            EditorGUILayout.PropertyField(trackingSourceProp);
+
+            EditorGUILayout.Space();
+
+            if (Application.isPlaying)
+            {
+                EditorGUI.BeginDisabledGroup(true);
+                EditorGUILayout.PropertyField(serviceProviderProp);
+                EditorGUILayout.PropertyField(openXRProviderProp);
+                EditorGUI.EndDisabledGroup();
+            }
+            else
+            {
+                EditorGUILayout.PropertyField(serviceProviderProp);
+                EditorGUILayout.PropertyField(openXRProviderProp);
+            }
+        }
+    }
+}

--- a/Packages/Tracking/Core/Editor/Scripts/XRLeapProviderManagerEditor.cs.meta
+++ b/Packages/Tracking/Core/Editor/Scripts/XRLeapProviderManagerEditor.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 48b1665485d58f94e8d772c192707d40
+timeCreated: 1429813852
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/Tracking/Core/Runtime/Prefabs/XR Leap Provider Manager.prefab
+++ b/Packages/Tracking/Core/Runtime/Prefabs/XR Leap Provider Manager.prefab
@@ -49,7 +49,7 @@ MonoBehaviour:
   editTimePose: 1
   openXRLeapProvider: {fileID: 1276715513614782159}
   leapXRServiceProvider: {fileID: 8681616449881122529}
-  forceLeapService: 0
+  trackingSource: 0
 --- !u!114 &2683451079520186211
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Packages/Tracking/Core/Runtime/Scripts/XRLeapProviderManager.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/XRLeapProviderManager.cs
@@ -71,7 +71,7 @@ namespace Leap.Unity
         /// <summary>
         /// The chosen source of hand tracking data
         /// </summary>
-        [Tooltip("AUTOMATIC - Windows will use LeapService, Other platforms will use OpenXR if available and LeapService if OpenXR if not" +
+        [Tooltip("AUTOMATIC - Windows will use LeapService, other platforms will use OpenXR if available and LeapService if OpenXR if not" +
                     "OPEN_XR - Use OpenXR as the source of tracking" +
                     "LEAP_SERVICE - Use LeapC as the source of tracking")]
         public TrackingSource trackingSource;
@@ -116,13 +116,13 @@ namespace Leap.Unity
         /// <param name="_source">A tracking source. Where possible, this should not be AUTOMATIC when this method is called</param>
         void SelectTrackingSource(TrackingSource _source)
         {
-            if(_source == TrackingSource.AUTOMATIC)
+            if (_source == TrackingSource.AUTOMATIC)
             {
                 Debug.LogWarning("No specific Tracking Source selected. Automatically selecting Leap Service");
                 _source = TrackingSource.LEAP_SERVICE;
             }
-            
-            if(_source == TrackingSource.OPEN_XR)
+
+            if (_source == TrackingSource.OPEN_XR)
             {
                 Debug.Log("Using OpenXR for Hand Tracking");
                 LeapProvider = openXRLeapProvider;


### PR DESCRIPTION
## Summary

- Adds a dropdown to swap between Automatic/OpenXR/LeapC to the XRLeapProviderManager
- Ensures all Prefabs are available via the GameObject context menu
- Adds an editor script to make the Inspector cleaner
- XRLeapProviderManager Automatic selects LeapC when in Editor or Windows to avoid OpenXR runtimes that don't present tracking 'quality' options yet

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [ ] Pair review with a member of the QA team.
- [ ] Add any release testing considerations to the MR for the next release.
- [x] Check any relevant CHANGELOG files have been updated.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.
- [ ] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [x] Checked and agree with release testing considerations added to MR for the next release.

## Closes JIRA Issue

Closes UNITY-941