### PR TITLE
UNITY-967 Added null check for mainCamera in (get) EditTimeFrame in OpenXRLeapProvider

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 
 
 ### Fixed
+- Check for main camera being null in (get) EditTimeFrame in OpenXRLeapProvider
 - Detector null reference error when creating a detector at runtime
 - InteractionSlider now raises event for value changes when setting values via the Horizontal and Vertical Percent properties
 - XRServiceProvider and OpenXRLeapProvider do not scale when the player scales

--- a/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
+++ b/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
@@ -393,7 +393,12 @@ namespace Ultraleap.Tracking.OpenXR
                 (_backingUntransformedEditTimeFrame ??= new Frame()).Hands.Clear();
                 _backingUntransformedEditTimeFrame.Hands.Add(EditTimeLeftHand);
                 _backingUntransformedEditTimeFrame.Hands.Add(EditTimeRightHand);
-                _backingEditTimeFrame = _backingUntransformedEditTimeFrame.TransformedCopy(new LeapTransform(mainCamera.transform));
+
+                if (mainCamera != null)
+                {
+                    _backingEditTimeFrame = _backingUntransformedEditTimeFrame.TransformedCopy(new LeapTransform(mainCamera.transform));
+                }
+
                 return _backingEditTimeFrame;
             }
         }


### PR DESCRIPTION
## Summary

I've seen an error logged to the console every now and again in the tracking test app. This comes from a call to get the EditTimeFrame property. From debugging, the mainCamera is null, which causes a null reference exception. I've added a null check to the code.

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [x] Pair review with a member of the QA team.
- [x] Add any release testing considerations to the MR for the next release.
- [x] Check any relevant CHANGELOG files have been updated.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.
- [x] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [x] Checked and agree with release testing considerations added to MR for the next release.

## Closes JIRA Issue

Closes UNITY-967