### PR TITLE
Grab ball dynamically respects interaction zone

### DIFF
--- a/Packages/Tracking/Examples~/Example Assets/3D Interaction/Prefabs/Grab Ball.prefab
+++ b/Packages/Tracking/Examples~/Example Assets/3D Interaction/Prefabs/Grab Ball.prefab
@@ -331,6 +331,7 @@ MonoBehaviour:
   useAttachedObjectsXRotation: 1
   xRotation: 25
   restrictGrabBallDistanceFromHead: 1
+  dynamicallyLimitHeadDistance: 1
   maxHorizontalDistanceFromHead: 0.5
   minHorizontalDistanceFromHead: 0.1
   maxHeightFromHead: 0.3
@@ -350,10 +351,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   useHover: 0
   usePrimaryHover: 1
+  useGrasp: 1
   defaultColor: {r: 0, g: 0.9215687, b: 0.5215686, a: 1}
   suspendedColor: {r: 1, g: 0, b: 0, a: 1}
-  hoverColor: {r: 0.65882355, g: 0.18431373, b: 0.93725497, a: 1}
-  primaryHoverColor: {r: 1, g: 0.5529412, b: 0, a: 1}
+  graspColor: {r: 1, g: 0.5529412, b: 0, a: 1}
+  hoverColor: {r: 0.654902, g: 0.18431373, b: 0.9294118, a: 1}
   pressedColor: {r: 0.65882355, g: 0.18431373, b: 0.93725497, a: 1}
   rends:
   - materialID: 0

--- a/Packages/Tracking/Examples~/Example Assets/3D Interaction/Scripts/SimpleGrabBallFeedback.cs
+++ b/Packages/Tracking/Examples~/Example Assets/3D Interaction/Scripts/SimpleGrabBallFeedback.cs
@@ -54,8 +54,6 @@ namespace Leap.InteractionEngine.Examples
                 return;
             }
 
-            defaultMesh.transform.rotation = LookAtRotationParallelToHorizon(defaultMesh.transform.position, Camera.main.transform.position);
-
             bool expanded = grabBall.grabBallInteractionBehaviour.closestHoveringControllerDistance < distanceToScaleGrabBall;
             defaultMesh.transform.localScale = Vector3.Lerp(defaultMesh.transform.localScale, (expanded) ? expandedScale : minimisedScale, Time.deltaTime * lerpTime);
 
@@ -69,11 +67,6 @@ namespace Leap.InteractionEngine.Examples
             {
                 ghostedMesh.gameObject.SetActive(false);
             }
-        }
-
-        private Quaternion LookAtRotationParallelToHorizon(Vector3 posA, Vector3 posB)
-        {
-            return Quaternion.AngleAxis(Quaternion.LookRotation((posA - posB).normalized).eulerAngles.y, Vector3.up);
         }
     }
 }

--- a/Packages/Tracking/Examples~/Example Assets/Common Example Assets/Scripts/SimpleInteractionGlow.cs
+++ b/Packages/Tracking/Examples~/Example Assets/Common Example Assets/Scripts/SimpleInteractionGlow.cs
@@ -27,10 +27,14 @@ namespace Leap.Unity.InteractionEngine.Examples
         [Tooltip("If enabled, the object will use its primaryHoverColor when the primary hover of an InteractionHand.")]
         public bool usePrimaryHover = false;
 
+        [Tooltip("If enabled, the object will use its graspColor when grasped by an InteractionHand.")]
+        public bool useGrasp = false;
+
         [Header("InteractionBehaviour Colors")]
         public Color defaultColor = Color.Lerp(Color.black, Color.white, 0.1F);
 
         public Color suspendedColor = Color.red;
+        public Color graspColor = Color.Lerp(Color.black, Color.white, 0.9F);
         public Color hoverColor = Color.Lerp(Color.black, Color.white, 0.7F);
         public Color primaryHoverColor = Color.Lerp(Color.black, Color.white, 0.8F);
 
@@ -95,6 +99,11 @@ namespace Leap.Unity.InteractionEngine.Examples
                     }
                 }
 
