### PR TITLE
Reduce allocations in OpenXRLeapProvider

### DIFF
--- a/Packages/Tracking Preview/UI Input/Runtime/Scripts/PointerElement.cs
+++ b/Packages/Tracking Preview/UI Input/Runtime/Scripts/PointerElement.cs
@@ -163,9 +163,13 @@ namespace Leap.Unity.InputModule
 
         internal void Process(Hand hand, IProjectionOriginProvider projectionOriginProvider)
         {
-            if(hand == null && cursor.gameObject.activeSelf)
+            if(hand == null)
             {
-                cursor.gameObject.SetActive(false);
+                if (cursor.gameObject.activeSelf)
+                {
+                    cursor.gameObject.SetActive(false);
+                }
+
                 return;
             }
 

--- a/Packages/Tracking Preview/UI Input/Runtime/Scripts/PointerElement.cs
+++ b/Packages/Tracking Preview/UI Input/Runtime/Scripts/PointerElement.cs
@@ -163,21 +163,26 @@ namespace Leap.Unity.InputModule
 
         internal void Process(Hand hand, IProjectionOriginProvider projectionOriginProvider)
         {
-            //Control cursor display
-            cursor.gameObject.SetActive(true);
+            if(hand == null && cursor.gameObject.activeSelf)
+            {
+                cursor.gameObject.SetActive(false);
+                return;
+            }
 
             if (forceDisable)
             {
                 cursor.gameObject.SetActive(false);
             }
-
-            if (hand == null || (disableWhenOffCanvas && PointerState == PointerStates.OffCanvas))
+            else if (disableWhenOffCanvas && PointerState == PointerStates.OffCanvas)
             {
-                if (gameObject.activeInHierarchy)
+                if (cursor.gameObject.activeSelf)
                 {
                     cursor.gameObject.SetActive(false);
-                    if (hand == null) return;
                 }
+            }
+            else if(!cursor.gameObject.activeSelf)
+            {
+                cursor.gameObject.SetActive(true);
             }
 
             //Select interaction

--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Capsule Hands pinky metacarpal position to better represent the actual joint position
+- Reduced performance overhead of OpenXRLeapProvider
+- Reduced performance overhead when accessing Hands via Hands.Right, Hands.Left and Hands.GetHand
+- Reduced performance overhead when transforming Leap.Frames, Leap.Hands and Leap.Bones using Basis
+- Reduced performance overhead when accessing scale in Capsule Hands
+- Reduced performance overhead when using Preview UI Input Cursor
 
 ### Fixed
 - 

--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Bone.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Bone.cs
@@ -132,6 +132,8 @@ namespace Leap
         /// </summary>
         public Quaternion Rotation;
 
+        LeapTransform _basis = new LeapTransform(Vector3.one, Quaternion.identity);
+
         /// <summary>
         /// The orthonormal basis vectors for this Bone as a Matrix.
         /// The orientation of this Bone as a Quaternion.
@@ -163,7 +165,16 @@ namespace Leap
         /// 
         /// @since 2.0
         /// </summary>
-        public LeapTransform Basis { get { return new LeapTransform(PrevJoint, Rotation); } }
+        public LeapTransform Basis
+        {
+            get
+            {
+                _basis.translation = PrevJoint;
+                _basis.rotation = Rotation;
+
+                return _basis;
+            }
+        }
 
         /// <summary>
         /// Enumerates the type of bones.

--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Hand.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Hand.cs
@@ -201,13 +201,24 @@ namespace Leap
         /// </summary>
         public Vector3 Direction;
 
+        LeapTransform _basis = new LeapTransform(Vector3.one, Quaternion.identity);
+        
         /// <summary>
         /// The transform of the hand.
         /// 
         /// Note, in version prior to 3.1, the Basis was a Matrix object.
         /// @since 3.1
         /// </summary>
-        public LeapTransform Basis { get { return new LeapTransform(PalmPosition, Rotation); } }
+        public LeapTransform Basis
+        { 
+            get 
+            {
+                _basis.translation = PalmPosition;
+                _basis.rotation = Rotation;
+
+                return _basis;
+            }
+        }
 
         /// <summary>
         /// The rotation of the hand as a quaternion.

--- a/Packages/Tracking/Core/Runtime/Scripts/Hands/CapsuleHand.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Hands/CapsuleHand.cs
@@ -85,6 +85,8 @@ namespace Leap.Unity
         private MaterialPropertyBlock _materialPropertyBlock;
         private Color[] _sphereColors;
 
+        private float currentLossyScaleX;
+
         [HideInInspector]
         public bool SetIndividualSphereColors = false;
         public Color[] SphereColors
@@ -294,6 +296,8 @@ namespace Leap.Unity
         /// </summary>
         public override void UpdateHand()
         {
+            currentLossyScaleX = transform.lossyScale.x;
+
             _curSphereIndex = 0;
             _curCylinderIndex = 0;
 
@@ -448,7 +452,7 @@ namespace Leap.Unity
 
             //multiply radius by 2 because the default unity sphere has a radius of 0.5 meters at scale 1.
             _sphereMatrices[_curSphereIndex++] = Matrix4x4.TRS(position,
-              Quaternion.identity, Vector3.one * radius * 2.0f * transform.lossyScale.x);
+              Quaternion.identity, Vector3.one * radius * 2.0f * currentLossyScaleX);
         }
 
         private void drawCylinder(Vector3 a, Vector3 b)
@@ -460,7 +464,7 @@ namespace Leap.Unity
             if ((a - b).magnitude > 0.001f)
             {
                 _cylinderMatrices[_curCylinderIndex++] = Matrix4x4.TRS(a,
-                  Quaternion.LookRotation(b - a), new Vector3(transform.lossyScale.x, transform.lossyScale.x, length));
+                  Quaternion.LookRotation(b - a), new Vector3(currentLossyScaleX, currentLossyScaleX, length));
             }
         }
 

