### PR TITLE
Correctly check for existing Android manifest entries

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 
 
 ### Fixed
-- 
+- Android Manifest auto-population when building for OpenXR always adds permissions 
 
 ### Known issues 
 - Offset between skeleton hand wrist and forearm in sample scenes

--- a/Packages/Tracking/OpenXR/Editor/Scripts/AndroidManifest.cs
+++ b/Packages/Tracking/OpenXR/Editor/Scripts/AndroidManifest.cs
@@ -1,4 +1,4 @@
-﻿using JetBrains.Annotations;
+using JetBrains.Annotations;
 using System.Linq;
 using System.Xml.Linq;
 
@@ -42,7 +42,7 @@ namespace Ultraleap.Tracking.OpenXR
             }
 
             // Check for the package statement and create it if doesn't exist
-            if (queries.Elements("package").All(el => el.Attribute(_android + "name")?.Name != packageName))
+            if (queries.Elements("package").All(el => el.Attribute(_android + "name")?.Value != packageName))
             {
                 queries.Add(
                     new XElement("package", new XAttribute(_android + "name", packageName))
@@ -73,7 +73,7 @@ namespace Ultraleap.Tracking.OpenXR
         {
             // Check if the uses-permission is already there, and create it if not.
             if (_manifest.Root!.Elements("uses-permission")
-                .All(el => el.Attribute(_android + "name")?.Name != name))
+                .All(el => el.Attribute(_android + "name")?.Value != name))
             {
                 _manifest.Root!.Add(
                     new XElement("uses-permission", new XAttribute(_android + "name", name))
@@ -87,7 +87,7 @@ namespace Ultraleap.Tracking.OpenXR
             // Check if the uses-feature is already there.
             var feature = _manifest.Root!
                 .Elements("uses-feature")
-                .FirstOrDefault(el => el.Attribute(_android + "name")?.Name == name);
+                .FirstOrDefault(el => el.Attribute(_android + "name")?.Value == name);
 
             // Add if it doesn't exist, or upgrade to required if it does and required was declared.
             if (feature == null)
@@ -112,7 +112,7 @@ namespace Ultraleap.Tracking.OpenXR
             var application = _manifest.Root!.Element("application")!;
             var metaData = application
                 .Elements("meta-data")
-                .FirstOrDefault(el => el.Attribute(_android + "name")?.Name == name);
+                .FirstOrDefault(el => el.Attribute(_android + "name")?.Value == name);
 
             // Check for the meta-data element and create it if doesn't exist, or update if it does.
             if (metaData == null)

--- a/Packages/Tracking/OpenXR/Editor/Scripts/AndroidManifest.cs
+++ b/Packages/Tracking/OpenXR/Editor/Scripts/AndroidManifest.cs
@@ -71,9 +71,13 @@ namespace Ultraleap.Tracking.OpenXR
         [PublicAPI]
         public void AddUsesPermission(string name)
         {
-            // Check if the uses-permission is already there, and create it if not.
-            if (_manifest.Root!.Elements("uses-permission")
-                .All(el => el.Attribute(_android + "name")?.Value != name))
+            // Check if the uses-feature is already there.
+            var feature = _manifest.Root!
+                .Elements("uses-permission")
+                .FirstOrDefault(el => el.Attribute(_android + "name")?.Value == name);
+
+            // Create it if not.
+            if (feature == null)
             {
                 _manifest.Root!.Add(
                     new XElement("uses-permission", new XAttribute(_android + "name", name))


### PR DESCRIPTION
Fixes a bug when building for OpenXR with existing AndroidManifest entries. Now correctly checks for existing values and will not re-write them if they already exist, avoiding a fatal build error.