### PR TITLE
Fix errors when deleting a physicsProvider at runtime

### DIFF
--- a/Packages/Tracking/Core/Runtime/Scripts/PostProcessProvider.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/PostProcessProvider.cs
@@ -105,6 +105,15 @@ namespace Leap.Unity
             validateInput();
         }
 
+        private void OnDestroy()
+        {
+            if (_inputLeapProvider != null)
+            {
+                _inputLeapProvider.OnFixedFrame -= processFixedFrame;
+                _inputLeapProvider.OnUpdateFrame -= processUpdateFrame;
+            }
+        }
+
         public abstract void ProcessFrame(ref Frame inputFrame);
 
         private void validateInput()


### PR DESCRIPTION

## Summary

Deleting a physicsProvider at runtime throws up lots of errors and leads to some weird behaviour where hands might freeze. This fixes it by unsubscribing from frame update events when a postProcessProvider gets destroyed.

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [ ] Pair review with a member of the QA team.
- [x] Add any release testing considerations to the MR for the next release.
- [ ] Check any relevant CHANGELOG files have been updated.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.
- [ ] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [x] Checked and agree with release testing considerations added to MR for the next release.

## Closes JIRA Issue

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_
Closes UNITY-1002