--- a/Packages/Tracking/Core/Runtime/Scripts/Utils/HandUtils.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Utils/HandUtils.cs
@@ -622,9 +622,20 @@ namespace Leap.Unity
         /// <returns>The first hand of the argument whichHand found in the argument frame.</returns>
         public static Hand GetHand(this Frame frame, Chirality whichHand)
         {
-            if (frame.Hands == null) { return null; }
-            return frame.Hands.FirstOrDefault(
-              h => h.IsLeft == (whichHand == Chirality.Left));
+            if (frame.Hands == null)
+            {
+                return null;
+            }
+
+            foreach (var hand in frame.Hands)
+            {
+                if (hand.IsLeft && whichHand == Chirality.Left || hand.IsRight && whichHand == Chirality.Right)
+                {
+                    return hand;
+                }
+            }
+
+            return null;
         }
 
         #endregion

--- a/Packages/Tracking/Core/Runtime/Scripts/Utils/HandUtils.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Utils/HandUtils.cs
@@ -146,7 +146,7 @@ namespace Leap.Unity
             {
                 if (Provider == null) return null;
                 if (Provider.CurrentFrame == null) return null;
-                return Provider.CurrentFrame.GetHand(Chirality.Right); ;
+                return Provider.CurrentFrame.GetHand(Chirality.Right);
             }
         }
 

--- a/Packages/Tracking/Core/Runtime/Scripts/Utils/HandUtils.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Utils/HandUtils.cs
@@ -132,7 +132,7 @@ namespace Leap.Unity
             {
                 if (Provider == null) return null;
                 if (Provider.CurrentFrame == null) return null;
-                return Provider.CurrentFrame.Hands.FirstOrDefault(hand => hand.IsLeft);
+                return Provider.CurrentFrame.GetHand(Chirality.Left);
             }
         }
 
@@ -146,7 +146,7 @@ namespace Leap.Unity
             {
                 if (Provider == null) return null;
                 if (Provider.CurrentFrame == null) return null;
-                else return Provider.CurrentFrame.Hands.FirstOrDefault(hand => hand.IsRight);
+                return Provider.CurrentFrame.GetHand(Chirality.Right); ;
             }
         }
 
