### PR TITLE
Fix thumb metacarpal rotation on OpenXR provider

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Android Manifest auto-population when building for OpenXR always adds permissions
 - OpenXR finger lengths wrongly include metacarpal lengths
+- OpenXR provider incorrectly populated the zero-length thumb metacarpal with a rotation instead of zero
 
 ### Known issues 
 - Offset between skeleton hand wrist and forearm in sample scenes

--- a/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
+++ b/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
@@ -198,7 +198,7 @@ namespace Ultraleap.Tracking.OpenXR
                             metacarpalPosition,
                             metacarpalPosition,
                             metacarpalPosition,
-                            (joints[(int)HandJoint.ThumbMetacarpal].Pose.rotation * Vector3.forward),
+                            Vector3.zero,
                             0f,
                             joints[(int)HandJoint.ThumbMetacarpal].Radius * 2f,
                             (Bone.BoneType)boneIndex,


### PR DESCRIPTION
## Summary

Fixes the rotation of the zero-length metacarpal for the OpenXR provider. Contrary to normal use of LeapC (which contains a rotation). Leap hands in unity expect this bone to have a zero rotation.

## Contributor Tasks

- [ ] Pair review with a member of the QA team.
- [ ] Add any release testing considerations to the MR for the next release.
- [x] Check any relevant CHANGELOG files have been updated.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.
- [x] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

- [ ] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [ ] Checked and agree with release testing considerations added to MR for the next release.