### PR TITLE
OnAnchorDisable() has now been renamed "OnDisable()" so it will be called when the class is Disabled.

### DIFF
--- a/Packages/Tracking/Interaction Engine/Runtime/Scripts/UI/Anchors/Anchor.cs
+++ b/Packages/Tracking/Interaction Engine/Runtime/Scripts/UI/Anchors/Anchor.cs
@@ -116,7 +116,7 @@ namespace Leap.Unity.Interaction
             updateAnchorCallbacks();
         }
 
-        void OnAnchorDisabled()
+        void OnDisable()
         {
             if (matchActiveStateWithAttachedObjects)
             {


### PR DESCRIPTION
## Summary

This renames the previous "OnAnchorDisabled" to OnDissabled so that it is called automatically by the unity event when the object is disabled.

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [ ] Pair review with a member of the QA team.
- [ ] Add any release testing considerations to the MR for the next release.
- [ ] Check any relevant CHANGELOG files have been updated.
- [ ] Ensure documentation requirements are met e.g., public API is commented.
- [ ] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [ ] Add any relevant labels such as `breaking` to this MR.
- [ ] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [ ] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [ ] Checked and agree with release testing considerations added to MR for the next release.

## Closes JIRA Issue

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_