@@ -160,7 +160,7 @@ namespace Leap.Unity
             {
                 if (Provider == null) return null;
                 if (Provider.CurrentFixedFrame == null) return null;
-                return Provider.CurrentFixedFrame.Hands.FirstOrDefault(hand => hand.IsLeft);
+                return Provider.CurrentFixedFrame.GetHand(Chirality.Left);
             }
         }
 
@@ -174,7 +174,7 @@ namespace Leap.Unity
             {
                 if (Provider == null) return null;
                 if (Provider.CurrentFixedFrame == null) return null;
-                else return Provider.CurrentFixedFrame.Hands.FirstOrDefault(hand => hand.IsRight);
+                return Provider.CurrentFixedFrame.GetHand(Chirality.Right);
             }
         }
 

--- a/Packages/Tracking/Interaction Engine/Runtime/Scripts/InteractionController.cs
+++ b/Packages/Tracking/Interaction Engine/Runtime/Scripts/InteractionController.cs
@@ -1088,13 +1088,15 @@ namespace Leap.Unity.Interaction
             float errorDistance = 0f;
             float errorFraction = 0f;
 
+            float boneWidth = contactBone.width;
+
             Vector3 lastTargetPositionTransformedAhead = contactBone.lastTargetPosition;
             if (manager.hasMovingFrameOfReference)
             {
                 manager.TransformAheadByFixedUpdate(contactBone.lastTargetPosition, out lastTargetPositionTransformedAhead);
             }
             errorDistance = Vector3.Distance(lastTargetPositionTransformedAhead, body.position);
-            errorFraction = errorDistance / contactBone.width;
+            errorFraction = errorDistance / boneWidth;
 
             // Adjust the mass of the contact bone based on the mass of
             // the object it is currently touching.
@@ -1118,7 +1120,7 @@ namespace Leap.Unity.Interaction
             // Attempt to move the contact bone to its target position and rotation
             // by setting its target velocity and angular velocity. Include a "deadzone"
             // for position to avoid tiny vibrations.
-            float deadzone = Mathf.Min(DEAD_ZONE_FRACTION * contactBone.width, 0.01F * scale);
+            float deadzone = Mathf.Min(DEAD_ZONE_FRACTION * boneWidth, 0.01F * scale);
             Vector3 delta = (targetPosition - body.position);
             float deltaMag = delta.magnitude;
             if (deltaMag <= deadzone)

--- a/Packages/Tracking/Interaction Engine/Runtime/Scripts/InteractionManager.cs
+++ b/Packages/Tracking/Interaction Engine/Runtime/Scripts/InteractionManager.cs
@@ -807,9 +807,7 @@ namespace Leap.Unity.Interaction
         {
             get
             {
-                return (this.transform.position - _prevPosition).magnitude > 0.0001F
-                    || Quaternion.Angle(transform.rotation * Quaternion.Inverse(_prevRotation),
-                                        Quaternion.identity) > 0.01F;
+                return (transform.position - _prevPosition).magnitude > 0.0001F;
             }
         }
 
@@ -819,8 +817,8 @@ namespace Leap.Unity.Interaction
 
         private void updateMovingFrameOfReferenceSupport()
         {
-            _prevPosition = this.transform.position;
-            _prevRotation = this.transform.rotation;
+            _prevPosition = transform.position;
+            _prevRotation = transform.rotation;
         }
 
         /// <summary>
@@ -831,9 +829,9 @@ namespace Leap.Unity.Interaction
         /// </summary>
         public void TransformAheadByFixedUpdate(Vector3 position, Quaternion rotation, out Vector3 newPosition, out Quaternion newRotation)
         {
-            Vector3 worldDisplacement = this.transform.position - _prevPosition;
-            Quaternion worldRotation = this.transform.rotation * Quaternion.Inverse(_prevRotation);
-            newPosition = ((worldRotation * (position - this.transform.position + worldDisplacement))) + this.transform.position;
+            Vector3 worldDisplacement = transform.position - _prevPosition;
+            Quaternion worldRotation = transform.rotation * Quaternion.Inverse(_prevRotation);
+            newPosition = ((worldRotation * (position - transform.position + worldDisplacement))) + transform.position;
             newRotation = worldRotation * rotation;
         }
 