+                if (_intObj.isGrasped && useGrasp)
+                {
+                    targetColor = graspColor;
+                }
+
                 if (_intObj.isSuspended)
                 {
                     // If the object is held by only one hand and that holding hand stops tracking, the
@@ -114,7 +123,7 @@ namespace Leap.Unity.InteractionEngine.Examples
                 // Lerp actual material color to the target color.
                 for (int i = 0; i < _materials.Length; i++)
                 {
-                    _materials[i].color = Color.Lerp(_materials[i].color, targetColor, 30F * Time.deltaTime);
+                    _materials[i].color = Color.Lerp(_materials[i].color, targetColor, 10F * Time.deltaTime);
                 }
             }
         }

--- a/Packages/Tracking/Interaction Engine/Editor/GrabBallEditor.cs
+++ b/Packages/Tracking/Interaction Engine/Editor/GrabBallEditor.cs
@@ -18,6 +18,7 @@ namespace Leap.Unity.Interaction
         SerializedProperty _useAttachedObjectsXRotation;
         SerializedProperty _xRotation;
         SerializedProperty _restrictGrabBallDistanceFromHead;
+        SerializedProperty _dynamicallyLimitHeadDistance;
         SerializedProperty _maxHorizontalDistanceFromHead;
         SerializedProperty _minHorizontalDistanceFromHead;
         SerializedProperty _maxHeightFromHead;
@@ -68,6 +69,7 @@ namespace Leap.Unity.Interaction
             EditorGUILayout.PropertyField(_restrictGrabBallDistanceFromHead);
             if (_restrictGrabBallDistanceFromHead.boolValue)
             {
+                EditorGUILayout.PropertyField(_dynamicallyLimitHeadDistance);
                 GUILayout.Space(2.5f);
                 EditorGUILayout.PropertyField(_maxHorizontalDistanceFromHead);
                 EditorGUILayout.PropertyField(_minHorizontalDistanceFromHead);
@@ -91,6 +93,7 @@ namespace Leap.Unity.Interaction
             _useAttachedObjectsXRotation = serializedObject.FindProperty("useAttachedObjectsXRotation");
             _xRotation = serializedObject.FindProperty("xRotation");
             _restrictGrabBallDistanceFromHead = serializedObject.FindProperty("restrictGrabBallDistanceFromHead");
+            _dynamicallyLimitHeadDistance = serializedObject.FindProperty("dynamicallyLimitHeadDistance");
             _maxHorizontalDistanceFromHead = serializedObject.FindProperty("maxHorizontalDistanceFromHead");
             _minHorizontalDistanceFromHead = serializedObject.FindProperty("minHorizontalDistanceFromHead");
             _maxHeightFromHead = serializedObject.FindProperty("maxHeightFromHead");

--- a/Packages/Tracking/Interaction Engine/Runtime/Scripts/UI/GrabBall.cs
+++ b/Packages/Tracking/Interaction Engine/Runtime/Scripts/UI/GrabBall.cs
@@ -229,18 +229,24 @@ namespace Leap.Unity.Interaction
             if (restrictGrabBallDistanceFromHead || dynamicallyLimitHeadDistance)
             {
                 RestrictGrabBallPosition();
-            } 
+            }
             else
             {
                 grabBallPose.position = grabBallInteractionBehaviour.transform.position;
             }
 
             _transformHelper.position = grabBallPose.position;
-            if (updateRotation) grabBallPose.rotation = LookAtRotationParallelToHorizon(grabBallPose.position, _head.position);
+            if (updateRotation)
+            {
+                grabBallPose.rotation = LookAtRotationParallelToHorizon(grabBallPose.position, _head.position);
+            }
             _transformHelper.rotation = grabBallPose.rotation;
 
             _attachedObjectTargetPose.position = _transformHelper.TransformPoint(_attachedObjectOffset);
-            if (updateRotation) _attachedObjectTargetPose.rotation = Quaternion.Euler(xRotation, grabBallPose.rotation.eulerAngles.y, grabBallPose.rotation.eulerAngles.z);
+            if (updateRotation)
+            {
+                _attachedObjectTargetPose.rotation = Quaternion.Euler(xRotation, grabBallPose.rotation.eulerAngles.y, grabBallPose.rotation.eulerAngles.z);
+            }
         }
         private bool IsAttachedObjectCloseToTargetPose()
         {


### PR DESCRIPTION
Added an option in inspector to have the grab ball always respect the interaction zone regardless of currently being grabbed. Solves issues when moving away from the UI panel without an additional recenter option.

Also removed the orientation in SimpleGrabBallFeedback as it was not visible with the material used (and against our recommendations), and also added a grasp colour to SimpleInteractionGlow as this is more similar to how we have used grab balls in the past.