### PR TITLE
Don't check for ignore on destroyed rigidbody

### DIFF
--- a/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsHand.cs
+++ b/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsHand.cs
@@ -528,6 +528,9 @@ namespace Leap.Unity.Interaction.PhysicsHands
                         _ignoredData[i].timeout -= Time.fixedDeltaTime;
                     }
 
+                    if (_ignoredData[i].rigid == null)
+                        continue;
+
                     if (_ignoredData[i].timeout <= 0 && !IsObjectInHandRadius(_ignoredData[i].rigid, _ignoredData[i].radius))
                     {
                         TogglePhysicsIgnore(_ignoredData[i].rigid, false);


### PR DESCRIPTION
Mini MR to add a null check on the object ignorer to stop looking at destroyed rigidbodies.

This error was killing phys hands in Aurora 👻