@@ -845,9 +843,9 @@ namespace Leap.Unity.Interaction
         /// </summary>
         public void TransformAheadByFixedUpdate(Vector3 position, out Vector3 newPosition)
         {
-            Vector3 worldDisplacement = this.transform.position - _prevPosition;
-            Quaternion worldRotation = this.transform.rotation * Quaternion.Inverse(_prevRotation);
-            newPosition = ((worldRotation * (position - this.transform.position + worldDisplacement))) + this.transform.position;
+            Vector3 worldDisplacement = transform.position - _prevPosition;
+            Quaternion worldRotation = transform.rotation * Quaternion.Inverse(_prevRotation);
+            newPosition = ((worldRotation * (position - transform.position + worldDisplacement))) + transform.position;
         }
 
         #endregion

--- a/Packages/Tracking/Interaction Engine/Runtime/Scripts/Internal/ContactBone.cs
+++ b/Packages/Tracking/Interaction Engine/Runtime/Scripts/Internal/ContactBone.cs
@@ -40,7 +40,7 @@ namespace Leap.Unity.Interaction
 #if UNITY_EDITOR
     new
 #endif
-    Rigidbody rigidbody;
+        Rigidbody rigidbody;
 
         /// <summary>
         /// The Collider of this ContactBone. This field must not be null for the ContactBone

--- a/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
+++ b/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
@@ -123,7 +123,8 @@ namespace Ultraleap.Tracking.OpenXR
                 trackerTransform.scale = transform.lossyScale;
             }
 
-            _currentFrame = _updateFrame.TransformedCopy(trackerTransform);
+            _currentFrame = _updateFrame;
+            _currentFrame.Transform(trackerTransform);
 
             DispatchUpdateFrameEvent(_currentFrame);
         }

--- a/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
+++ b/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+using UnityEngine.SpatialTracking;
 using UnityEngine.XR.Management;
 using UnityEngine.XR.OpenXR;
 using Bone = Leap.Bone;
@@ -14,6 +15,8 @@ namespace Ultraleap.Tracking.OpenXR
 {
     public class OpenXRLeapProvider : LeapProvider
     {
+        private LeapTransform trackerTransform = new LeapTransform(Vector3.zero, Quaternion.identity);
+        
         private Frame _updateFrame = new Frame();
         private Frame _currentFrame = new Frame();
 
@@ -54,6 +57,9 @@ namespace Ultraleap.Tracking.OpenXR
             }
         }
 
+        private TrackedPoseDriver   _trackedPoseDriver;
+        private HandJointLocation[] _joints;
+
         public override TrackingSource TrackingDataSource { get { return CheckOpenXRAvailable(); } }
 
         private TrackingSource CheckOpenXRAvailable()
@@ -88,18 +94,20 @@ namespace Ultraleap.Tracking.OpenXR
             return _trackingSource;
         }
 
