### PR TITLE
ignore use of metacarpals when calculating finger lengths via OpenXR

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 
 
 ### Fixed
-- Android Manifest auto-population when building for OpenXR always adds permissions 
+- Android Manifest auto-population when building for OpenXR always adds permissions
+- OpenXR finger lengths wrongly include metacarpal lengths
 
 ### Known issues 
 - Offset between skeleton hand wrist and forearm in sample scenes

--- a/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
+++ b/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
@@ -218,8 +218,13 @@ namespace Ultraleap.Tracking.OpenXR
                         (Bone.BoneType)boneIndex,
                         prevJoint.Pose.rotation);
                     fingerWidth = Math.Max(fingerWidth, bone.Width);
-                    fingerLength += bone.Length;
                     xrTipIndex = xrNextIndex;
+
+                    // Ignore metacarpals when calculating finger lengths
+                    if(boneIndex != 0)
+                    {
+                        fingerLength += bone.Length;
+                    }
                 }
 
                 // Populate the higher - level finger data.


### PR DESCRIPTION
## Summary

Removes metacarpal lengths from the total finger length calculation. The finger length is expected to be the length of the finger beyond the palm.

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [x] Pair review with a member of the QA team.
- [x] Add any release testing considerations to the MR for the next release.
- [x] Check any relevant CHANGELOG files have been updated.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.
- [ ] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [x] Checked and agree with release testing considerations added to MR for the next release.

## Closes JIRA Issue

Closes UNITY-992