### PR TITLE
Enable mirrored hand tracking support

### DIFF
--- a/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
@@ -171,6 +171,10 @@ namespace Leap.Unity
         [SerializeField]
         protected float _physicsExtrapolationTime = 1.0f / 90.0f;
 
+        [Tooltip("Makes right hands track for left hands, and left hands track for right hands.")]
+        [SerializeField]
+        protected bool MirrorHandTracking = false;
+        
         #region Multiple Device
         public enum MultipleDeviceMode
         {
@@ -1042,7 +1046,19 @@ namespace Leap.Unity
 
         protected virtual void transformFrame(Frame source, Frame dest)
         {
-            dest.CopyFrom(source).Transform(new LeapTransform(transform));
+            var frameTransform = new LeapTransform(transform);
+
+            if (MirrorHandTracking)
+            {
+                foreach (Hand hand in source.Hands)
+                {
+                    hand.IsLeft = !hand.IsLeft;
+                }
+
+                frameTransform.MirrorX();
+            }
+
+            dest.CopyFrom(source).Transform(frameTransform);
         }
 
         private TrackingSource CheckLeapServiceAvailable()


### PR DESCRIPTION
## Summary

_Adds an option to make right hands track for left hands, and left hands track for right hands._

I've seen a couple people request this, and I think the Unreal plugin already supports this, but I wanted to enable the end user to be able to make their right hand work as their left hand and their left hand work as their right hand without having to rebind too much. 
![Mirrored Tracking](https://user-images.githubusercontent.com/5521574/216812830-f9705cf9-cee7-4535-8642-5cbf287b16e0.gif)



I did this by adding a checkbox to "Mirror Hand Tracking"
![image](https://user-images.githubusercontent.com/5521574/216812393-a96907f1-f122-40f1-8230-2a35187d7f92.png)

And I did this at the provider level in the transformFrame method, modifying the frames read from the device directly, which allows other things that depend on the provider such as physics hands to "automagically" support it.
![image](https://user-images.githubusercontent.com/5521574/216812449-719d2dda-597f-415b-9276-2dcad6c8893b.png)


I'm not sure if there's a better way to do this currently, but if there is a better way, I can implement those changes, or if this works and is acceptable I think a lot of users would be happy to have support for this. I'm also pretty new to Unity and Unity plugin development in general so if there's any changes or recommendations that should be made, please let me know! 



## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [ ] Pair review with a member of the QA team.
- [ ] Add any release testing considerations to the MR for the next release.
- [ ] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [ ] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [ ] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] Checked and agree with release testing considerations added to MR for the next release.

## Closes JIRA Issue

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_