+        private void Start()
+        {
+            _trackedPoseDriver = mainCamera.GetComponent<TrackedPoseDriver>();
+        }
+
         private void Update()
         {
             PopulateLeapFrame(ref _updateFrame);
 
-            LeapTransform trackerTransform = new LeapTransform(Vector3.zero, Quaternion.identity, Vector3.one);
-
             // Adjust for relative transform if it's in use.
-            var trackedPoseDriver = mainCamera.GetComponent<UnityEngine.SpatialTracking.TrackedPoseDriver>();
-            if (trackedPoseDriver != null && trackedPoseDriver.UseRelativeTransform)
+            if (_trackedPoseDriver != null && _trackedPoseDriver.UseRelativeTransform)
             {
-                trackerTransform.translation += trackedPoseDriver.originPose.position;
-                trackerTransform.rotation *= trackedPoseDriver.originPose.rotation;
+                trackerTransform.translation += _trackedPoseDriver.originPose.position;
+                trackerTransform.rotation *= _trackedPoseDriver.originPose.rotation;
             }
 
             // Adjust for the camera parent transform if this camera is part of a rig.
@@ -146,8 +154,9 @@ namespace Ultraleap.Tracking.OpenXR
 
         private bool PopulateLeapHandFromOpenXRJoints(HandTracker handTracker, ref Hand hand)
         {
-            var joints = new HandJointLocation[handTracker.JointCount];
-            if (!handTracker.TryLocateHandJoints(joints))
+            _joints ??= new HandJointLocation[handTracker.JointCount];
+            
+            if (!handTracker.TryLocateHandJoints(_joints))
             {
                 if (handTracker == HandTracker.Left)
                 {
@@ -160,7 +169,6 @@ namespace Ultraleap.Tracking.OpenXR
 
                 return false;
             }
-
 
             float timeVisible = 0;
             if (handTracker == HandTracker.Left)
@@ -193,20 +201,20 @@ namespace Ultraleap.Tracking.OpenXR
                 {
                     var xrPrevIndex = fingerIndex * 5 + boneIndex + 1;
                     var xrNextIndex = xrPrevIndex + 1;
-                    var prevJoint = joints[xrPrevIndex];
-                    var nextJoint = joints[xrNextIndex];
+                    var prevJoint = _joints[xrPrevIndex];
+                    var nextJoint = _joints[xrNextIndex];
 
                     // Ignore thumb Metacarpal
                     if (fingerIndex == 0 && boneIndex == 0)
                     {
-                        var metacarpalPosition = joints[(int)HandJoint.ThumbMetacarpal].Pose.position;
+                        var metacarpalPosition = _joints[(int)HandJoint.ThumbMetacarpal].Pose.position;
                         hand.GetBone(boneIndex).Fill(
                             metacarpalPosition,
                             metacarpalPosition,
                             metacarpalPosition,
-                            (joints[(int)HandJoint.ThumbMetacarpal].Pose.rotation * Vector3.forward),
+                            _joints[(int)HandJoint.ThumbMetacarpal].Pose.rotation * Vector3.forward,
                             0f,
-                            joints[(int)HandJoint.ThumbMetacarpal].Radius * 2f,
+                            _joints[(int)HandJoint.ThumbMetacarpal].Radius * 2f,
                             (Bone.BoneType)boneIndex,
                             hand.Rotation * Quaternion.Euler(0, hand.IsLeft ? HAND_ROTATION_OFFSET_Y : -HAND_ROTATION_OFFSET_Y, hand.IsLeft ? HAND_ROTATION_OFFSET_Z : -HAND_ROTATION_OFFSET_Z));
                         continue;
@@ -239,15 +247,15 @@ namespace Ultraleap.Tracking.OpenXR
                     (handTracker == HandTracker.Left ? 0 : 1),
                     fingerIndex,
                     timeVisible,
-                    joints[xrTipIndex].Pose.position,
-                    (joints[xrTipIndex].Pose.rotation * Vector3.forward),
+                    _joints[xrTipIndex].Pose.position,
+                    (_joints[xrTipIndex].Pose.rotation * Vector3.forward),
                     fingerWidth,
                     fingerLength,
                     hand.GetFingerStrength(fingerIndex) < 0.4, // Fixed for now
                     (Finger.FingerType)fingerIndex);
             }
 
-            var palmWidth = joints[(int)HandJoint.Palm].Radius * 2.0f;
+            var palmWidth = _joints[(int)HandJoint.Palm].Radius * 2.0f;
 
             // Populate the whole hand information.
             hand.Fill(
@@ -261,24 +269,24 @@ namespace Ultraleap.Tracking.OpenXR
                 handTracker == HandTracker.Left,
                 timeVisible,
                 null, // Already Populated
-                joints[(int)HandJoint.Palm].Pose.position,
-                joints[(int)HandJoint.Palm].Pose.position,
-                joints[(int)HandJoint.Palm].LinearVelocity,
-                (joints[(int)HandJoint.Palm].Pose.rotation * Vector3.down),
-                joints[(int)HandJoint.Palm].Pose.rotation,
-                (joints[(int)HandJoint.Palm].Pose.rotation * Vector3.forward),
-                joints[(int)HandJoint.Wrist].Pose.position
+                _joints[(int)HandJoint.Palm].Pose.position,
+                _joints[(int)HandJoint.Palm].Pose.position,
+                _joints[(int)HandJoint.Palm].LinearVelocity,
+                _joints[(int)HandJoint.Palm].Pose.rotation * Vector3.down,
+                _joints[(int)HandJoint.Palm].Pose.rotation,
+                _joints[(int)HandJoint.Palm].Pose.rotation * Vector3.forward,
+                _joints[(int)HandJoint.Wrist].Pose.position
             );
 
             // Fill arm data.
-            var palmPosition = joints[(int)HandJoint.Palm].Pose.position;
-            var wristPosition = joints[(int)HandJoint.Wrist].Pose.position;
-            var wristWidth = joints[(int)HandJoint.Wrist].Radius * 2f;
+            var palmPosition = _joints[(int)HandJoint.Palm].Pose.position;
+            var wristPosition = _joints[(int)HandJoint.Wrist].Pose.position;
+            var wristWidth = _joints[(int)HandJoint.Wrist].Radius * 2f;
 
             if (handTracker.JointSet == HandJointSet.HandWithForearm)
             {
-                var elbowPosition = joints[(int)HandJoint.Elbow].Pose.position;
-                var elbowRotation = joints[(int)HandJoint.Elbow].Pose.rotation;
+                var elbowPosition = _joints[(int)HandJoint.Elbow].Pose.position;
+                var elbowRotation = _joints[(int)HandJoint.Elbow].Pose.rotation;
                 var elbowDirection = elbowRotation * Vector3.back;
                 var elbowLength = (elbowPosition - palmPosition).magnitude;
                 var centerPosition = (elbowPosition + palmPosition) / 2f;
@@ -294,9 +302,9 @@ namespace Ultraleap.Tracking.OpenXR
             }
             else
             {
-                var elbowRotation = joints[(int)HandJoint.Palm].Pose.rotation;
+                var elbowRotation = _joints[(int)HandJoint.Palm].Pose.rotation;
                 var elbowDirection = elbowRotation * Vector3.back;
-                var elbowPosition = joints[(int)HandJoint.Palm].Pose.position + (elbowDirection * 0.3f);
+                var elbowPosition = _joints[(int)HandJoint.Palm].Pose.position + (elbowDirection * 0.3f);
                 var elbowLength = 0.3f;
                 var centerPosition = (elbowPosition + palmPosition) / 2f;
                 hand.Arm.Fill(
@@ -324,9 +332,11 @@ namespace Ultraleap.Tracking.OpenXR
 
             // Compute the distance midpoints between the thumb and the each finger and find the smallest.
             var minDistanceSquared = float.MaxValue;
-            foreach (var finger in hand.Fingers.Skip(1))
+            
+            // Iterate through the fingers, skipping the thumb.
+            for (var i = 1; i < hand.Fingers.Count; ++i)
             {
-                var distanceSquared = (finger.TipPosition - thumbTipPosition).sqrMagnitude;
+                var distanceSquared = (hand.Fingers[i].TipPosition - thumbTipPosition).sqrMagnitude;
                 minDistanceSquared = Mathf.Min(distanceSquared, minDistanceSquared);
             }
 
@@ -361,11 +371,13 @@ namespace Ultraleap.Tracking.OpenXR
         {
             // Get the farthest 2 segments of thumb and index finger, respectively, and compute distances.
             var minDistanceSquared = float.MaxValue;
-            foreach (var thumbBone in hand.GetThumb().bones.Skip(2))
+            for (var thumbBoneIndex = 2; thumbBoneIndex < hand.GetThumb().bones.Length; ++thumbBoneIndex)
             {
-                foreach (var indexBone in hand.GetIndex().bones.Skip(2))
+                for (var indexBoneIndex = 2; indexBoneIndex < hand.GetIndex().bones.Length; ++indexBoneIndex)
                 {
-                    var distanceSquared = CalculateBoneDistanceSquared(thumbBone, indexBone);
+                    var distanceSquared = CalculateBoneDistanceSquared(
+                        hand.GetThumb().bones[thumbBoneIndex],
+                        hand.GetIndex().bones[indexBoneIndex]);
                     minDistanceSquared = Mathf.Min(distanceSquared, minDistanceSquared);
                 }
             }

--- a/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
+++ b/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
@@ -57,7 +57,7 @@ namespace Ultraleap.Tracking.OpenXR
             }
         }
 
-        private TrackedPoseDriver   _trackedPoseDriver;
+        private TrackedPoseDriver _trackedPoseDriver;
         private HandJointLocation[] _joints;
 
         public override TrackingSource TrackingDataSource { get { return CheckOpenXRAvailable(); } }
@@ -171,24 +171,26 @@ namespace Ultraleap.Tracking.OpenXR
                 return false;
             }
 
+            long currentDateTimeTicks = DateTime.Now.Ticks;
+
             float timeVisible = 0;
             if (handTracker == HandTracker.Left)
             {
                 if (_leftHandFirstSeen_ticks == -1)
                 {
-                    _leftHandFirstSeen_ticks = DateTime.Now.Ticks;
+                    _leftHandFirstSeen_ticks = currentDateTimeTicks;
                     _leftHandId = _handId++;
                 }
-                timeVisible = ((float)(DateTime.Now.Ticks - _leftHandFirstSeen_ticks)) / (float)TimeSpan.TicksPerSecond;
+                timeVisible = ((float)(currentDateTimeTicks - _leftHandFirstSeen_ticks)) / (float)TimeSpan.TicksPerSecond;
             }
             else
             {
                 if (_rightHandFirstSeen_ticks == -1)
                 {
-                    _rightHandFirstSeen_ticks = DateTime.Now.Ticks;
+                    _rightHandFirstSeen_ticks = currentDateTimeTicks;
                     _rightHandId = _handId++;
                 }
-                timeVisible = ((float)(DateTime.Now.Ticks - _rightHandFirstSeen_ticks)) /
+                timeVisible = ((float)(currentDateTimeTicks - _rightHandFirstSeen_ticks)) /
                               (float)TimeSpan.TicksPerSecond;
             }
 
@@ -232,7 +234,7 @@ namespace Ultraleap.Tracking.OpenXR
                         prevJoint.Radius * 2f,
                         (Bone.BoneType)boneIndex,
                         prevJoint.Pose.rotation);
-                    fingerWidth = Math.Max(fingerWidth, bone.Width);
+                    fingerWidth = Mathf.Max(fingerWidth, bone.Width);
                     xrTipIndex = xrNextIndex;
 
                     // Ignore metacarpals when calculating finger lengths

--- a/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
+++ b/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
@@ -17,7 +17,6 @@ namespace Ultraleap.Tracking.OpenXR
     {
         private LeapTransform trackerTransform = new LeapTransform(Vector3.zero, Quaternion.identity);
         
-        private Frame _updateFrame = new Frame();
         private Frame _currentFrame = new Frame();
 
         private Hand _leftHand = new Hand();
@@ -101,7 +100,11 @@ namespace Ultraleap.Tracking.OpenXR
 
         private void Update()
         {
-            PopulateLeapFrame(ref _updateFrame);
+            PopulateLeapFrame(ref _currentFrame);
+
+            trackerTransform.translation = Vector3.zero;
+            trackerTransform.rotation = Quaternion.identity;
+            trackerTransform.scale = mainCamera.transform.lossyScale;
 
             // Adjust for relative transform if it's in use.
             if (_trackedPoseDriver != null && _trackedPoseDriver.UseRelativeTransform)
@@ -116,14 +119,8 @@ namespace Ultraleap.Tracking.OpenXR
             {
                 trackerTransform.translation += parentTransform.position;
                 trackerTransform.rotation *= parentTransform.rotation;
-                trackerTransform.scale = parentTransform.lossyScale;
-            }
-            else
-            {
-                trackerTransform.scale = transform.lossyScale;
             }
 
-            _currentFrame = _updateFrame;
             _currentFrame.Transform(trackerTransform);
 
             DispatchUpdateFrameEvent(_currentFrame);


### PR DESCRIPTION
## Summary

Remove unneeded allocations in the `OpenXRLeapProvider`. This was leading to performance degradation and garbage collection which could be avoided.

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [ ] Pair review with a member of the QA team.
- [x] Add any release testing considerations to the MR for the next release.
- [x] Check any relevant CHANGELOG files have been updated.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.
- [ ] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [ ] Checked and agree with release testing considerations added to MR for the next release.

## Closes JIRA Issue

Closes UNITY-1059