### PR TITLE
Fix fingertip scale when scaling service provider

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - 0th thumb bone rotation values when using OpenXR
 - "Pullcord" jitters when being interacted with
+- Hand Binder finger tip scale disproportionately when LeapProvider Transform is scaled
 
 ### Known issues 
 - Scenes containing the infrared viewer render incorrectly on Android build targets and in scriptable render pipelines such as URP and HDRP. 

--- a/Packages/Tracking/Hands/Runtime/Scripts/HandBinder/HandBinder.cs
+++ b/Packages/Tracking/Hands/Runtime/Scripts/HandBinder/HandBinder.cs
@@ -244,9 +244,12 @@ namespace Leap.Unity.HandsModule
                 float ratio = leapFingerLength / fingerTipLength;
                 //Adjust the ratio by an offset value exposed in the inspector and the overal scale that has been calculated
                 float adjustedRatio = (ratio * (finger.fingerTipScaleOffset) - BoundHand.scaleOffset);
-
+                //Adjust the ratio to account for service provider scale, assuming the service provider is uniformly scaled
+                var serviceProviderScale = leapProvider?.gameObject.transform.localScale.x ?? 1f;
+                adjustedRatio /= serviceProviderScale;
                 //Calculate the direction that goes up the bone towards the next bone
                 Vector3 direction = (intermediateBone.boundTransform.position - distalBone.boundTransform.position).normalized;
+
                 //Calculate which axis to scale along
                 Vector3 axis = CalculateAxis(distalBone.boundTransform, direction);
                 //Calculate the scale by ensuring all axis are 1 apart from the axis to scale along
@@ -435,6 +438,10 @@ namespace Leap.Unity.HandsModule
         Vector3 CalculateAxis(Transform t, Vector3 dir)
         {
             var boneForward = t.InverseTransformDirection(dir.normalized).normalized;
+            // Ensure axes are positive to account for negative model scaling
+            boneForward.x = Mathf.Abs(boneForward.x);
+            boneForward.y = Mathf.Abs(boneForward.y);
+            boneForward.z = Mathf.Abs(boneForward.z);
             return boneForward;
         }
         #endregion

--- a/Packages/Tracking/Hands/Runtime/Scripts/HandBinder/HandBinder.cs
+++ b/Packages/Tracking/Hands/Runtime/Scripts/HandBinder/HandBinder.cs
@@ -245,7 +245,7 @@ namespace Leap.Unity.HandsModule
                 //Adjust the ratio by an offset value exposed in the inspector and the overal scale that has been calculated
                 float adjustedRatio = (ratio * (finger.fingerTipScaleOffset) - BoundHand.scaleOffset);
                 //Adjust the ratio to account for service provider scale, assuming the service provider is uniformly scaled
-                var serviceProviderScale = leapProvider?.gameObject.transform.localScale.x ?? 1f;
+                var serviceProviderScale = leapProvider?.gameObject.transform.lossyScale.x ?? 1f;
                 adjustedRatio /= serviceProviderScale;
                 //Calculate the direction that goes up the bone towards the next bone
                 Vector3 direction = (intermediateBone.boundTransform.position - distalBone.boundTransform.position).normalized;


### PR DESCRIPTION
## Summary

Fixes hand binder fingertips scaling disproportionately with the rest of the hand when the service provider is scaled.
![capture](https://user-images.githubusercontent.com/3116852/214836419-e3166819-048b-4882-820c-627b75dfb5ee.jpg)


## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [x] Pair review with a member of the QA team.
- [x] Add any release testing considerations to the MR for the next release.
- [x] Check any relevant CHANGELOG files have been updated.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.
- [ ] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [x] Checked and agree with release testing considerations added to MR for the next release.

## Closes JIRA Issue

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_
`Closes UNITY-1012`