### PR TITLE
Add waist position to inferred body positions and fix Euler Angle Deadzone reset bug

### DIFF
--- a/Packages/Tracking Preview/HandRays/Runtime/Scripts/InferredBodyPositions/EulerAngleDeadzone.cs
+++ b/Packages/Tracking Preview/HandRays/Runtime/Scripts/InferredBodyPositions/EulerAngleDeadzone.cs
@@ -94,15 +94,15 @@ namespace Leap.Unity.Preview.HandRays
             float delta = currentAngle + recentredPositionDelta - DeadzoneCentre;
             delta = SimplifyAngle(delta);
 
+            float signDelta = Mathf.Sign(delta);
+            float absDelta = Mathf.Abs(delta);
+
             // You've rotated too far in a single frame
-            if (Mathf.Abs(delta) > 15)
+            if (absDelta > 35)
             {
                 ResetDeadzone(currentAngle);
                 return;
             }
-
-            float signDelta = Mathf.Sign(delta);
-            float absDelta = Mathf.Abs(delta);
 
             if (absDelta > DeadzoneSize)
             {

--- a/Packages/Tracking Preview/HandRays/Runtime/Scripts/InferredBodyPositions/EulerAngleDeadzone.cs
+++ b/Packages/Tracking Preview/HandRays/Runtime/Scripts/InferredBodyPositions/EulerAngleDeadzone.cs
@@ -94,9 +94,8 @@ namespace Leap.Unity.Preview.HandRays
             float delta = currentAngle + recentredPositionDelta - DeadzoneCentre;
             delta = SimplifyAngle(delta);
 
-            float signDelta = Mathf.Sign(delta);
             float absDelta = Mathf.Abs(delta);
-
+            
             // You've rotated too far in a single frame
             if (absDelta > 35)
             {
@@ -111,6 +110,8 @@ namespace Leap.Unity.Preview.HandRays
                     deadzoneCentreHistory.Clear();
                     recentredWhilstStill = false;
                 }
+                
+                float signDelta = Mathf.Sign(delta);
                 DeadzoneCentre += (absDelta - DeadzoneSize) * signDelta;
                 DeadzoneCentre %= 360;
 

--- a/Packages/Tracking Preview/HandRays/Runtime/Scripts/InferredBodyPositions/InferredBodyPositions.cs
+++ b/Packages/Tracking Preview/HandRays/Runtime/Scripts/InferredBodyPositions/InferredBodyPositions.cs
@@ -158,6 +158,11 @@ namespace Leap.Unity.Preview.HandRays
         /// </summary>
         public Vector3[] HipPositions { get; private set; }
 
+        /// <summary>
+        /// The midpoint between your hips
+        /// </summary>
+        public Vector3 WaistPosition { get { return Vector3.Lerp(HipPositions[0], HipPositions[1], 0.5f); } }
+
 
         private void Start()
         {

--- a/Packages/Tracking Preview/HandRays/Runtime/Scripts/InferredBodyPositions/InferredBodyPositions.cs
+++ b/Packages/Tracking Preview/HandRays/Runtime/Scripts/InferredBodyPositions/InferredBodyPositions.cs
@@ -159,10 +159,9 @@ namespace Leap.Unity.Preview.HandRays
         public Vector3[] HipPositions { get; private set; }
 
         /// <summary>
-        /// The midpoint between your hips
+        /// Inferred waist position, calculated the midpoint between the two hips
         /// </summary>
         public Vector3 WaistPosition { get { return Vector3.Lerp(HipPositions[0], HipPositions[1], 0.5f); } }
-
 
         private void Start()
         {


### PR DESCRIPTION
## Summary

- Add a waist position (the midpoint of the hip positions to inferred body positions
- Fix a bug where EulerAngleDeadzone was resetting too aggressively

note: the EulerAngleDeadzone reset was introduced to stop ray jitter when teleporting at high angles. I've tested to ensure this is still fixed after my changes.

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [ ] Pair review with a member of the QA team.
- [ ] Add any release testing considerations to the MR for the next release.
- [ ] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [ ] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] Checked and agree with release testing considerations added to MR for the next release.

## Closes JIRA Issue

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_