### PR TITLE
Physics Hands - Minor fixes and adjustments.

### DIFF
--- a/Packages/Tracking Preview/Examples~/PhysicsHands/PhysicsHands.unity
+++ b/Packages/Tracking Preview/Examples~/PhysicsHands/PhysicsHands.unity
@@ -123,123 +123,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &14895152
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 14895154}
-  - component: {fileID: 14895153}
-  - component: {fileID: 14895155}
-  - component: {fileID: 14895156}
-  m_Layer: 0
-  m_Name: Left Middle Joint 2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!136 &14895153
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 14895152}
-  m_Material: {fileID: 1690218108}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.025400002
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.0087}
---- !u!4 &14895154
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 14895152}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.026330002}
-  m_LocalScale: {x: 1, y: 0.9999999, z: 0.9999999}
-  m_Children: []
-  m_Father: {fileID: 979227609}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &14895155
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 14895152}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 4.656617e-10, y: -0.00000000931323, z: 0.026330002}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &14895156
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 14895152}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2057484866}
-  _body: {fileID: 14895155}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 2
-  _joint: 2
 --- !u!1 &25869035
 GameObject:
   m_ObjectHideFlags: 0
@@ -352,123 +235,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 25869035}
   m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &32345355
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 32345357}
-  - component: {fileID: 32345356}
-  - component: {fileID: 32345358}
-  - component: {fileID: 32345359}
-  m_Layer: 0
-  m_Name: Right Pinky Joint 2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!136 &32345356
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 32345355}
-  m_Material: {fileID: 189111359}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.023960002
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.00798}
---- !u!4 &32345357
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 32345355}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.018110001}
-  m_LocalScale: {x: 1.0000001, y: 0.9999999, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1509403553}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &32345358
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 32345355}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.000000015832498, y: 0.00000000884757, z: 0.018110014}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000004}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &32345359
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 32345355}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2045161950}
-  _body: {fileID: 32345358}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 4
-  _joint: 2
 --- !u!1 &48836609
 GameObject:
   m_ObjectHideFlags: 0
@@ -609,241 +375,6 @@ Transform:
   m_Father: {fileID: 463914042}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &65960884
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 65960885}
-  - component: {fileID: 65960886}
-  - component: {fileID: 65960887}
-  - component: {fileID: 65960888}
-  m_Layer: 0
-  m_Name: Right Middle Joint 0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &65960885
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 65960884}
-  m_LocalRotation: {x: 0.07527792, y: -0.009242235, z: -0.073994935, w: 0.99437046}
-  m_LocalPosition: {x: -0.002788769, y: 0.0040000016, z: 0.023252115}
-  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
-  m_Children:
-  - {fileID: 1995389692}
-  m_Father: {fileID: 1085073651}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &65960886
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 65960884}
-  m_Material: {fileID: 189111359}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.052630004
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.022315001}
---- !u!171741748 &65960887
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 65960884}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.002788769, y: 0.0040000016, z: 0.023252115}
-  m_ParentAnchorRotation: {x: 0.075277954, y: -0.009242229, z: -0.07399494, w: 0.9943706}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -30
-    upperLimit: 80
-    stiffness: 200
-    damping: 1
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -15
-    upperLimit: 15
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &65960888
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 65960884}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2045161950}
-  _body: {fileID: 65960887}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 2
-  _joint: 0
---- !u!1 &71022532
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 71022534}
-  - component: {fileID: 71022533}
-  - component: {fileID: 71022535}
-  - component: {fileID: 71022536}
-  m_Layer: 0
-  m_Name: Left Pinky Joint 2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!136 &71022533
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 71022532}
-  m_Material: {fileID: 1324615029}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.023960002
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.00798}
---- !u!4 &71022534
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 71022532}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.018110001}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1973713156}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &71022535
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 71022532}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.000000013038521, y: 0.0000000020280109, z: 0.018110018}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &71022536
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 71022532}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 1552987639}
-  _body: {fileID: 71022535}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 4
-  _joint: 2
 --- !u!1 &77060052
 GameObject:
   m_ObjectHideFlags: 0
@@ -940,360 +471,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 77060052}
   m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &80499001
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 80499002}
-  - component: {fileID: 80499003}
-  - component: {fileID: 80499004}
-  - component: {fileID: 80499005}
-  m_Layer: 0
-  m_Name: Left Index Joint 1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &80499002
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 80499001}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.039780002}
-  m_LocalScale: {x: 0.99999964, y: 0.99999964, z: 0.99999976}
-  m_Children:
-  - {fileID: 1330061737}
-  m_Father: {fileID: 374448558}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &80499003
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 80499001}
-  m_Material: {fileID: 1690218108}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.03038
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.01119}
---- !u!171741748 &80499004
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 80499001}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.0000000041909525, y: -0.000000003725291, z: 0.039780017}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &80499005
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 80499001}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2057484866}
-  _body: {fileID: 80499004}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 1
-  _joint: 1
---- !u!1 &80816726
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 80816727}
-  - component: {fileID: 80816728}
-  - component: {fileID: 80816729}
-  - component: {fileID: 80816730}
-  m_Layer: 0
-  m_Name: Left Middle Joint 0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &80816727
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 80816726}
-  m_LocalRotation: {x: 0.07527789, y: 0.009242246, z: 0.073994935, w: 0.9943705}
-  m_LocalPosition: {x: 0.002788771, y: 0.0040000007, z: 0.023252115}
-  m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999999}
-  m_Children:
-  - {fileID: 246457847}
-  m_Father: {fileID: 889282513}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &80816728
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 80816726}
-  m_Material: {fileID: 1324615029}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.052630004
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.022315001}
---- !u!171741748 &80816729
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 80816726}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.002788771, y: 0.0040000007, z: 0.023252115}
-  m_ParentAnchorRotation: {x: 0.075277895, y: 0.0092422515, z: 0.073994935, w: 0.9943706}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -30
-    upperLimit: 80
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -15
-    upperLimit: 15
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &80816730
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 80816726}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 1552987639}
-  _body: {fileID: 80816729}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 2
-  _joint: 0
---- !u!1 &84440797
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 84440798}
-  - component: {fileID: 84440799}
-  - component: {fileID: 84440800}
-  - component: {fileID: 84440801}
-  m_Layer: 0
-  m_Name: Left Index Joint 1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &84440798
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 84440797}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.039780002}
-  m_LocalScale: {x: 0.99999964, y: 0.99999964, z: 0.99999976}
-  m_Children:
-  - {fileID: 1559450537}
-  m_Father: {fileID: 143027714}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &84440799
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 84440797}
-  m_Material: {fileID: 1324615029}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.03038
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.01119}
---- !u!171741748 &84440800
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 84440797}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.0000000041909525, y: -0.000000003725291, z: 0.039780017}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &84440801
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 84440797}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 1552987639}
-  _body: {fileID: 84440800}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 1
-  _joint: 1
 --- !u!1 &85926699
 GameObject:
   m_ObjectHideFlags: 0
@@ -1423,124 +600,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 100141845}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &102763815
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 102763816}
-  - component: {fileID: 102763817}
-  - component: {fileID: 102763818}
-  - component: {fileID: 102763819}
-  m_Layer: 0
-  m_Name: Right Ring Joint 0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &102763816
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 102763815}
-  m_LocalRotation: {x: 0.067679256, y: 0.06845519, z: -0.104890674, w: 0.9898138}
-  m_LocalPosition: {x: 0.017447188, y: 0.004000012, z: 0.017279157}
-  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
-  m_Children:
-  - {fileID: 1535878787}
-  m_Father: {fileID: 653981089}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &102763817
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 102763815}
-  m_Material: {fileID: 585538801}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.049370002
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.020685}
---- !u!171741748 &102763818
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 102763815}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.017447188, y: 0.004000012, z: 0.017279157}
-  m_ParentAnchorRotation: {x: 0.067679256, y: 0.06845519, z: -0.10489069, w: 0.9898139}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -30
-    upperLimit: 80
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -15
-    upperLimit: 15
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &102763819
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 102763815}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 575778803}
-  _body: {fileID: 102763818}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 3
-  _joint: 0
 --- !u!4 &115806331 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 882061859479617651, guid: 5fad9bc118c955741a03cf98cf3f0a46, type: 3}
@@ -1642,7 +701,7 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 135976652}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &143027713
+--- !u!1 &138166227
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1650,116 +709,246 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 143027714}
-  - component: {fileID: 143027715}
-  - component: {fileID: 143027716}
-  - component: {fileID: 143027717}
+  - component: {fileID: 138166229}
+  - component: {fileID: 138166228}
   m_Layer: 0
-  m_Name: Left Index Joint 0
+  m_Name: Right Hand
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &143027714
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 143027713}
-  m_LocalRotation: {x: 0.074111804, y: 0.08401716, z: -0.006266229, w: 0.99368477}
-  m_LocalPosition: {x: 0.023181278, y: 0.0020000078, z: 0.023149362}
-  m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999999}
-  m_Children:
-  - {fileID: 84440798}
-  m_Father: {fileID: 889282513}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &143027715
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 143027713}
-  m_Material: {fileID: 1324615029}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.047780003
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.019890001}
---- !u!171741748 &143027716
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 143027713}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.023181278, y: 0.0020000078, z: 0.023149362}
-  m_ParentAnchorRotation: {x: 0.07411182, y: 0.08401718, z: -0.006266229, w: 0.9936849}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -30
-    upperLimit: 80
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -15
-    upperLimit: 15
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &143027717
+--- !u!114 &138166228
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 143027713}
+  m_GameObject: {fileID: 138166227}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 445639c80127bbd44b6bd9d34463b470, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _physicsHand:
+    triggerDistance: 0.004
+    oldPosition: {x: 0, y: 0, z: 0}
+    gameObject: {fileID: 705853060}
+    rootObject: {fileID: 138166227}
+    transform: {fileID: 705853064}
+    palmBone: {fileID: 705853063}
+    palmBody: {fileID: 705853062}
+    palmCollider: {fileID: 705853061}
+    jointBones:
+    - {fileID: 1843646421}
+    - {fileID: 839701701}
+    - {fileID: 759660569}
+    - {fileID: 783923114}
+    - {fileID: 2117531309}
+    - {fileID: 1791223839}
+    - {fileID: 468922240}
+    - {fileID: 1851164606}
+    - {fileID: 781686256}
+    - {fileID: 863936986}
+    - {fileID: 218380739}
+    - {fileID: 197423089}
+    - {fileID: 491256546}
+    - {fileID: 1892537478}
+    - {fileID: 1623982462}
+    jointBodies:
+    - {fileID: 1843646420}
+    - {fileID: 839701700}
+    - {fileID: 759660568}
+    - {fileID: 783923113}
+    - {fileID: 2117531308}
+    - {fileID: 1791223838}
+    - {fileID: 468922239}
+    - {fileID: 1851164605}
+    - {fileID: 781686255}
+    - {fileID: 863936985}
+    - {fileID: 218380738}
+    - {fileID: 197423088}
+    - {fileID: 491256545}
+    - {fileID: 1892537477}
+    - {fileID: 1623982461}
+    jointColliders:
+    - {fileID: 1843646419}
+    - {fileID: 839701699}
+    - {fileID: 759660566}
+    - {fileID: 783923112}
+    - {fileID: 2117531307}
+    - {fileID: 1791223836}
+    - {fileID: 468922238}
+    - {fileID: 1851164604}
+    - {fileID: 781686253}
+    - {fileID: 863936984}
+    - {fileID: 218380737}
+    - {fileID: 197423086}
+    - {fileID: 491256544}
+    - {fileID: 1892537476}
+    - {fileID: 1623982459}
+    overRotationFrameCount: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+    defaultRotations:
+    - {x: -0.6644467, y: -0.34441155, z: -0.5637821, w: 0.34934357}
+    - {x: -0.19850887, y: -0.549382, z: -0.8101427, w: 0.04942213}
+    - {x: -0.095235884, y: -0.55546176, z: -0.82590574, w: 0.016494589}
+    - {x: -0.013266354, y: -0.54483914, z: -0.8380312, w: 0.026037607}
+    - {x: 0.08120667, y: -0.50801295, z: -0.85746795, w: -0.00878219}
+    - {x: -0.12940955, y: -0.4829629, z: -0.8627299, w: 0.07547912}
+    strength: 2
+    stiffness: 100
+    forceLimit: 1000
+    boneMass: 0.6
+    physicMaterial: {fileID: 1489137147}
+  _handedness: 1
+--- !u!4 &138166229
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 138166227}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 705853064}
+  m_Father: {fileID: 1874090592}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!134 &141484666
+PhysicMaterial:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Button Material
+  dynamicFriction: 1
+  staticFriction: 1
+  bounciness: 0
+  frictionCombine: 3
+  bounceCombine: 0
+--- !u!1 &141516353
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 141516357}
+  - component: {fileID: 141516355}
+  - component: {fileID: 141516354}
+  - component: {fileID: 141516356}
+  m_Layer: 0
+  m_Name: Left Palm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &141516354
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 141516353}
+  m_Material: {fileID: 232411772}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.0833, y: 0.025, z: 0.10353848}
+  m_Center: {x: 0, y: 0.0025, z: -0.015}
+--- !u!171741748 &141516355
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 141516353}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 1.8000001
+  m_ParentAnchorPosition: {x: 0, y: 0, z: 0}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_ComputeParentAnchor: 1
+  m_ArticulationJointType: 0
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 2
+  m_SwingZ: 2
+  m_Twist: 2
+  m_XDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 0
+    damping: 0
+    forceLimit: 3.4028235e+38
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 0
+    damping: 0
+    forceLimit: 3.4028235e+38
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 0
+    damping: 0
+    forceLimit: 3.4028235e+38
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 50
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &141516356
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 141516353}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _hand: {fileID: 1552987639}
-  _body: {fileID: 143027716}
+  _hand: {fileID: 1392200166}
+  _body: {fileID: 141516355}
   _origXDriveLimit: 0
   _currentXDriveLimit: 3.4028235e+38
-  _finger: 1
+  _finger: 5
   _joint: 0
+--- !u!4 &141516357
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 141516353}
+  m_LocalRotation: {x: -0.12940949, y: 0.48296294, z: 0.86272997, w: 0.07547909}
+  m_LocalPosition: {x: -0.21999998, y: -0.13000001, z: 0.27000004}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1811146118}
+  - {fileID: 1633464193}
+  - {fileID: 1312042431}
+  - {fileID: 401704354}
+  - {fileID: 1812239549}
+  m_Father: {fileID: 1392200167}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &149014349
 GameObject:
   m_ObjectHideFlags: 0
@@ -1959,124 +1148,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 178749804}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &182831393
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 182831394}
-  - component: {fileID: 182831395}
-  - component: {fileID: 182831396}
-  - component: {fileID: 182831397}
-  m_Layer: 0
-  m_Name: Right Pinky Joint 0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &182831394
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 182831393}
-  m_LocalRotation: {x: 0.029145695, y: 0.13843815, z: -0.17725913, w: 0.9739429}
-  m_LocalPosition: {x: 0.035337448, y: -0.000000009313226, z: 0.009728717}
-  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
-  m_Children:
-  - {fileID: 1509403553}
-  m_Father: {fileID: 1085073651}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &182831395
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 182831393}
-  m_Material: {fileID: 189111359}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.040740006
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.016370002}
---- !u!171741748 &182831396
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 182831393}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.035337463, y: -0.000000013038516, z: 0.009728714}
-  m_ParentAnchorRotation: {x: 0.029145688, y: 0.13843818, z: -0.17725915, w: 0.973943}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -30
-    upperLimit: 80
-    stiffness: 200
-    damping: 1
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -15
-    upperLimit: 15
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &182831397
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 182831393}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2045161950}
-  _body: {fileID: 182831396}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 4
-  _joint: 0
 --- !u!1 &187038646
 GameObject:
   m_ObjectHideFlags: 0
@@ -2189,136 +1260,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 187038646}
   m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
---- !u!134 &189111359
-PhysicMaterial:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: HandPhysics
-  dynamicFriction: 1
-  staticFriction: 1
-  bounciness: 0
-  frictionCombine: 0
-  bounceCombine: 1
---- !u!1 &190012336
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 190012337}
-  - component: {fileID: 190012338}
-  - component: {fileID: 190012339}
-  - component: {fileID: 190012340}
-  m_Layer: 0
-  m_Name: Right Middle Joint 0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &190012337
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 190012336}
-  m_LocalRotation: {x: 0.07527792, y: -0.009242235, z: -0.073994935, w: 0.99437046}
-  m_LocalPosition: {x: -0.002788769, y: 0.0040000016, z: 0.023252115}
-  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
-  m_Children:
-  - {fileID: 1993941822}
-  m_Father: {fileID: 653981089}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &190012338
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 190012336}
-  m_Material: {fileID: 585538801}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.052630004
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.022315001}
---- !u!171741748 &190012339
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 190012336}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.002788769, y: 0.0040000016, z: 0.023252115}
-  m_ParentAnchorRotation: {x: 0.075277954, y: -0.009242229, z: -0.07399494, w: 0.9943706}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -30
-    upperLimit: 80
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -15
-    upperLimit: 15
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &190012340
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 190012336}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 575778803}
-  _body: {fileID: 190012339}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 2
-  _joint: 0
 --- !u!1 &195425108
 GameObject:
   m_ObjectHideFlags: 0
@@ -2414,7 +1355,7 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 195425108}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &202587802
+--- !u!1 &197423085
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2422,61 +1363,60 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 202587803}
-  - component: {fileID: 202587804}
-  - component: {fileID: 202587805}
-  - component: {fileID: 202587806}
+  - component: {fileID: 197423087}
+  - component: {fileID: 197423086}
+  - component: {fileID: 197423088}
+  - component: {fileID: 197423089}
   m_Layer: 0
-  m_Name: Right Pinky Joint 1
+  m_Name: Right Ring Joint 2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &202587803
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 202587802}
-  m_LocalRotation: {x: -0, y: -0, z: 4.6566123e-10, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.032740004}
-  m_LocalScale: {x: 0.9999994, y: 0.99999964, z: 0.99999976}
-  m_Children:
-  - {fileID: 1462953422}
-  m_Father: {fileID: 1303817055}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &202587804
+--- !u!136 &197423086
 CapsuleCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 202587802}
-  m_Material: {fileID: 585538801}
+  m_GameObject: {fileID: 197423085}
+  m_Material: {fileID: 1489137147}
   m_IsTrigger: 0
   m_Enabled: 1
   m_Radius: 0.004
-  m_Height: 0.02611
+  m_Height: 0.0253
   m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.009055001}
---- !u!171741748 &202587805
+  m_Center: {x: 0, y: 0, z: 0.00865}
+--- !u!4 &197423087
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 197423085}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.02565}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 218380736}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!171741748 &197423088
 ArticulationBody:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 202587802}
+  m_GameObject: {fileID: 197423085}
   m_Enabled: 1
   serializedVersion: 3
   m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.000000022817412, y: -0.000000010069928, z: 0.03274001}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000004}
+  m_ParentAnchorPosition: {x: 0.000000005587938, y: -0.000000020489102, z: 0.02565001}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
+  m_ComputeParentAnchor: 0
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -2514,24 +1454,24 @@ ArticulationBody:
   m_Immovable: 0
   m_UseGravity: 0
   m_CollisionDetectionMode: 3
---- !u!114 &202587806
+--- !u!114 &197423089
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 202587802}
+  m_GameObject: {fileID: 197423085}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _hand: {fileID: 575778803}
-  _body: {fileID: 202587805}
+  _hand: {fileID: 138166228}
+  _body: {fileID: 197423088}
   _origXDriveLimit: 0
   _currentXDriveLimit: 3.4028235e+38
-  _finger: 4
-  _joint: 1
+  _finger: 3
+  _joint: 2
 --- !u!1 &207924400
 GameObject:
   m_ObjectHideFlags: 0
@@ -2700,7 +1640,7 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 217433089}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &221313056
+--- !u!1 &218380735
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2708,57 +1648,58 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 221313058}
-  - component: {fileID: 221313057}
-  - component: {fileID: 221313059}
-  - component: {fileID: 221313060}
+  - component: {fileID: 218380736}
+  - component: {fileID: 218380737}
+  - component: {fileID: 218380738}
+  - component: {fileID: 218380739}
   m_Layer: 0
-  m_Name: Right Pinky Joint 2
+  m_Name: Right Ring Joint 1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!136 &221313057
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 221313056}
-  m_Material: {fileID: 1081093971}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.023960002
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.00798}
---- !u!4 &221313058
+--- !u!4 &218380736
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 221313056}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.018110001}
-  m_LocalScale: {x: 1.0000001, y: 0.9999999, z: 1}
-  m_Children: []
-  m_Father: {fileID: 436964832}
+  m_GameObject: {fileID: 218380735}
+  m_LocalRotation: {x: -0, y: -0, z: -0.0000000018626451, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.04137}
+  m_LocalScale: {x: 0.9999999, y: 1, z: 0.9999999}
+  m_Children:
+  - {fileID: 197423087}
+  m_Father: {fileID: 863936983}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &221313059
+--- !u!136 &218380737
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 218380735}
+  m_Material: {fileID: 1489137147}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.03365
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.012825}
+--- !u!171741748 &218380738
 ArticulationBody:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 221313056}
+  m_GameObject: {fileID: 218380735}
   m_Enabled: 1
   serializedVersion: 3
   m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.000000015832498, y: 0.00000000884757, z: 0.018110014}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000004}
+  m_ParentAnchorPosition: {x: 0.000000012107198, y: -0.000000013504181, z: 0.041370012}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
   m_ComputeParentAnchor: 0
@@ -2799,24 +1740,24 @@ ArticulationBody:
   m_Immovable: 0
   m_UseGravity: 0
   m_CollisionDetectionMode: 3
---- !u!114 &221313060
+--- !u!114 &218380739
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 221313056}
+  m_GameObject: {fileID: 218380735}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _hand: {fileID: 2127376581}
-  _body: {fileID: 221313059}
+  _hand: {fileID: 138166228}
+  _body: {fileID: 218380738}
   _origXDriveLimit: 0
   _currentXDriveLimit: 3.4028235e+38
-  _finger: 4
-  _joint: 2
+  _finger: 3
+  _joint: 1
 --- !u!1 &221939407
 GameObject:
   m_ObjectHideFlags: 0
@@ -2912,241 +1853,18 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 221939407}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &226590105
-GameObject:
+--- !u!134 &232411772
+PhysicMaterial:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 226590106}
-  - component: {fileID: 226590107}
-  - component: {fileID: 226590108}
-  - component: {fileID: 226590109}
-  m_Layer: 0
-  m_Name: Left Thumb Joint 0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &226590106
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 226590105}
-  m_LocalRotation: {x: 0.019904852, y: 0.35755512, z: -0.53516835, w: 0.7650836}
-  m_LocalPosition: {x: 0.019338273, y: -0.006000001, z: -0.053168494}
-  m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999999}
-  m_Children:
-  - {fileID: 1435153063}
-  m_Father: {fileID: 1921003926}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &226590107
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 226590105}
-  m_Material: {fileID: 2041109289}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.054220006
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.023110002}
---- !u!171741748 &226590108
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 226590105}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.019338273, y: -0.0059999935, z: -0.053168505}
-  m_ParentAnchorRotation: {x: 0.019904822, y: 0.35755518, z: -0.5351684, w: 0.7650837}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -45
-    upperLimit: 45
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -10
-    upperLimit: 50
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &226590109
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 226590105}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 1656071730}
-  _body: {fileID: 226590108}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 0
-  _joint: 0
---- !u!1 &236780703
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 236780705}
-  - component: {fileID: 236780704}
-  - component: {fileID: 236780706}
-  - component: {fileID: 236780707}
-  m_Layer: 0
-  m_Name: Left Thumb Joint 2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!136 &236780704
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 236780703}
-  m_Material: {fileID: 1324615029}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.02967
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.010835}
---- !u!4 &236780705
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 236780703}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.031570002}
-  m_LocalScale: {x: 1, y: 1.0000001, z: 1.0000001}
-  m_Children: []
-  m_Father: {fileID: 1945723378}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &236780706
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 236780703}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.000000009313227, y: -0.0000000037252916, z: 0.03157001}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 2
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &236780707
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 236780703}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 1552987639}
-  _body: {fileID: 236780706}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 0
-  _joint: 2
+  m_Name: HandPhysics
+  dynamicFriction: 1
+  staticFriction: 1
+  bounciness: 0
+  frictionCombine: 0
+  bounceCombine: 1
 --- !u!1 &239016654
 GameObject:
   m_ObjectHideFlags: 0
@@ -3305,124 +2023,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   anchor: {fileID: 2129453843}
   player: {fileID: 463914037}
---- !u!1 &246457846
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 246457847}
-  - component: {fileID: 246457848}
-  - component: {fileID: 246457849}
-  - component: {fileID: 246457850}
-  m_Layer: 0
-  m_Name: Left Middle Joint 1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &246457847
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 246457846}
-  m_LocalRotation: {x: -0, y: -0, z: -0.000000001513399, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.044630002}
-  m_LocalScale: {x: 0.9999995, y: 0.99999976, z: 0.9999999}
-  m_Children:
-  - {fileID: 928808897}
-  m_Father: {fileID: 80816727}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &246457848
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 246457846}
-  m_Material: {fileID: 1324615029}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.034330003
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.013165001}
---- !u!171741748 &246457849
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 246457846}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.0000000047730295, y: -0.000000018160794, z: 0.044630006}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &246457850
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 246457846}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 1552987639}
-  _body: {fileID: 246457849}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 2
-  _joint: 1
 --- !u!1 &254592135
 GameObject:
   m_ObjectHideFlags: 0
@@ -3630,7 +2230,7 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 259186204}
   m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &268531133
+--- !u!1 &290336277
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3638,10 +2238,10 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 268531134}
-  - component: {fileID: 268531135}
-  - component: {fileID: 268531136}
-  - component: {fileID: 268531137}
+  - component: {fileID: 290336278}
+  - component: {fileID: 290336279}
+  - component: {fileID: 290336280}
+  - component: {fileID: 290336281}
   m_Layer: 0
   m_Name: Left Ring Joint 1
   m_TagString: Untagged
@@ -3649,164 +2249,47 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &268531134
+--- !u!4 &290336278
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 268531133}
+  m_GameObject: {fileID: 290336277}
   m_LocalRotation: {x: -0, y: -0, z: -4.656613e-10, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0.04137}
   m_LocalScale: {x: 0.99999976, y: 1, z: 1}
   m_Children:
-  - {fileID: 1523185468}
-  m_Father: {fileID: 1349590843}
+  - {fileID: 912663688}
+  m_Father: {fileID: 401704354}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &268531135
+--- !u!136 &290336279
 CapsuleCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 268531133}
-  m_Material: {fileID: 2041109289}
+  m_GameObject: {fileID: 290336277}
+  m_Material: {fileID: 232411772}
   m_IsTrigger: 0
   m_Enabled: 1
   m_Radius: 0.004
   m_Height: 0.03365
   m_Direction: 2
   m_Center: {x: 0, y: 0, z: 0.012825}
---- !u!171741748 &268531136
+--- !u!171741748 &290336280
 ArticulationBody:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 268531133}
+  m_GameObject: {fileID: 290336277}
   m_Enabled: 1
   serializedVersion: 3
   m_Mass: 0.6
   m_ParentAnchorPosition: {x: -0.0000000093132275, y: -0.000000015366826, z: 0.04137001}
   m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &268531137
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 268531133}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 1656071730}
-  _body: {fileID: 268531136}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 3
-  _joint: 1
---- !u!1 &302522887
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 302522889}
-  - component: {fileID: 302522888}
-  - component: {fileID: 302522890}
-  - component: {fileID: 302522891}
-  m_Layer: 0
-  m_Name: Right Middle Joint 2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!136 &302522888
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 302522887}
-  m_Material: {fileID: 1081093971}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.025400002
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.0087}
---- !u!4 &302522889
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 302522887}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.026330002}
-  m_LocalScale: {x: 1.0000001, y: 1.0000001, z: 1.0000001}
-  m_Children: []
-  m_Father: {fileID: 1077167462}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &302522890
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 302522887}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 2.3283078e-10, y: 0.0000000055879377, z: 0.026330026}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
   m_ComputeParentAnchor: 0
@@ -3847,141 +2330,23 @@ ArticulationBody:
   m_Immovable: 0
   m_UseGravity: 0
   m_CollisionDetectionMode: 3
---- !u!114 &302522891
+--- !u!114 &290336281
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 302522887}
+  m_GameObject: {fileID: 290336277}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _hand: {fileID: 2127376581}
-  _body: {fileID: 302522890}
+  _hand: {fileID: 1392200166}
+  _body: {fileID: 290336280}
   _origXDriveLimit: 0
   _currentXDriveLimit: 3.4028235e+38
-  _finger: 2
-  _joint: 2
---- !u!1 &315683682
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 315683683}
-  - component: {fileID: 315683684}
-  - component: {fileID: 315683685}
-  - component: {fileID: 315683686}
-  m_Layer: 0
-  m_Name: Left Pinky Joint 1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &315683683
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 315683682}
-  m_LocalRotation: {x: -0.0000000018626449, y: -0, z: -0.000000006053596, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.032740004}
-  m_LocalScale: {x: 0.9999999, y: 1, z: 1}
-  m_Children:
-  - {fileID: 2115103741}
-  m_Father: {fileID: 891900967}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &315683684
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 315683682}
-  m_Material: {fileID: 2041109289}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.02611
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.009055001}
---- !u!171741748 &315683685
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 315683682}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.000000017695132, y: -0.0000000137370115, z: 0.03274001}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &315683686
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 315683682}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 1656071730}
-  _body: {fileID: 315683685}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 4
+  _finger: 3
   _joint: 1
 --- !u!1 &320794400
 GameObject:
@@ -4078,360 +2443,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 320794400}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &334822912
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 334822913}
-  - component: {fileID: 334822914}
-  - component: {fileID: 334822915}
-  - component: {fileID: 334822916}
-  m_Layer: 0
-  m_Name: Right Index Joint 1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &334822913
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 334822912}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.039780002}
-  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 0.99999976}
-  m_Children:
-  - {fileID: 1830967253}
-  m_Father: {fileID: 2080805427}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &334822914
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 334822912}
-  m_Material: {fileID: 189111359}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.03038
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.01119}
---- !u!171741748 &334822915
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 334822912}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.000000030267994, y: -0.00000002328307, z: 0.039780017}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &334822916
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 334822912}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2045161950}
-  _body: {fileID: 334822915}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 1
-  _joint: 1
---- !u!1 &356802675
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 356802676}
-  - component: {fileID: 356802677}
-  - component: {fileID: 356802678}
-  - component: {fileID: 356802679}
-  m_Layer: 0
-  m_Name: Left Middle Joint 1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &356802676
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 356802675}
-  m_LocalRotation: {x: -0, y: -0, z: -0.000000001513399, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.044630002}
-  m_LocalScale: {x: 0.9999995, y: 0.99999976, z: 0.9999999}
-  m_Children:
-  - {fileID: 1883123094}
-  m_Father: {fileID: 1331277409}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &356802677
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 356802675}
-  m_Material: {fileID: 2041109289}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.034330003
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.013165001}
---- !u!171741748 &356802678
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 356802675}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.0000000047730295, y: -0.000000018160794, z: 0.044630006}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &356802679
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 356802675}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 1656071730}
-  _body: {fileID: 356802678}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 2
-  _joint: 1
---- !u!1 &374448557
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 374448558}
-  - component: {fileID: 374448559}
-  - component: {fileID: 374448560}
-  - component: {fileID: 374448561}
-  m_Layer: 0
-  m_Name: Left Index Joint 0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &374448558
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 374448557}
-  m_LocalRotation: {x: 0.074111804, y: 0.08401716, z: -0.006266229, w: 0.99368477}
-  m_LocalPosition: {x: 0.023181278, y: 0.0020000078, z: 0.023149362}
-  m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999999}
-  m_Children:
-  - {fileID: 80499002}
-  m_Father: {fileID: 632214914}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &374448559
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 374448557}
-  m_Material: {fileID: 1690218108}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.047780003
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.019890001}
---- !u!171741748 &374448560
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 374448557}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.023181278, y: 0.0020000078, z: 0.023149362}
-  m_ParentAnchorRotation: {x: 0.07411182, y: 0.08401718, z: -0.006266229, w: 0.9936849}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -30
-    upperLimit: 80
-    stiffness: 200
-    damping: 1
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -15
-    upperLimit: 15
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &374448561
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 374448557}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2057484866}
-  _body: {fileID: 374448560}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 1
-  _joint: 0
 --- !u!1001 &395359349
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6721,6 +4732,124 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
+--- !u!1 &401704353
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 401704354}
+  - component: {fileID: 401704355}
+  - component: {fileID: 401704356}
+  - component: {fileID: 401704357}
+  m_Layer: 0
+  m_Name: Left Ring Joint 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &401704354
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 401704353}
+  m_LocalRotation: {x: 0.06767923, y: -0.06845519, z: 0.104890674, w: 0.9898138}
+  m_LocalPosition: {x: -0.017447187, y: 0.0040000137, z: 0.01727916}
+  m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999999}
+  m_Children:
+  - {fileID: 290336278}
+  m_Father: {fileID: 141516357}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &401704355
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 401704353}
+  m_Material: {fileID: 232411772}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.049370002
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.020685}
+--- !u!171741748 &401704356
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 401704353}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.017447187, y: 0.0040000137, z: 0.01727916}
+  m_ParentAnchorRotation: {x: 0.067679256, y: -0.06845519, z: 0.10489069, w: 0.9898139}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -30
+    upperLimit: 80
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -15
+    upperLimit: 15
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &401704357
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 401704353}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 1392200166}
+  _body: {fileID: 401704356}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 3
+  _joint: 0
 --- !u!1 &415101508
 GameObject:
   m_ObjectHideFlags: 0
@@ -6975,13 +5104,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 42bf16dc17d04074399626551f65de64, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _physicsHand: {fileID: 1656071730}
+  _physicsHand: {fileID: 0}
   _handModel: {fileID: 7337961843106110330}
   _alpha: 0.05
   _minimumDistance: 0.02
   _maximumDistance: 0.08
   _lerpTime: 0.1
---- !u!1 &436964831
+--- !u!1 &441012507
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -6989,180 +5118,61 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 436964832}
-  - component: {fileID: 436964833}
-  - component: {fileID: 436964834}
-  - component: {fileID: 436964835}
+  - component: {fileID: 441012509}
+  - component: {fileID: 441012508}
+  - component: {fileID: 441012510}
+  - component: {fileID: 441012511}
   m_Layer: 0
-  m_Name: Right Pinky Joint 1
+  m_Name: Left Thumb Joint 2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &436964832
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 436964831}
-  m_LocalRotation: {x: -0, y: -0, z: 4.6566123e-10, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.032740004}
-  m_LocalScale: {x: 0.9999994, y: 0.99999964, z: 0.99999976}
-  m_Children:
-  - {fileID: 221313058}
-  m_Father: {fileID: 971476548}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &436964833
+--- !u!136 &441012508
 CapsuleCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 436964831}
-  m_Material: {fileID: 1081093971}
+  m_GameObject: {fileID: 441012507}
+  m_Material: {fileID: 232411772}
   m_IsTrigger: 0
   m_Enabled: 1
   m_Radius: 0.004
-  m_Height: 0.02611
+  m_Height: 0.02967
   m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.009055001}
---- !u!171741748 &436964834
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 436964831}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.000000022817412, y: -0.000000010069928, z: 0.03274001}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000004}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &436964835
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 436964831}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2127376581}
-  _body: {fileID: 436964834}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 4
-  _joint: 1
---- !u!1 &439291897
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 439291898}
-  - component: {fileID: 439291899}
-  - component: {fileID: 439291900}
-  - component: {fileID: 439291901}
-  m_Layer: 0
-  m_Name: Left Pinky Joint 1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &439291898
+  m_Center: {x: 0, y: 0, z: 0.010835}
+--- !u!4 &441012509
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 439291897}
-  m_LocalRotation: {x: -0.0000000018626449, y: -0, z: -0.000000006053596, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.032740004}
-  m_LocalScale: {x: 0.9999999, y: 1, z: 1}
-  m_Children:
-  - {fileID: 864411119}
-  m_Father: {fileID: 1997924415}
+  m_GameObject: {fileID: 441012507}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.031570002}
+  m_LocalScale: {x: 1, y: 1.0000001, z: 1.0000001}
+  m_Children: []
+  m_Father: {fileID: 1259386102}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &439291899
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 439291897}
-  m_Material: {fileID: 1690218108}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.02611
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.009055001}
---- !u!171741748 &439291900
+--- !u!171741748 &441012510
 ArticulationBody:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 439291897}
+  m_GameObject: {fileID: 441012507}
   m_Enabled: 1
   serializedVersion: 3
   m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.000000017695132, y: -0.0000000137370115, z: 0.03274001}
+  m_ParentAnchorPosition: {x: -0.000000009313227, y: -0.0000000037252916, z: 0.03157001}
   m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
   m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
+  m_ArticulationJointType: 2
   m_LinearX: 2
   m_LinearY: 2
   m_LinearZ: 2
@@ -7174,7 +5184,7 @@ ArticulationBody:
     upperLimit: 89
     stiffness: 200
     damping: 1
-    forceLimit: 100000
+    forceLimit: 180001.81
     target: 0
     targetVelocity: 0
   m_YDrive:
@@ -7182,7 +5192,7 @@ ArticulationBody:
     upperLimit: 8
     stiffness: 200
     damping: 2
-    forceLimit: 100000
+    forceLimit: 180001.81
     target: 0
     targetVelocity: 0
   m_ZDrive:
@@ -7190,7 +5200,7 @@ ArticulationBody:
     upperLimit: 0
     stiffness: 200
     damping: 2
-    forceLimit: 100000
+    forceLimit: 180001.81
     target: 0
     targetVelocity: 0
   m_LinearDamping: 0
@@ -7199,24 +5209,24 @@ ArticulationBody:
   m_Immovable: 0
   m_UseGravity: 0
   m_CollisionDetectionMode: 3
---- !u!114 &439291901
+--- !u!114 &441012511
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 439291897}
+  m_GameObject: {fileID: 441012507}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _hand: {fileID: 2057484866}
-  _body: {fileID: 439291900}
+  _hand: {fileID: 1392200166}
+  _body: {fileID: 441012510}
   _origXDriveLimit: 0
   _currentXDriveLimit: 3.4028235e+38
-  _finger: 4
-  _joint: 1
+  _finger: 0
+  _joint: 2
 --- !u!1 &461023103
 GameObject:
   m_ObjectHideFlags: 0
@@ -7268,123 +5278,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 87e704a32bb13db4381cb8507400082c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &462755183
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 462755185}
-  - component: {fileID: 462755184}
-  - component: {fileID: 462755186}
-  - component: {fileID: 462755187}
-  m_Layer: 0
-  m_Name: Left Ring Joint 2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!136 &462755184
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 462755183}
-  m_Material: {fileID: 1324615029}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.0253
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.00865}
---- !u!4 &462755185
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 462755183}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.02565}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1642491618}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &462755186
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 462755183}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 9.31323e-10, y: -0.000000025145715, z: 0.02565002}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &462755187
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 462755183}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 1552987639}
-  _body: {fileID: 462755186}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 3
-  _joint: 2
 --- !u!1 &463914037
 GameObject:
   m_ObjectHideFlags: 0
@@ -7506,11 +5399,247 @@ Transform:
   m_Father: {fileID: 244881942}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &468922236
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 468922237}
+  - component: {fileID: 468922238}
+  - component: {fileID: 468922239}
+  - component: {fileID: 468922240}
+  m_Layer: 0
+  m_Name: Right Middle Joint 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &468922237
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 468922236}
+  m_LocalRotation: {x: 0.07527792, y: -0.009242235, z: -0.073994935, w: 0.99437046}
+  m_LocalPosition: {x: -0.002788769, y: 0.0040000016, z: 0.023252115}
+  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
+  m_Children:
+  - {fileID: 1851164603}
+  m_Father: {fileID: 705853064}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &468922238
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 468922236}
+  m_Material: {fileID: 1489137147}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.052630004
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.022315001}
+--- !u!171741748 &468922239
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 468922236}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.002788769, y: 0.0040000016, z: 0.023252115}
+  m_ParentAnchorRotation: {x: 0.075277954, y: -0.009242229, z: -0.07399494, w: 0.9943706}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -30
+    upperLimit: 80
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -15
+    upperLimit: 15
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &468922240
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 468922236}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 138166228}
+  _body: {fileID: 468922239}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 2
+  _joint: 0
 --- !u!4 &484297172 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 7430377636917100820, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
   m_PrefabInstance: {fileID: 395359349}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &491256542
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 491256543}
+  - component: {fileID: 491256544}
+  - component: {fileID: 491256545}
+  - component: {fileID: 491256546}
+  m_Layer: 0
+  m_Name: Right Pinky Joint 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &491256543
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 491256542}
+  m_LocalRotation: {x: 0.029145695, y: 0.13843815, z: -0.17725913, w: 0.9739429}
+  m_LocalPosition: {x: 0.035337448, y: -0.000000009313226, z: 0.009728717}
+  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
+  m_Children:
+  - {fileID: 1892537475}
+  m_Father: {fileID: 705853064}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &491256544
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 491256542}
+  m_Material: {fileID: 1489137147}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.040740006
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.016370002}
+--- !u!171741748 &491256545
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 491256542}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 0.035337463, y: -0.000000013038516, z: 0.009728714}
+  m_ParentAnchorRotation: {x: 0.029145688, y: 0.13843818, z: -0.17725915, w: 0.973943}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -30
+    upperLimit: 80
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -15
+    upperLimit: 15
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &491256546
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 491256542}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 138166228}
+  _body: {fileID: 491256545}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 4
+  _joint: 0
 --- !u!1 &497145779
 GameObject:
   m_ObjectHideFlags: 0
@@ -7683,124 +5812,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!1 &513332372
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 513332373}
-  - component: {fileID: 513332374}
-  - component: {fileID: 513332375}
-  - component: {fileID: 513332376}
-  m_Layer: 0
-  m_Name: Right Index Joint 0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &513332373
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 513332372}
-  m_LocalRotation: {x: 0.07411184, y: -0.08401716, z: 0.0062662363, w: 0.99368477}
-  m_LocalPosition: {x: -0.023181278, y: 0.0020000078, z: 0.023149364}
-  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
-  m_Children:
-  - {fileID: 517433465}
-  m_Father: {fileID: 1384551531}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &513332374
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 513332372}
-  m_Material: {fileID: 1081093971}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.047780003
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.019890001}
---- !u!171741748 &513332375
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 513332372}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.023181293, y: 0.0020000115, z: 0.023149366}
-  m_ParentAnchorRotation: {x: 0.07411185, y: -0.08401715, z: 0.0062662363, w: 0.9936849}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -30
-    upperLimit: 80
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -15
-    upperLimit: 15
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &513332376
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 513332372}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2127376581}
-  _body: {fileID: 513332375}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 1
-  _joint: 0
 --- !u!1 &513771341
 GameObject:
   m_ObjectHideFlags: 0
@@ -7896,124 +5907,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 513771341}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &517433464
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 517433465}
-  - component: {fileID: 517433466}
-  - component: {fileID: 517433467}
-  - component: {fileID: 517433468}
-  m_Layer: 0
-  m_Name: Right Index Joint 1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &517433465
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 517433464}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.039780002}
-  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 0.99999976}
-  m_Children:
-  - {fileID: 1305726773}
-  m_Father: {fileID: 513332373}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &517433466
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 517433464}
-  m_Material: {fileID: 1081093971}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.03038
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.01119}
---- !u!171741748 &517433467
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 517433464}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.000000030267994, y: -0.00000002328307, z: 0.039780017}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &517433468
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 517433464}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2127376581}
-  _body: {fileID: 517433467}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 1
-  _joint: 1
 --- !u!1 &518429782
 GameObject:
   m_ObjectHideFlags: 0
@@ -8046,121 +5939,6 @@ Transform:
   m_Father: {fileID: 461023104}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &575778802
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 575778804}
-  - component: {fileID: 575778803}
-  m_Layer: 0
-  m_Name: Right Hand
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &575778803
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 575778802}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 445639c80127bbd44b6bd9d34463b470, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _physicsHand:
-    triggerDistance: 0.004
-    oldPosition: {x: 0, y: 0, z: 0}
-    gameObject: {fileID: 653981085}
-    rootObject: {fileID: 575778802}
-    transform: {fileID: 653981089}
-    palmBone: {fileID: 653981088}
-    palmBody: {fileID: 653981087}
-    palmCollider: {fileID: 653981086}
-    jointBones:
-    - {fileID: 2116615602}
-    - {fileID: 1828296619}
-    - {fileID: 1613455054}
-    - {fileID: 1288267147}
-    - {fileID: 666865877}
-    - {fileID: 954897685}
-    - {fileID: 190012340}
-    - {fileID: 1993941825}
-    - {fileID: 1579476879}
-    - {fileID: 102763819}
-    - {fileID: 1535878790}
-    - {fileID: 585023818}
-    - {fileID: 1303817058}
-    - {fileID: 202587806}
-    - {fileID: 1462953424}
-    jointBodies:
-    - {fileID: 2116615601}
-    - {fileID: 1828296618}
-    - {fileID: 1613455053}
-    - {fileID: 1288267146}
-    - {fileID: 666865876}
-    - {fileID: 954897684}
-    - {fileID: 190012339}
-    - {fileID: 1993941824}
-    - {fileID: 1579476878}
-    - {fileID: 102763818}
-    - {fileID: 1535878789}
-    - {fileID: 585023817}
-    - {fileID: 1303817057}
-    - {fileID: 202587805}
-    - {fileID: 1462953423}
-    jointColliders:
-    - {fileID: 2116615600}
-    - {fileID: 1828296617}
-    - {fileID: 1613455051}
-    - {fileID: 1288267145}
-    - {fileID: 666865875}
-    - {fileID: 954897682}
-    - {fileID: 190012338}
-    - {fileID: 1993941823}
-    - {fileID: 1579476876}
-    - {fileID: 102763817}
-    - {fileID: 1535878788}
-    - {fileID: 585023815}
-    - {fileID: 1303817056}
-    - {fileID: 202587804}
-    - {fileID: 1462953421}
-    overRotationFrameCount: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-    defaultRotations:
-    - {x: -0.6644467, y: -0.34441155, z: -0.5637821, w: 0.34934357}
-    - {x: -0.19850887, y: -0.549382, z: -0.8101427, w: 0.04942213}
-    - {x: -0.095235884, y: -0.55546176, z: -0.82590574, w: 0.016494589}
-    - {x: -0.013266354, y: -0.54483914, z: -0.8380312, w: 0.026037607}
-    - {x: 0.08120667, y: -0.50801295, z: -0.85746795, w: -0.00878219}
-    - {x: -0.12940955, y: -0.4829629, z: -0.8627299, w: 0.07547912}
-    strength: 2
-    stiffness: 100
-    forceLimit: 1000
-    boneMass: 0.6
-    physicMaterial: {fileID: 585538801}
-  _handedness: 1
---- !u!4 &575778804
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 575778802}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 653981089}
-  m_Father: {fileID: 1874090592}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!134 &578926404
 PhysicMaterial:
   m_ObjectHideFlags: 0
@@ -8173,252 +5951,6 @@ PhysicMaterial:
   bounciness: 0
   frictionCombine: 3
   bounceCombine: 0
---- !u!1 &584145260
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 584145262}
-  - component: {fileID: 584145261}
-  - component: {fileID: 584145263}
-  - component: {fileID: 584145264}
-  m_Layer: 0
-  m_Name: Right Thumb Joint 2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!136 &584145261
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 584145260}
-  m_Material: {fileID: 189111359}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.02967
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.010835}
---- !u!4 &584145262
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 584145260}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.031570002}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1930163463}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &584145263
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 584145260}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.000000018626457, y: 0.000000031664985, z: 0.031570025}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 2
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &584145264
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 584145260}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2045161950}
-  _body: {fileID: 584145263}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 0
-  _joint: 2
---- !u!1 &585023814
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 585023816}
-  - component: {fileID: 585023815}
-  - component: {fileID: 585023817}
-  - component: {fileID: 585023818}
-  m_Layer: 0
-  m_Name: Right Ring Joint 2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!136 &585023815
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 585023814}
-  m_Material: {fileID: 585538801}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.0253
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.00865}
---- !u!4 &585023816
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 585023814}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.02565}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1535878787}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &585023817
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 585023814}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.000000005587938, y: -0.000000020489102, z: 0.02565001}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &585023818
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 585023814}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 575778803}
-  _body: {fileID: 585023817}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 3
-  _joint: 2
---- !u!134 &585538801
-PhysicMaterial:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: HandPhysics
-  dynamicFriction: 1
-  staticFriction: 1
-  bounciness: 0
-  frictionCombine: 0
-  bounceCombine: 1
 --- !u!1 &619053899
 GameObject:
   m_ObjectHideFlags: 0
@@ -8591,602 +6123,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!1 &632214910
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 632214914}
-  - component: {fileID: 632214912}
-  - component: {fileID: 632214911}
-  - component: {fileID: 632214913}
-  m_Layer: 0
-  m_Name: Left Palm
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!65 &632214911
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 632214910}
-  m_Material: {fileID: 1690218108}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 0.0833, y: 0.025, z: 0.10353848}
-  m_Center: {x: 0, y: 0.0025, z: -0.015}
---- !u!171741748 &632214912
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 632214910}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 1.8000001
-  m_ParentAnchorPosition: {x: 0, y: 0, z: 0}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 0
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 2
-  m_SwingZ: 2
-  m_Twist: 2
-  m_XDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 0
-    damping: 0
-    forceLimit: 3.4028235e+38
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 0
-    damping: 0
-    forceLimit: 3.4028235e+38
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 0
-    damping: 0
-    forceLimit: 3.4028235e+38
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 50
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &632214913
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 632214910}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2057484866}
-  _body: {fileID: 632214912}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 5
-  _joint: 0
---- !u!4 &632214914
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 632214910}
-  m_LocalRotation: {x: -0.12940949, y: 0.48296294, z: 0.86272997, w: 0.07547909}
-  m_LocalPosition: {x: -0.21999998, y: -0.13000001, z: 0.27000004}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 2058509477}
-  - {fileID: 374448558}
-  - {fileID: 1422669237}
-  - {fileID: 1280355242}
-  - {fileID: 1997924415}
-  m_Father: {fileID: 2057484867}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &653981085
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 653981089}
-  - component: {fileID: 653981087}
-  - component: {fileID: 653981086}
-  - component: {fileID: 653981088}
-  m_Layer: 0
-  m_Name: Right Palm
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!65 &653981086
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 653981085}
-  m_Material: {fileID: 585538801}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 0.0833, y: 0.025, z: 0.103538476}
-  m_Center: {x: 0, y: 0.0025, z: -0.015}
---- !u!171741748 &653981087
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 653981085}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 1.8000001
-  m_ParentAnchorPosition: {x: 0, y: 0, z: 0}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 0
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 2
-  m_SwingZ: 2
-  m_Twist: 2
-  m_XDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 0
-    damping: 0
-    forceLimit: 3.4028235e+38
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 0
-    damping: 0
-    forceLimit: 3.4028235e+38
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 0
-    damping: 0
-    forceLimit: 3.4028235e+38
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 50
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &653981088
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 653981085}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 575778803}
-  _body: {fileID: 653981087}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 5
-  _joint: 0
---- !u!4 &653981089
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 653981085}
-  m_LocalRotation: {x: -0.12940957, y: -0.4829629, z: -0.86272997, w: 0.07547912}
-  m_LocalPosition: {x: 0.22000004, y: -0.13000001, z: 0.26999998}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 2116615599}
-  - {fileID: 1288267144}
-  - {fileID: 190012337}
-  - {fileID: 102763816}
-  - {fileID: 1303817055}
-  m_Father: {fileID: 575778804}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &666865873
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 666865874}
-  - component: {fileID: 666865875}
-  - component: {fileID: 666865876}
-  - component: {fileID: 666865877}
-  m_Layer: 0
-  m_Name: Right Index Joint 1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &666865874
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 666865873}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.039780002}
-  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 0.99999976}
-  m_Children:
-  - {fileID: 954897683}
-  m_Father: {fileID: 1288267144}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &666865875
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 666865873}
-  m_Material: {fileID: 585538801}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.03038
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.01119}
---- !u!171741748 &666865876
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 666865873}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.000000030267994, y: -0.00000002328307, z: 0.039780017}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &666865877
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 666865873}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 575778803}
-  _body: {fileID: 666865876}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 1
-  _joint: 1
---- !u!1 &674034229
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 674034230}
-  - component: {fileID: 674034231}
-  - component: {fileID: 674034232}
-  - component: {fileID: 674034233}
-  m_Layer: 0
-  m_Name: Left Index Joint 0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &674034230
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 674034229}
-  m_LocalRotation: {x: 0.074111804, y: 0.08401716, z: -0.006266229, w: 0.99368477}
-  m_LocalPosition: {x: 0.023181278, y: 0.0020000078, z: 0.023149362}
-  m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999999}
-  m_Children:
-  - {fileID: 1859197413}
-  m_Father: {fileID: 1921003926}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &674034231
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 674034229}
-  m_Material: {fileID: 2041109289}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.047780003
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.019890001}
---- !u!171741748 &674034232
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 674034229}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.023181278, y: 0.0020000078, z: 0.023149362}
-  m_ParentAnchorRotation: {x: 0.07411182, y: 0.08401718, z: -0.006266229, w: 0.9936849}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -30
-    upperLimit: 80
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -15
-    upperLimit: 15
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &674034233
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 674034229}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 1656071730}
-  _body: {fileID: 674034232}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 1
-  _joint: 0
---- !u!1 &676571246
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 676571247}
-  - component: {fileID: 676571248}
-  - component: {fileID: 676571249}
-  - component: {fileID: 676571250}
-  m_Layer: 0
-  m_Name: Right Ring Joint 1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &676571247
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 676571246}
-  m_LocalRotation: {x: -0, y: -0, z: -0.0000000018626451, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.04137}
-  m_LocalScale: {x: 0.9999999, y: 1, z: 0.9999999}
-  m_Children:
-  - {fileID: 1625487771}
-  m_Father: {fileID: 1326941326}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &676571248
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 676571246}
-  m_Material: {fileID: 189111359}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.03365
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.012825}
---- !u!171741748 &676571249
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 676571246}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.000000012107198, y: -0.000000013504181, z: 0.041370012}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &676571250
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 676571246}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2045161950}
-  _body: {fileID: 676571249}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 3
-  _joint: 1
 --- !u!1 &689004047
 GameObject:
   m_ObjectHideFlags: 0
@@ -9370,7 +6306,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 89a6155d1ade3a442a3c9a1ff5aa29c0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &794028891
+--- !u!1 &705853060
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -9378,140 +6314,120 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 794028892}
-  - component: {fileID: 794028893}
-  - component: {fileID: 794028894}
-  - component: {fileID: 794028895}
+  - component: {fileID: 705853064}
+  - component: {fileID: 705853062}
+  - component: {fileID: 705853061}
+  - component: {fileID: 705853063}
   m_Layer: 0
-  m_Name: Right Thumb Joint 0
+  m_Name: Right Palm
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &794028892
-Transform:
+--- !u!65 &705853061
+BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 794028891}
-  m_LocalRotation: {x: 0.019904856, y: -0.35755515, z: 0.53516835, w: 0.7650837}
-  m_LocalPosition: {x: -0.01933824, y: -0.0059999824, z: -0.05316848}
-  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
-  m_Children:
-  - {fileID: 2000139858}
-  m_Father: {fileID: 1384551531}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &794028893
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 794028891}
-  m_Material: {fileID: 1081093971}
+  m_GameObject: {fileID: 705853060}
+  m_Material: {fileID: 1489137147}
   m_IsTrigger: 0
   m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.054220006
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.023110002}
---- !u!171741748 &794028894
+  serializedVersion: 2
+  m_Size: {x: 0.0833, y: 0.025, z: 0.103538476}
+  m_Center: {x: 0, y: 0.0025, z: -0.015}
+--- !u!171741748 &705853062
 ArticulationBody:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 794028891}
+  m_GameObject: {fileID: 705853060}
   m_Enabled: 1
   serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.01933824, y: -0.0059999824, z: -0.05316848}
-  m_ParentAnchorRotation: {x: 0.019904852, y: -0.35755515, z: 0.53516847, w: 0.7650838}
+  m_Mass: 1.8000001
+  m_ParentAnchorPosition: {x: 0, y: 0, z: 0}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
+  m_AnchorRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_ComputeParentAnchor: 1
+  m_ArticulationJointType: 0
   m_LinearX: 2
   m_LinearY: 2
   m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
+  m_SwingY: 2
+  m_SwingZ: 2
+  m_Twist: 2
   m_XDrive:
-    lowerLimit: -45
-    upperLimit: 45
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 0
+    damping: 0
+    forceLimit: 3.4028235e+38
     target: 0
     targetVelocity: 0
   m_YDrive:
-    lowerLimit: -50
-    upperLimit: 10
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 0
+    damping: 0
+    forceLimit: 3.4028235e+38
     target: 0
     targetVelocity: 0
   m_ZDrive:
     lowerLimit: 0
     upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
+    stiffness: 0
+    damping: 0
+    forceLimit: 3.4028235e+38
     target: 0
     targetVelocity: 0
   m_LinearDamping: 0
-  m_AngularDamping: 0.05
+  m_AngularDamping: 50
   m_JointFriction: 0.05
   m_Immovable: 0
   m_UseGravity: 0
   m_CollisionDetectionMode: 3
---- !u!114 &794028895
+--- !u!114 &705853063
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 794028891}
+  m_GameObject: {fileID: 705853060}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _hand: {fileID: 2127376581}
-  _body: {fileID: 794028894}
+  _hand: {fileID: 138166228}
+  _body: {fileID: 705853062}
   _origXDriveLimit: 0
   _currentXDriveLimit: 3.4028235e+38
-  _finger: 0
+  _finger: 5
   _joint: 0
---- !u!114 &799113158 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 882061859479617650, guid: 5fad9bc118c955741a03cf98cf3f0a46, type: 3}
-  m_PrefabInstance: {fileID: 1551443168}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 89a6155d1ade3a442a3c9a1ff5aa29c0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!134 &861115678
-PhysicMaterial:
+--- !u!4 &705853064
+Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: Button Material
-  dynamicFriction: 1
-  staticFriction: 1
-  bounciness: 0
-  frictionCombine: 3
-  bounceCombine: 0
---- !u!1 &864411117
+  m_GameObject: {fileID: 705853060}
+  m_LocalRotation: {x: -0.12940957, y: -0.4829629, z: -0.86272997, w: 0.07547912}
+  m_LocalPosition: {x: 0.22000004, y: -0.13000001, z: 0.26999998}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1843646418}
+  - {fileID: 783923111}
+  - {fileID: 468922237}
+  - {fileID: 863936983}
+  - {fileID: 491256543}
+  m_Father: {fileID: 138166229}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &720346351
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -9519,10 +6435,10 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 864411119}
-  - component: {fileID: 864411118}
-  - component: {fileID: 864411120}
-  - component: {fileID: 864411121}
+  - component: {fileID: 720346353}
+  - component: {fileID: 720346352}
+  - component: {fileID: 720346354}
+  - component: {fileID: 720346355}
   m_Layer: 0
   m_Name: Left Pinky Joint 2
   m_TagString: Untagged
@@ -9530,41 +6446,41 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!136 &864411118
+--- !u!136 &720346352
 CapsuleCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 864411117}
-  m_Material: {fileID: 1690218108}
+  m_GameObject: {fileID: 720346351}
+  m_Material: {fileID: 232411772}
   m_IsTrigger: 0
   m_Enabled: 1
   m_Radius: 0.004
   m_Height: 0.023960002
   m_Direction: 2
   m_Center: {x: 0, y: 0, z: 0.00798}
---- !u!4 &864411119
+--- !u!4 &720346353
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 864411117}
+  m_GameObject: {fileID: 720346351}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0.018110001}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 439291898}
+  m_Father: {fileID: 1584748073}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &864411120
+--- !u!171741748 &720346354
 ArticulationBody:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 864411117}
+  m_GameObject: {fileID: 720346351}
   m_Enabled: 1
   serializedVersion: 3
   m_Mass: 0.6
@@ -9585,7 +6501,7 @@ ArticulationBody:
     upperLimit: 89
     stiffness: 200
     damping: 1
-    forceLimit: 100000
+    forceLimit: 180001.81
     target: 0
     targetVelocity: 0
   m_YDrive:
@@ -9593,7 +6509,7 @@ ArticulationBody:
     upperLimit: 8
     stiffness: 200
     damping: 2
-    forceLimit: 100000
+    forceLimit: 180001.81
     target: 0
     targetVelocity: 0
   m_ZDrive:
@@ -9601,7 +6517,7 @@ ArticulationBody:
     upperLimit: 0
     stiffness: 200
     damping: 2
-    forceLimit: 100000
+    forceLimit: 180001.81
     target: 0
     targetVelocity: 0
   m_LinearDamping: 0
@@ -9610,24 +6526,647 @@ ArticulationBody:
   m_Immovable: 0
   m_UseGravity: 0
   m_CollisionDetectionMode: 3
---- !u!114 &864411121
+--- !u!114 &720346355
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 864411117}
+  m_GameObject: {fileID: 720346351}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _hand: {fileID: 2057484866}
-  _body: {fileID: 864411120}
+  _hand: {fileID: 1392200166}
+  _body: {fileID: 720346354}
   _origXDriveLimit: 0
   _currentXDriveLimit: 3.4028235e+38
   _finger: 4
   _joint: 2
+--- !u!1 &759660565
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 759660567}
+  - component: {fileID: 759660566}
+  - component: {fileID: 759660568}
+  - component: {fileID: 759660569}
+  m_Layer: 0
+  m_Name: Right Thumb Joint 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!136 &759660566
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 759660565}
+  m_Material: {fileID: 1489137147}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.02967
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.010835}
+--- !u!4 &759660567
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 759660565}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.031570002}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 839701698}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!171741748 &759660568
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 759660565}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.000000018626457, y: 0.000000031664985, z: 0.031570025}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 2
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &759660569
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 759660565}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 138166228}
+  _body: {fileID: 759660568}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 0
+  _joint: 2
+--- !u!1 &781686252
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 781686254}
+  - component: {fileID: 781686253}
+  - component: {fileID: 781686255}
+  - component: {fileID: 781686256}
+  m_Layer: 0
+  m_Name: Right Middle Joint 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!136 &781686253
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 781686252}
+  m_Material: {fileID: 1489137147}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.025400002
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.0087}
+--- !u!4 &781686254
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 781686252}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.026330002}
+  m_LocalScale: {x: 1.0000001, y: 1.0000001, z: 1.0000001}
+  m_Children: []
+  m_Father: {fileID: 1851164603}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!171741748 &781686255
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 781686252}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 2.3283078e-10, y: 0.0000000055879377, z: 0.026330026}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &781686256
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 781686252}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 138166228}
+  _body: {fileID: 781686255}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 2
+  _joint: 2
+--- !u!1 &783923110
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 783923111}
+  - component: {fileID: 783923112}
+  - component: {fileID: 783923113}
+  - component: {fileID: 783923114}
+  m_Layer: 0
+  m_Name: Right Index Joint 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &783923111
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 783923110}
+  m_LocalRotation: {x: 0.07411184, y: -0.08401716, z: 0.0062662363, w: 0.99368477}
+  m_LocalPosition: {x: -0.023181278, y: 0.0020000078, z: 0.023149364}
+  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
+  m_Children:
+  - {fileID: 2117531306}
+  m_Father: {fileID: 705853064}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &783923112
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 783923110}
+  m_Material: {fileID: 1489137147}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.047780003
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.019890001}
+--- !u!171741748 &783923113
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 783923110}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.023181293, y: 0.0020000115, z: 0.023149366}
+  m_ParentAnchorRotation: {x: 0.07411185, y: -0.08401715, z: 0.0062662363, w: 0.9936849}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -30
+    upperLimit: 80
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -15
+    upperLimit: 15
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &783923114
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 783923110}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 138166228}
+  _body: {fileID: 783923113}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 1
+  _joint: 0
+--- !u!114 &799113158 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 882061859479617650, guid: 5fad9bc118c955741a03cf98cf3f0a46, type: 3}
+  m_PrefabInstance: {fileID: 1551443168}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 89a6155d1ade3a442a3c9a1ff5aa29c0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!134 &804596361
+PhysicMaterial:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Button Material
+  dynamicFriction: 1
+  staticFriction: 1
+  bounciness: 0
+  frictionCombine: 3
+  bounceCombine: 0
+--- !u!1 &839701697
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 839701698}
+  - component: {fileID: 839701699}
+  - component: {fileID: 839701700}
+  - component: {fileID: 839701701}
+  m_Layer: 0
+  m_Name: Right Thumb Joint 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &839701698
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 839701697}
+  m_LocalRotation: {x: -0, y: -0, z: -0.0000000088475645, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.046220005}
+  m_LocalScale: {x: 1.0000001, y: 0.99999964, z: 0.9999995}
+  m_Children:
+  - {fileID: 759660567}
+  m_Father: {fileID: 1843646418}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &839701699
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 839701697}
+  m_Material: {fileID: 1489137147}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.039570004
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.015785001}
+--- !u!171741748 &839701700
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 839701697}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.0000000130385205, y: 0.0000000046566138, z: 0.046220012}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 2
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &839701701
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 839701697}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 138166228}
+  _body: {fileID: 839701700}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 0
+  _joint: 1
+--- !u!134 &861115678
+PhysicMaterial:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Button Material
+  dynamicFriction: 1
+  staticFriction: 1
+  bounciness: 0
+  frictionCombine: 3
+  bounceCombine: 0
+--- !u!1 &863936982
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 863936983}
+  - component: {fileID: 863936984}
+  - component: {fileID: 863936985}
+  - component: {fileID: 863936986}
+  m_Layer: 0
+  m_Name: Right Ring Joint 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &863936983
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 863936982}
+  m_LocalRotation: {x: 0.067679256, y: 0.06845519, z: -0.104890674, w: 0.9898138}
+  m_LocalPosition: {x: 0.017447188, y: 0.004000012, z: 0.017279157}
+  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
+  m_Children:
+  - {fileID: 218380736}
+  m_Father: {fileID: 705853064}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &863936984
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 863936982}
+  m_Material: {fileID: 1489137147}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.049370002
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.020685}
+--- !u!171741748 &863936985
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 863936982}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 0.017447188, y: 0.004000012, z: 0.017279157}
+  m_ParentAnchorRotation: {x: 0.067679256, y: 0.06845519, z: -0.10489069, w: 0.9898139}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -30
+    upperLimit: 80
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -15
+    upperLimit: 15
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &863936986
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 863936982}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 138166228}
+  _body: {fileID: 863936985}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 3
+  _joint: 0
 --- !u!1 &888698408
 GameObject:
   m_ObjectHideFlags: 0
@@ -9694,245 +7233,6 @@ Transform:
   m_Father: {fileID: 463914042}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &889282509
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 889282513}
-  - component: {fileID: 889282511}
-  - component: {fileID: 889282510}
-  - component: {fileID: 889282512}
-  m_Layer: 0
-  m_Name: Left Palm
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!65 &889282510
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 889282509}
-  m_Material: {fileID: 1324615029}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 0.0833, y: 0.025, z: 0.10353848}
-  m_Center: {x: 0, y: 0.0025, z: -0.015}
---- !u!171741748 &889282511
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 889282509}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 1.8000001
-  m_ParentAnchorPosition: {x: 0, y: 0, z: 0}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 0
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 2
-  m_SwingZ: 2
-  m_Twist: 2
-  m_XDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 0
-    damping: 0
-    forceLimit: 3.4028235e+38
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 0
-    damping: 0
-    forceLimit: 3.4028235e+38
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 0
-    damping: 0
-    forceLimit: 3.4028235e+38
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 50
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &889282512
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 889282509}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 1552987639}
-  _body: {fileID: 889282511}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 5
-  _joint: 0
---- !u!4 &889282513
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 889282509}
-  m_LocalRotation: {x: -0.12940949, y: 0.48296294, z: 0.86272997, w: 0.07547909}
-  m_LocalPosition: {x: -0.21999998, y: -0.13000001, z: 0.27000004}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1211426961}
-  - {fileID: 143027714}
-  - {fileID: 80816727}
-  - {fileID: 1120470095}
-  - {fileID: 1660436105}
-  m_Father: {fileID: 1552987640}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &891900966
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 891900967}
-  - component: {fileID: 891900968}
-  - component: {fileID: 891900969}
-  - component: {fileID: 891900970}
-  m_Layer: 0
-  m_Name: Left Pinky Joint 0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &891900967
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 891900966}
-  m_LocalRotation: {x: 0.02914566, y: -0.13843812, z: 0.17725913, w: 0.9739428}
-  m_LocalPosition: {x: -0.035337448, y: -0.000000004656613, z: 0.00972872}
-  m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999999}
-  m_Children:
-  - {fileID: 315683683}
-  m_Father: {fileID: 1921003926}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &891900968
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 891900966}
-  m_Material: {fileID: 2041109289}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.040740006
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.016370002}
---- !u!171741748 &891900969
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 891900966}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.035337463, y: -0.000000008381903, z: 0.009728719}
-  m_ParentAnchorRotation: {x: 0.029145658, y: -0.13843812, z: 0.17725913, w: 0.97394294}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -30
-    upperLimit: 80
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -15
-    upperLimit: 15
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &891900970
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 891900966}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 1656071730}
-  _body: {fileID: 891900969}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 4
-  _joint: 0
 --- !u!1 &896341549
 GameObject:
   m_ObjectHideFlags: 0
@@ -10172,7 +7472,7 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 910863327}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &928808895
+--- !u!1 &912663686
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -10180,57 +7480,57 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 928808897}
-  - component: {fileID: 928808896}
-  - component: {fileID: 928808898}
-  - component: {fileID: 928808899}
+  - component: {fileID: 912663688}
+  - component: {fileID: 912663687}
+  - component: {fileID: 912663689}
+  - component: {fileID: 912663690}
   m_Layer: 0
-  m_Name: Left Middle Joint 2
+  m_Name: Left Ring Joint 2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!136 &928808896
+--- !u!136 &912663687
 CapsuleCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 928808895}
-  m_Material: {fileID: 1324615029}
+  m_GameObject: {fileID: 912663686}
+  m_Material: {fileID: 232411772}
   m_IsTrigger: 0
   m_Enabled: 1
   m_Radius: 0.004
-  m_Height: 0.025400002
+  m_Height: 0.0253
   m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.0087}
---- !u!4 &928808897
+  m_Center: {x: 0, y: 0, z: 0.00865}
+--- !u!4 &912663688
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 928808895}
+  m_GameObject: {fileID: 912663686}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.026330002}
-  m_LocalScale: {x: 1, y: 0.9999999, z: 0.9999999}
+  m_LocalPosition: {x: 0, y: 0, z: 0.02565}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 246457847}
+  m_Father: {fileID: 290336278}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &928808898
+--- !u!171741748 &912663689
 ArticulationBody:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 928808895}
+  m_GameObject: {fileID: 912663686}
   m_Enabled: 1
   serializedVersion: 3
   m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 4.656617e-10, y: -0.00000000931323, z: 0.026330002}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
+  m_ParentAnchorPosition: {x: 9.31323e-10, y: -0.000000025145715, z: 0.02565002}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
   m_ComputeParentAnchor: 0
@@ -10271,23 +7571,23 @@ ArticulationBody:
   m_Immovable: 0
   m_UseGravity: 0
   m_CollisionDetectionMode: 3
---- !u!114 &928808899
+--- !u!114 &912663690
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 928808895}
+  m_GameObject: {fileID: 912663686}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _hand: {fileID: 1552987639}
-  _body: {fileID: 928808898}
+  _hand: {fileID: 1392200166}
+  _body: {fileID: 912663689}
   _origXDriveLimit: 0
   _currentXDriveLimit: 3.4028235e+38
-  _finger: 2
+  _finger: 3
   _joint: 2
 --- !u!1 &929646170
 GameObject:
@@ -10461,240 +7761,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!1 &931978641
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 931978643}
-  - component: {fileID: 931978642}
-  - component: {fileID: 931978644}
-  - component: {fileID: 931978645}
-  m_Layer: 0
-  m_Name: Left Index Joint 2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!136 &931978642
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 931978641}
-  m_Material: {fileID: 2041109289}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.023820002
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.00791}
---- !u!4 &931978643
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 931978641}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.02238}
-  m_LocalScale: {x: 1, y: 1.0000001, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1859197413}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &931978644
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 931978641}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.0000000102445545, y: -0.000000020489109, z: 0.022380015}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &931978645
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 931978641}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 1656071730}
-  _body: {fileID: 931978644}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 1
-  _joint: 2
---- !u!1 &954897681
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 954897683}
-  - component: {fileID: 954897682}
-  - component: {fileID: 954897684}
-  - component: {fileID: 954897685}
-  m_Layer: 0
-  m_Name: Right Index Joint 2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!136 &954897682
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 954897681}
-  m_Material: {fileID: 585538801}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.023820002
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.00791}
---- !u!4 &954897683
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 954897681}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.02238}
-  m_LocalScale: {x: 1, y: 1.0000001, z: 1}
-  m_Children: []
-  m_Father: {fileID: 666865874}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &954897684
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 954897681}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.000000003725293, y: -0.00000001583249, z: 0.022380007}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &954897685
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 954897681}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 575778803}
-  _body: {fileID: 954897684}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 1
-  _joint: 2
 --- !u!1 &964751602
 GameObject:
   m_ObjectHideFlags: 0
@@ -10867,124 +7933,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!1 &971476547
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 971476548}
-  - component: {fileID: 971476549}
-  - component: {fileID: 971476550}
-  - component: {fileID: 971476551}
-  m_Layer: 0
-  m_Name: Right Pinky Joint 0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &971476548
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 971476547}
-  m_LocalRotation: {x: 0.029145695, y: 0.13843815, z: -0.17725913, w: 0.9739429}
-  m_LocalPosition: {x: 0.035337448, y: -0.000000009313226, z: 0.009728717}
-  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
-  m_Children:
-  - {fileID: 436964832}
-  m_Father: {fileID: 1384551531}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &971476549
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 971476547}
-  m_Material: {fileID: 1081093971}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.040740006
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.016370002}
---- !u!171741748 &971476550
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 971476547}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.035337463, y: -0.000000013038516, z: 0.009728714}
-  m_ParentAnchorRotation: {x: 0.029145688, y: 0.13843818, z: -0.17725915, w: 0.973943}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -30
-    upperLimit: 80
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -15
-    upperLimit: 15
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &971476551
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 971476547}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2127376581}
-  _body: {fileID: 971476550}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 4
-  _joint: 0
 --- !u!1 &976655189
 GameObject:
   m_ObjectHideFlags: 0
@@ -11097,124 +8045,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 976655189}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &979227608
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 979227609}
-  - component: {fileID: 979227610}
-  - component: {fileID: 979227611}
-  - component: {fileID: 979227612}
-  m_Layer: 0
-  m_Name: Left Middle Joint 1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &979227609
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 979227608}
-  m_LocalRotation: {x: -0, y: -0, z: -0.000000001513399, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.044630002}
-  m_LocalScale: {x: 0.9999995, y: 0.99999976, z: 0.9999999}
-  m_Children:
-  - {fileID: 14895154}
-  m_Father: {fileID: 1422669237}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &979227610
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 979227608}
-  m_Material: {fileID: 1690218108}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.034330003
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.013165001}
---- !u!171741748 &979227611
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 979227608}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.0000000047730295, y: -0.000000018160794, z: 0.044630006}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &979227612
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 979227608}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2057484866}
-  _body: {fileID: 979227611}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 2
-  _joint: 1
 --- !u!1 &980869086
 GameObject:
   m_ObjectHideFlags: 0
@@ -11387,7 +8217,7 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!1 &1017830909
+--- !u!1 &981931936
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -11395,56 +8225,57 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1017830911}
-  - component: {fileID: 1017830910}
-  - component: {fileID: 1017830912}
-  - component: {fileID: 1017830913}
+  - component: {fileID: 981931937}
+  - component: {fileID: 981931938}
+  - component: {fileID: 981931939}
+  - component: {fileID: 981931940}
   m_Layer: 0
-  m_Name: Right Middle Joint 2
+  m_Name: Left Index Joint 1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!136 &1017830910
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1017830909}
-  m_Material: {fileID: 189111359}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.025400002
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.0087}
---- !u!4 &1017830911
+--- !u!4 &981931937
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1017830909}
+  m_GameObject: {fileID: 981931936}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.026330002}
-  m_LocalScale: {x: 1.0000001, y: 1.0000001, z: 1.0000001}
-  m_Children: []
-  m_Father: {fileID: 1995389692}
+  m_LocalPosition: {x: 0, y: 0, z: 0.039780002}
+  m_LocalScale: {x: 0.99999964, y: 0.99999964, z: 0.99999976}
+  m_Children:
+  - {fileID: 2047016340}
+  m_Father: {fileID: 1633464193}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &1017830912
+--- !u!136 &981931938
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 981931936}
+  m_Material: {fileID: 232411772}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.03038
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.01119}
+--- !u!171741748 &981931939
 ArticulationBody:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1017830909}
+  m_GameObject: {fileID: 981931936}
   m_Enabled: 1
   serializedVersion: 3
   m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 2.3283078e-10, y: 0.0000000055879377, z: 0.026330026}
+  m_ParentAnchorPosition: {x: -0.0000000041909525, y: -0.000000003725291, z: 0.039780017}
   m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
@@ -11461,7 +8292,7 @@ ArticulationBody:
     upperLimit: 89
     stiffness: 200
     damping: 1
-    forceLimit: 100000
+    forceLimit: 180001.81
     target: 0
     targetVelocity: 0
   m_YDrive:
@@ -11469,7 +8300,7 @@ ArticulationBody:
     upperLimit: 8
     stiffness: 200
     damping: 2
-    forceLimit: 100000
+    forceLimit: 180001.81
     target: 0
     targetVelocity: 0
   m_ZDrive:
@@ -11477,7 +8308,7 @@ ArticulationBody:
     upperLimit: 0
     stiffness: 200
     damping: 2
-    forceLimit: 100000
+    forceLimit: 180001.81
     target: 0
     targetVelocity: 0
   m_LinearDamping: 0
@@ -11486,24 +8317,24 @@ ArticulationBody:
   m_Immovable: 0
   m_UseGravity: 0
   m_CollisionDetectionMode: 3
---- !u!114 &1017830913
+--- !u!114 &981931940
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1017830909}
+  m_GameObject: {fileID: 981931936}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _hand: {fileID: 2045161950}
-  _body: {fileID: 1017830912}
+  _hand: {fileID: 1392200166}
+  _body: {fileID: 981931939}
   _origXDriveLimit: 0
   _currentXDriveLimit: 3.4028235e+38
-  _finger: 2
-  _joint: 2
+  _finger: 1
+  _joint: 1
 --- !u!1 &1031752490
 GameObject:
   m_ObjectHideFlags: 0
@@ -11862,257 +8693,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 89a6155d1ade3a442a3c9a1ff5aa29c0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &1077167461
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1077167462}
-  - component: {fileID: 1077167463}
-  - component: {fileID: 1077167464}
-  - component: {fileID: 1077167465}
-  m_Layer: 0
-  m_Name: Right Middle Joint 1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1077167462
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1077167461}
-  m_LocalRotation: {x: -0, y: -0, z: 9.895301e-10, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.044630002}
-  m_LocalScale: {x: 0.99999976, y: 0.9999999, z: 0.99999976}
-  m_Children:
-  - {fileID: 302522889}
-  m_Father: {fileID: 1216944352}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1077167463
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1077167461}
-  m_Material: {fileID: 1081093971}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.034330003
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.013165001}
---- !u!171741748 &1077167464
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1077167461}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.0000000036088763, y: 0.0000000051222755, z: 0.04463001}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1077167465
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1077167461}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2127376581}
-  _body: {fileID: 1077167464}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 2
-  _joint: 1
---- !u!134 &1081093971
-PhysicMaterial:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: HandPhysics
-  dynamicFriction: 1
-  staticFriction: 1
-  bounciness: 0
-  frictionCombine: 0
-  bounceCombine: 1
---- !u!1 &1085073647
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1085073651}
-  - component: {fileID: 1085073649}
-  - component: {fileID: 1085073648}
-  - component: {fileID: 1085073650}
-  m_Layer: 0
-  m_Name: Right Palm
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!65 &1085073648
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1085073647}
-  m_Material: {fileID: 189111359}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 0.0833, y: 0.025, z: 0.103538476}
-  m_Center: {x: 0, y: 0.0025, z: -0.015}
---- !u!171741748 &1085073649
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1085073647}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 1.8000001
-  m_ParentAnchorPosition: {x: 0, y: 0, z: 0}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 0
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 2
-  m_SwingZ: 2
-  m_Twist: 2
-  m_XDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 0
-    damping: 0
-    forceLimit: 3.4028235e+38
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 0
-    damping: 0
-    forceLimit: 3.4028235e+38
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 0
-    damping: 0
-    forceLimit: 3.4028235e+38
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 50
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1085073650
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1085073647}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2045161950}
-  _body: {fileID: 1085073649}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 5
-  _joint: 0
---- !u!4 &1085073651
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1085073647}
-  m_LocalRotation: {x: -0.12940957, y: -0.4829629, z: -0.86272997, w: 0.07547912}
-  m_LocalPosition: {x: 0.22000004, y: -0.13000001, z: 0.26999998}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1193507573}
-  - {fileID: 2080805427}
-  - {fileID: 65960885}
-  - {fileID: 1326941326}
-  - {fileID: 182831394}
-  m_Father: {fileID: 2045161951}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1092288546
 GameObject:
   m_ObjectHideFlags: 0
@@ -12261,124 +8841,6 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
---- !u!1 &1120470094
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1120470095}
-  - component: {fileID: 1120470096}
-  - component: {fileID: 1120470097}
-  - component: {fileID: 1120470098}
-  m_Layer: 0
-  m_Name: Left Ring Joint 0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1120470095
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1120470094}
-  m_LocalRotation: {x: 0.06767923, y: -0.06845519, z: 0.104890674, w: 0.9898138}
-  m_LocalPosition: {x: -0.017447187, y: 0.0040000137, z: 0.01727916}
-  m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999999}
-  m_Children:
-  - {fileID: 1642491618}
-  m_Father: {fileID: 889282513}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1120470096
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1120470094}
-  m_Material: {fileID: 1324615029}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.049370002
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.020685}
---- !u!171741748 &1120470097
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1120470094}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.017447187, y: 0.0040000137, z: 0.01727916}
-  m_ParentAnchorRotation: {x: 0.067679256, y: -0.06845519, z: 0.10489069, w: 0.9898139}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -30
-    upperLimit: 80
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -15
-    upperLimit: 15
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1120470098
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1120470094}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 1552987639}
-  _body: {fileID: 1120470097}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 3
-  _joint: 0
 --- !u!1 &1141051099
 GameObject:
   m_ObjectHideFlags: 0
@@ -12698,124 +9160,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1152218872}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &1193507572
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1193507573}
-  - component: {fileID: 1193507574}
-  - component: {fileID: 1193507575}
-  - component: {fileID: 1193507576}
-  m_Layer: 0
-  m_Name: Right Thumb Joint 0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1193507573
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1193507572}
-  m_LocalRotation: {x: 0.019904856, y: -0.35755515, z: 0.53516835, w: 0.7650837}
-  m_LocalPosition: {x: -0.01933824, y: -0.0059999824, z: -0.05316848}
-  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
-  m_Children:
-  - {fileID: 1930163463}
-  m_Father: {fileID: 1085073651}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1193507574
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1193507572}
-  m_Material: {fileID: 189111359}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.054220006
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.023110002}
---- !u!171741748 &1193507575
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1193507572}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.01933824, y: -0.0059999824, z: -0.05316848}
-  m_ParentAnchorRotation: {x: 0.019904852, y: -0.35755515, z: 0.53516847, w: 0.7650838}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -45
-    upperLimit: 45
-    stiffness: 200
-    damping: 1
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -50
-    upperLimit: 10
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1193507576
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1193507572}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2045161950}
-  _body: {fileID: 1193507575}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 0
-  _joint: 0
 --- !u!1 &1204820712
 GameObject:
   m_ObjectHideFlags: 0
@@ -12988,7 +9332,7 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!1 &1211426960
+--- !u!1 &1259386101
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -12996,62 +9340,62 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1211426961}
-  - component: {fileID: 1211426962}
-  - component: {fileID: 1211426963}
-  - component: {fileID: 1211426964}
+  - component: {fileID: 1259386102}
+  - component: {fileID: 1259386103}
+  - component: {fileID: 1259386104}
+  - component: {fileID: 1259386105}
   m_Layer: 0
-  m_Name: Left Thumb Joint 0
+  m_Name: Left Thumb Joint 1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1211426961
+--- !u!4 &1259386102
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1211426960}
-  m_LocalRotation: {x: 0.019904852, y: 0.35755512, z: -0.53516835, w: 0.7650836}
-  m_LocalPosition: {x: 0.019338273, y: -0.006000001, z: -0.053168494}
-  m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999999}
+  m_GameObject: {fileID: 1259386101}
+  m_LocalRotation: {x: -0, y: -0, z: 0.00000001071021, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.046220005}
+  m_LocalScale: {x: 1.0000001, y: 0.9999999, z: 0.99999976}
   m_Children:
-  - {fileID: 1945723378}
-  m_Father: {fileID: 889282513}
+  - {fileID: 441012509}
+  m_Father: {fileID: 1811146118}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1211426962
+--- !u!136 &1259386103
 CapsuleCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1211426960}
-  m_Material: {fileID: 1324615029}
+  m_GameObject: {fileID: 1259386101}
+  m_Material: {fileID: 232411772}
   m_IsTrigger: 0
   m_Enabled: 1
   m_Radius: 0.004
-  m_Height: 0.054220006
+  m_Height: 0.039570004
   m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.023110002}
---- !u!171741748 &1211426963
+  m_Center: {x: 0, y: 0, z: 0.015785001}
+--- !u!171741748 &1259386104
 ArticulationBody:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1211426960}
+  m_GameObject: {fileID: 1259386101}
   m_Enabled: 1
   serializedVersion: 3
   m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.019338273, y: -0.0059999935, z: -0.053168505}
-  m_ParentAnchorRotation: {x: 0.019904822, y: 0.35755518, z: -0.5351684, w: 0.7650837}
+  m_ParentAnchorPosition: {x: 9.313228e-10, y: 0.00000000651926, z: 0.046220012}
+  m_ParentAnchorRotation: {x: 0.000000014901161, y: 0, z: 0.000000029802322, w: 1.0000001}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
   m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
+  m_ArticulationJointType: 2
   m_LinearX: 2
   m_LinearY: 2
   m_LinearZ: 2
@@ -13059,16 +9403,16 @@ ArticulationBody:
   m_SwingZ: 1
   m_Twist: 1
   m_XDrive:
-    lowerLimit: -45
-    upperLimit: 45
+    lowerLimit: -10
+    upperLimit: 89
     stiffness: 200
     damping: 1
     forceLimit: 180001.81
     target: 0
     targetVelocity: 0
   m_YDrive:
-    lowerLimit: -10
-    upperLimit: 50
+    lowerLimit: -8
+    upperLimit: 8
     stiffness: 200
     damping: 2
     forceLimit: 180001.81
@@ -13088,142 +9432,24 @@ ArticulationBody:
   m_Immovable: 0
   m_UseGravity: 0
   m_CollisionDetectionMode: 3
---- !u!114 &1211426964
+--- !u!114 &1259386105
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1211426960}
+  m_GameObject: {fileID: 1259386101}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _hand: {fileID: 1552987639}
-  _body: {fileID: 1211426963}
+  _hand: {fileID: 1392200166}
+  _body: {fileID: 1259386104}
   _origXDriveLimit: 0
   _currentXDriveLimit: 3.4028235e+38
   _finger: 0
-  _joint: 0
---- !u!1 &1216944351
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1216944352}
-  - component: {fileID: 1216944353}
-  - component: {fileID: 1216944354}
-  - component: {fileID: 1216944355}
-  m_Layer: 0
-  m_Name: Right Middle Joint 0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1216944352
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1216944351}
-  m_LocalRotation: {x: 0.07527792, y: -0.009242235, z: -0.073994935, w: 0.99437046}
-  m_LocalPosition: {x: -0.002788769, y: 0.0040000016, z: 0.023252115}
-  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
-  m_Children:
-  - {fileID: 1077167462}
-  m_Father: {fileID: 1384551531}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1216944353
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1216944351}
-  m_Material: {fileID: 1081093971}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.052630004
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.022315001}
---- !u!171741748 &1216944354
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1216944351}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.002788769, y: 0.0040000016, z: 0.023252115}
-  m_ParentAnchorRotation: {x: 0.075277954, y: -0.009242229, z: -0.07399494, w: 0.9943706}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -30
-    upperLimit: 80
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -15
-    upperLimit: 15
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1216944355
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1216944351}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2127376581}
-  _body: {fileID: 1216944354}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 2
-  _joint: 0
+  _joint: 1
 --- !u!1 &1265756910
 GameObject:
   m_ObjectHideFlags: 0
@@ -13260,7 +9486,7 @@ Transform:
   m_Father: {fileID: 461023104}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1280355241
+--- !u!1 &1312042430
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -13268,728 +9494,10 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1280355242}
-  - component: {fileID: 1280355243}
-  - component: {fileID: 1280355244}
-  - component: {fileID: 1280355245}
-  m_Layer: 0
-  m_Name: Left Ring Joint 0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1280355242
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1280355241}
-  m_LocalRotation: {x: 0.06767923, y: -0.06845519, z: 0.104890674, w: 0.9898138}
-  m_LocalPosition: {x: -0.017447187, y: 0.0040000137, z: 0.01727916}
-  m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999999}
-  m_Children:
-  - {fileID: 1991305267}
-  m_Father: {fileID: 632214914}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1280355243
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1280355241}
-  m_Material: {fileID: 1690218108}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.049370002
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.020685}
---- !u!171741748 &1280355244
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1280355241}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.017447187, y: 0.0040000137, z: 0.01727916}
-  m_ParentAnchorRotation: {x: 0.067679256, y: -0.06845519, z: 0.10489069, w: 0.9898139}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -30
-    upperLimit: 80
-    stiffness: 200
-    damping: 1
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -15
-    upperLimit: 15
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1280355245
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1280355241}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2057484866}
-  _body: {fileID: 1280355244}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 3
-  _joint: 0
---- !u!1 &1288267143
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1288267144}
-  - component: {fileID: 1288267145}
-  - component: {fileID: 1288267146}
-  - component: {fileID: 1288267147}
-  m_Layer: 0
-  m_Name: Right Index Joint 0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1288267144
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1288267143}
-  m_LocalRotation: {x: 0.07411184, y: -0.08401716, z: 0.0062662363, w: 0.99368477}
-  m_LocalPosition: {x: -0.023181278, y: 0.0020000078, z: 0.023149364}
-  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
-  m_Children:
-  - {fileID: 666865874}
-  m_Father: {fileID: 653981089}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1288267145
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1288267143}
-  m_Material: {fileID: 585538801}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.047780003
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.019890001}
---- !u!171741748 &1288267146
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1288267143}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.023181293, y: 0.0020000115, z: 0.023149366}
-  m_ParentAnchorRotation: {x: 0.07411185, y: -0.08401715, z: 0.0062662363, w: 0.9936849}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -30
-    upperLimit: 80
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -15
-    upperLimit: 15
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1288267147
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1288267143}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 575778803}
-  _body: {fileID: 1288267146}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 1
-  _joint: 0
---- !u!1 &1303817054
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1303817055}
-  - component: {fileID: 1303817056}
-  - component: {fileID: 1303817057}
-  - component: {fileID: 1303817058}
-  m_Layer: 0
-  m_Name: Right Pinky Joint 0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1303817055
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1303817054}
-  m_LocalRotation: {x: 0.029145695, y: 0.13843815, z: -0.17725913, w: 0.9739429}
-  m_LocalPosition: {x: 0.035337448, y: -0.000000009313226, z: 0.009728717}
-  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
-  m_Children:
-  - {fileID: 202587803}
-  m_Father: {fileID: 653981089}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1303817056
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1303817054}
-  m_Material: {fileID: 585538801}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.040740006
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.016370002}
---- !u!171741748 &1303817057
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1303817054}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.035337463, y: -0.000000013038516, z: 0.009728714}
-  m_ParentAnchorRotation: {x: 0.029145688, y: 0.13843818, z: -0.17725915, w: 0.973943}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -30
-    upperLimit: 80
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -15
-    upperLimit: 15
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1303817058
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1303817054}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 575778803}
-  _body: {fileID: 1303817057}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 4
-  _joint: 0
---- !u!1 &1305726771
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1305726773}
-  - component: {fileID: 1305726772}
-  - component: {fileID: 1305726774}
-  - component: {fileID: 1305726775}
-  m_Layer: 0
-  m_Name: Right Index Joint 2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!136 &1305726772
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1305726771}
-  m_Material: {fileID: 1081093971}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.023820002
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.00791}
---- !u!4 &1305726773
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1305726771}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.02238}
-  m_LocalScale: {x: 1, y: 1.0000001, z: 1}
-  m_Children: []
-  m_Father: {fileID: 517433465}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &1305726774
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1305726771}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.000000003725293, y: -0.00000001583249, z: 0.022380007}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1305726775
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1305726771}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2127376581}
-  _body: {fileID: 1305726774}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 1
-  _joint: 2
---- !u!134 &1324615029
-PhysicMaterial:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: HandPhysics
-  dynamicFriction: 1
-  staticFriction: 1
-  bounciness: 0
-  frictionCombine: 0
-  bounceCombine: 1
---- !u!1 &1326941325
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1326941326}
-  - component: {fileID: 1326941327}
-  - component: {fileID: 1326941328}
-  - component: {fileID: 1326941329}
-  m_Layer: 0
-  m_Name: Right Ring Joint 0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1326941326
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1326941325}
-  m_LocalRotation: {x: 0.067679256, y: 0.06845519, z: -0.104890674, w: 0.9898138}
-  m_LocalPosition: {x: 0.017447188, y: 0.004000012, z: 0.017279157}
-  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
-  m_Children:
-  - {fileID: 676571247}
-  m_Father: {fileID: 1085073651}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1326941327
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1326941325}
-  m_Material: {fileID: 189111359}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.049370002
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.020685}
---- !u!171741748 &1326941328
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1326941325}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.017447188, y: 0.004000012, z: 0.017279157}
-  m_ParentAnchorRotation: {x: 0.067679256, y: 0.06845519, z: -0.10489069, w: 0.9898139}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -30
-    upperLimit: 80
-    stiffness: 200
-    damping: 1
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -15
-    upperLimit: 15
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1326941329
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1326941325}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2045161950}
-  _body: {fileID: 1326941328}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 3
-  _joint: 0
---- !u!1 &1330061735
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1330061737}
-  - component: {fileID: 1330061736}
-  - component: {fileID: 1330061738}
-  - component: {fileID: 1330061739}
-  m_Layer: 0
-  m_Name: Left Index Joint 2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!136 &1330061736
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1330061735}
-  m_Material: {fileID: 1690218108}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.023820002
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.00791}
---- !u!4 &1330061737
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1330061735}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.02238}
-  m_LocalScale: {x: 1, y: 1.0000001, z: 1}
-  m_Children: []
-  m_Father: {fileID: 80499002}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &1330061738
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1330061735}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.0000000102445545, y: -0.000000020489109, z: 0.022380015}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1330061739
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1330061735}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2057484866}
-  _body: {fileID: 1330061738}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 1
-  _joint: 2
---- !u!1 &1331277408
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1331277409}
-  - component: {fileID: 1331277410}
-  - component: {fileID: 1331277411}
-  - component: {fileID: 1331277412}
+  - component: {fileID: 1312042431}
+  - component: {fileID: 1312042432}
+  - component: {fileID: 1312042433}
+  - component: {fileID: 1312042434}
   m_Layer: 0
   m_Name: Left Middle Joint 0
   m_TagString: Untagged
@@ -13997,42 +9505,42 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1331277409
+--- !u!4 &1312042431
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1331277408}
+  m_GameObject: {fileID: 1312042430}
   m_LocalRotation: {x: 0.07527789, y: 0.009242246, z: 0.073994935, w: 0.9943705}
   m_LocalPosition: {x: 0.002788771, y: 0.0040000007, z: 0.023252115}
   m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999999}
   m_Children:
-  - {fileID: 356802676}
-  m_Father: {fileID: 1921003926}
+  - {fileID: 1864567764}
+  m_Father: {fileID: 141516357}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1331277410
+--- !u!136 &1312042432
 CapsuleCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1331277408}
-  m_Material: {fileID: 2041109289}
+  m_GameObject: {fileID: 1312042430}
+  m_Material: {fileID: 232411772}
   m_IsTrigger: 0
   m_Enabled: 1
   m_Radius: 0.004
   m_Height: 0.052630004
   m_Direction: 2
   m_Center: {x: 0, y: 0, z: 0.022315001}
---- !u!171741748 &1331277411
+--- !u!171741748 &1312042433
 ArticulationBody:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1331277408}
+  m_GameObject: {fileID: 1312042430}
   m_Enabled: 1
   serializedVersion: 3
   m_Mass: 0.6
@@ -14040,7 +9548,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0.075277895, y: 0.0092422515, z: 0.073994935, w: 0.9943706}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
+  m_ComputeParentAnchor: 0
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -14078,141 +9586,23 @@ ArticulationBody:
   m_Immovable: 0
   m_UseGravity: 0
   m_CollisionDetectionMode: 3
---- !u!114 &1331277412
+--- !u!114 &1312042434
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1331277408}
+  m_GameObject: {fileID: 1312042430}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _hand: {fileID: 1656071730}
-  _body: {fileID: 1331277411}
+  _hand: {fileID: 1392200166}
+  _body: {fileID: 1312042433}
   _origXDriveLimit: 0
   _currentXDriveLimit: 3.4028235e+38
   _finger: 2
-  _joint: 0
---- !u!1 &1349590842
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1349590843}
-  - component: {fileID: 1349590844}
-  - component: {fileID: 1349590845}
-  - component: {fileID: 1349590846}
-  m_Layer: 0
-  m_Name: Left Ring Joint 0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1349590843
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1349590842}
-  m_LocalRotation: {x: 0.06767923, y: -0.06845519, z: 0.104890674, w: 0.9898138}
-  m_LocalPosition: {x: -0.017447187, y: 0.0040000137, z: 0.01727916}
-  m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999999}
-  m_Children:
-  - {fileID: 268531134}
-  m_Father: {fileID: 1921003926}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1349590844
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1349590842}
-  m_Material: {fileID: 2041109289}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.049370002
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.020685}
---- !u!171741748 &1349590845
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1349590842}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.017447187, y: 0.0040000137, z: 0.01727916}
-  m_ParentAnchorRotation: {x: 0.067679256, y: -0.06845519, z: 0.10489069, w: 0.9898139}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -30
-    upperLimit: 80
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -15
-    upperLimit: 15
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1349590846
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1349590842}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 1656071730}
-  _body: {fileID: 1349590845}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 3
   _joint: 0
 --- !u!1 &1354581305
 GameObject:
@@ -14438,7 +9828,7 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1364199983}
   m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &1371222474
+--- !u!1 &1392200165
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -14446,355 +9836,113 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1371222475}
-  - component: {fileID: 1371222476}
-  - component: {fileID: 1371222477}
-  - component: {fileID: 1371222478}
+  - component: {fileID: 1392200167}
+  - component: {fileID: 1392200166}
   m_Layer: 0
-  m_Name: Right Ring Joint 0
+  m_Name: Left Hand
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1371222475
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1371222474}
-  m_LocalRotation: {x: 0.067679256, y: 0.06845519, z: -0.104890674, w: 0.9898138}
-  m_LocalPosition: {x: 0.017447188, y: 0.004000012, z: 0.017279157}
-  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
-  m_Children:
-  - {fileID: 1412118569}
-  m_Father: {fileID: 1384551531}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1371222476
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1371222474}
-  m_Material: {fileID: 1081093971}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.049370002
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.020685}
---- !u!171741748 &1371222477
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1371222474}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.017447188, y: 0.004000012, z: 0.017279157}
-  m_ParentAnchorRotation: {x: 0.067679256, y: 0.06845519, z: -0.10489069, w: 0.9898139}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -30
-    upperLimit: 80
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -15
-    upperLimit: 15
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1371222478
+--- !u!114 &1392200166
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1371222474}
+  m_GameObject: {fileID: 1392200165}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Script: {fileID: 11500000, guid: 445639c80127bbd44b6bd9d34463b470, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _hand: {fileID: 2127376581}
-  _body: {fileID: 1371222477}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 3
-  _joint: 0
---- !u!1 &1384551527
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1384551531}
-  - component: {fileID: 1384551529}
-  - component: {fileID: 1384551528}
-  - component: {fileID: 1384551530}
-  m_Layer: 0
-  m_Name: Right Palm
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!65 &1384551528
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1384551527}
-  m_Material: {fileID: 1081093971}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 0.0833, y: 0.025, z: 0.103538476}
-  m_Center: {x: 0, y: 0.0025, z: -0.015}
---- !u!171741748 &1384551529
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1384551527}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 1.8000001
-  m_ParentAnchorPosition: {x: 0, y: 0, z: 0}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 0
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 2
-  m_SwingZ: 2
-  m_Twist: 2
-  m_XDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 0
-    damping: 0
-    forceLimit: 3.4028235e+38
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 0
-    damping: 0
-    forceLimit: 3.4028235e+38
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 0
-    damping: 0
-    forceLimit: 3.4028235e+38
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 50
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1384551530
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1384551527}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2127376581}
-  _body: {fileID: 1384551529}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 5
-  _joint: 0
---- !u!4 &1384551531
+  _physicsHand:
+    triggerDistance: 0.004
+    oldPosition: {x: 0, y: 0, z: 0}
+    gameObject: {fileID: 141516353}
+    rootObject: {fileID: 1392200165}
+    transform: {fileID: 141516357}
+    palmBone: {fileID: 141516356}
+    palmBody: {fileID: 141516355}
+    palmCollider: {fileID: 141516354}
+    jointBones:
+    - {fileID: 1811146121}
+    - {fileID: 1259386105}
+    - {fileID: 441012511}
+    - {fileID: 1633464196}
+    - {fileID: 981931940}
+    - {fileID: 2047016342}
+    - {fileID: 1312042434}
+    - {fileID: 1864567767}
+    - {fileID: 1677594519}
+    - {fileID: 401704357}
+    - {fileID: 290336281}
+    - {fileID: 912663690}
+    - {fileID: 1812239552}
+    - {fileID: 1584748076}
+    - {fileID: 720346355}
+    jointBodies:
+    - {fileID: 1811146120}
+    - {fileID: 1259386104}
+    - {fileID: 441012510}
+    - {fileID: 1633464195}
+    - {fileID: 981931939}
+    - {fileID: 2047016341}
+    - {fileID: 1312042433}
+    - {fileID: 1864567766}
+    - {fileID: 1677594518}
+    - {fileID: 401704356}
+    - {fileID: 290336280}
+    - {fileID: 912663689}
+    - {fileID: 1812239551}
+    - {fileID: 1584748075}
+    - {fileID: 720346354}
+    jointColliders:
+    - {fileID: 1811146119}
+    - {fileID: 1259386103}
+    - {fileID: 441012508}
+    - {fileID: 1633464194}
+    - {fileID: 981931938}
+    - {fileID: 2047016339}
+    - {fileID: 1312042432}
+    - {fileID: 1864567765}
+    - {fileID: 1677594516}
+    - {fileID: 401704355}
+    - {fileID: 290336279}
+    - {fileID: 912663687}
+    - {fileID: 1812239550}
+    - {fileID: 1584748074}
+    - {fileID: 720346352}
+    overRotationFrameCount: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+    defaultRotations:
+    - {x: -0.66444665, y: 0.34441158, z: 0.56378216, w: 0.34934354}
+    - {x: -0.1985088, y: 0.549382, z: 0.8101427, w: 0.04942208}
+    - {x: -0.09523581, y: 0.55546176, z: 0.82590574, w: 0.01649454}
+    - {x: -0.013266281, y: 0.54483914, z: 0.8380312, w: 0.026037559}
+    - {x: 0.081206754, y: 0.50801295, z: 0.85746795, w: -0.008782235}
+    - {x: -0.12940948, y: 0.4829629, z: 0.8627299, w: 0.07547908}
+    strength: 2
+    stiffness: 100
+    forceLimit: 1000
+    boneMass: 0.6
+    physicMaterial: {fileID: 232411772}
+  _handedness: 0
+--- !u!4 &1392200167
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1384551527}
-  m_LocalRotation: {x: -0.12940957, y: -0.4829629, z: -0.86272997, w: 0.07547912}
-  m_LocalPosition: {x: 0.22000004, y: -0.13000001, z: 0.26999998}
+  m_GameObject: {fileID: 1392200165}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 794028892}
-  - {fileID: 513332373}
-  - {fileID: 1216944352}
-  - {fileID: 1371222475}
-  - {fileID: 971476548}
-  m_Father: {fileID: 2127376582}
+  - {fileID: 141516357}
+  m_Father: {fileID: 1874090592}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1412118568
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1412118569}
-  - component: {fileID: 1412118570}
-  - component: {fileID: 1412118571}
-  - component: {fileID: 1412118572}
-  m_Layer: 0
-  m_Name: Right Ring Joint 1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1412118569
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1412118568}
-  m_LocalRotation: {x: -0, y: -0, z: -0.0000000018626451, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.04137}
-  m_LocalScale: {x: 0.9999999, y: 1, z: 0.9999999}
-  m_Children:
-  - {fileID: 1530934140}
-  m_Father: {fileID: 1371222475}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1412118570
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1412118568}
-  m_Material: {fileID: 1081093971}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.03365
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.012825}
---- !u!171741748 &1412118571
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1412118568}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.000000012107198, y: -0.000000013504181, z: 0.041370012}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1412118572
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1412118568}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2127376581}
-  _body: {fileID: 1412118571}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 3
-  _joint: 1
 --- !u!1 &1414173479
 GameObject:
   m_ObjectHideFlags: 0
@@ -14907,946 +10055,18 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1414173479}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &1422669236
-GameObject:
+--- !u!134 &1489137147
+PhysicMaterial:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1422669237}
-  - component: {fileID: 1422669238}
-  - component: {fileID: 1422669239}
-  - component: {fileID: 1422669240}
-  m_Layer: 0
-  m_Name: Left Middle Joint 0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1422669237
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1422669236}
-  m_LocalRotation: {x: 0.07527789, y: 0.009242246, z: 0.073994935, w: 0.9943705}
-  m_LocalPosition: {x: 0.002788771, y: 0.0040000007, z: 0.023252115}
-  m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999999}
-  m_Children:
-  - {fileID: 979227609}
-  m_Father: {fileID: 632214914}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1422669238
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1422669236}
-  m_Material: {fileID: 1690218108}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.052630004
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.022315001}
---- !u!171741748 &1422669239
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1422669236}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.002788771, y: 0.0040000007, z: 0.023252115}
-  m_ParentAnchorRotation: {x: 0.075277895, y: 0.0092422515, z: 0.073994935, w: 0.9943706}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -30
-    upperLimit: 80
-    stiffness: 200
-    damping: 1
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -15
-    upperLimit: 15
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1422669240
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1422669236}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2057484866}
-  _body: {fileID: 1422669239}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 2
-  _joint: 0
---- !u!1 &1434036243
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1434036245}
-  - component: {fileID: 1434036244}
-  - component: {fileID: 1434036246}
-  - component: {fileID: 1434036247}
-  m_Layer: 0
-  m_Name: Left Thumb Joint 2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!136 &1434036244
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1434036243}
-  m_Material: {fileID: 2041109289}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.02967
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.010835}
---- !u!4 &1434036245
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1434036243}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.031570002}
-  m_LocalScale: {x: 1, y: 1.0000001, z: 1.0000001}
-  m_Children: []
-  m_Father: {fileID: 1435153063}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &1434036246
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1434036243}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.000000009313227, y: -0.0000000037252916, z: 0.03157001}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1434036247
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1434036243}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 1656071730}
-  _body: {fileID: 1434036246}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 0
-  _joint: 2
---- !u!1 &1435153062
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1435153063}
-  - component: {fileID: 1435153064}
-  - component: {fileID: 1435153065}
-  - component: {fileID: 1435153066}
-  m_Layer: 0
-  m_Name: Left Thumb Joint 1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1435153063
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1435153062}
-  m_LocalRotation: {x: -0, y: -0, z: 0.00000001071021, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.046220005}
-  m_LocalScale: {x: 1.0000001, y: 0.9999999, z: 0.99999976}
-  m_Children:
-  - {fileID: 1434036245}
-  m_Father: {fileID: 226590106}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1435153064
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1435153062}
-  m_Material: {fileID: 2041109289}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.039570004
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.015785001}
---- !u!171741748 &1435153065
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1435153062}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 9.313228e-10, y: 0.00000000651926, z: 0.046220012}
-  m_ParentAnchorRotation: {x: 0.000000014901161, y: 0, z: 0.000000029802322, w: 1.0000001}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1435153066
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1435153062}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 1656071730}
-  _body: {fileID: 1435153065}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 0
-  _joint: 1
---- !u!1 &1462953420
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1462953422}
-  - component: {fileID: 1462953421}
-  - component: {fileID: 1462953423}
-  - component: {fileID: 1462953424}
-  m_Layer: 0
-  m_Name: Right Pinky Joint 2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!136 &1462953421
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1462953420}
-  m_Material: {fileID: 585538801}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.023960002
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.00798}
---- !u!4 &1462953422
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1462953420}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.018110001}
-  m_LocalScale: {x: 1.0000001, y: 0.9999999, z: 1}
-  m_Children: []
-  m_Father: {fileID: 202587803}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &1462953423
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1462953420}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.000000015832498, y: 0.00000000884757, z: 0.018110014}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000004}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1462953424
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1462953420}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 575778803}
-  _body: {fileID: 1462953423}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 4
-  _joint: 2
---- !u!1 &1509403552
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1509403553}
-  - component: {fileID: 1509403554}
-  - component: {fileID: 1509403555}
-  - component: {fileID: 1509403556}
-  m_Layer: 0
-  m_Name: Right Pinky Joint 1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1509403553
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1509403552}
-  m_LocalRotation: {x: -0, y: -0, z: 4.6566123e-10, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.032740004}
-  m_LocalScale: {x: 0.9999994, y: 0.99999964, z: 0.99999976}
-  m_Children:
-  - {fileID: 32345357}
-  m_Father: {fileID: 182831394}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1509403554
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1509403552}
-  m_Material: {fileID: 189111359}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.02611
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.009055001}
---- !u!171741748 &1509403555
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1509403552}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.000000022817412, y: -0.000000010069928, z: 0.03274001}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000004}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1509403556
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1509403552}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2045161950}
-  _body: {fileID: 1509403555}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 4
-  _joint: 1
---- !u!1 &1523185466
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1523185468}
-  - component: {fileID: 1523185467}
-  - component: {fileID: 1523185469}
-  - component: {fileID: 1523185470}
-  m_Layer: 0
-  m_Name: Left Ring Joint 2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!136 &1523185467
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1523185466}
-  m_Material: {fileID: 2041109289}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.0253
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.00865}
---- !u!4 &1523185468
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1523185466}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.02565}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 268531134}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &1523185469
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1523185466}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 9.31323e-10, y: -0.000000025145715, z: 0.02565002}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1523185470
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1523185466}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 1656071730}
-  _body: {fileID: 1523185469}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 3
-  _joint: 2
---- !u!1 &1530934138
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1530934140}
-  - component: {fileID: 1530934139}
-  - component: {fileID: 1530934141}
-  - component: {fileID: 1530934142}
-  m_Layer: 0
-  m_Name: Right Ring Joint 2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!136 &1530934139
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1530934138}
-  m_Material: {fileID: 1081093971}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.0253
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.00865}
---- !u!4 &1530934140
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1530934138}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.02565}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1412118569}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &1530934141
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1530934138}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.000000005587938, y: -0.000000020489102, z: 0.02565001}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1530934142
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1530934138}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2127376581}
-  _body: {fileID: 1530934141}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 3
-  _joint: 2
---- !u!1 &1535878786
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1535878787}
-  - component: {fileID: 1535878788}
-  - component: {fileID: 1535878789}
-  - component: {fileID: 1535878790}
-  m_Layer: 0
-  m_Name: Right Ring Joint 1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1535878787
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1535878786}
-  m_LocalRotation: {x: -0, y: -0, z: -0.0000000018626451, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.04137}
-  m_LocalScale: {x: 0.9999999, y: 1, z: 0.9999999}
-  m_Children:
-  - {fileID: 585023816}
-  m_Father: {fileID: 102763816}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1535878788
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1535878786}
-  m_Material: {fileID: 585538801}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.03365
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.012825}
---- !u!171741748 &1535878789
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1535878786}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.000000012107198, y: -0.000000013504181, z: 0.041370012}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1535878790
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1535878786}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 575778803}
-  _body: {fileID: 1535878789}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 3
-  _joint: 1
+  m_Name: HandPhysics
+  dynamicFriction: 1
+  staticFriction: 1
+  bounciness: 0
+  frictionCombine: 0
+  bounceCombine: 1
 --- !u!1 &1543569617
 GameObject:
   m_ObjectHideFlags: 0
@@ -15992,356 +10212,6 @@ PrefabInstance:
       objectReference: {fileID: 861115678}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5fad9bc118c955741a03cf98cf3f0a46, type: 3}
---- !u!1 &1552987638
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1552987640}
-  - component: {fileID: 1552987639}
-  m_Layer: 0
-  m_Name: Left Hand
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1552987639
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1552987638}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 445639c80127bbd44b6bd9d34463b470, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _physicsHand:
-    triggerDistance: 0.004
-    oldPosition: {x: 0, y: 0, z: 0}
-    gameObject: {fileID: 889282509}
-    rootObject: {fileID: 1552987638}
-    transform: {fileID: 889282513}
-    palmBone: {fileID: 889282512}
-    palmBody: {fileID: 889282511}
-    palmCollider: {fileID: 889282510}
-    jointBones:
-    - {fileID: 1211426964}
-    - {fileID: 1945723381}
-    - {fileID: 236780707}
-    - {fileID: 143027717}
-    - {fileID: 84440801}
-    - {fileID: 1559450539}
-    - {fileID: 80816730}
-    - {fileID: 246457850}
-    - {fileID: 928808899}
-    - {fileID: 1120470098}
-    - {fileID: 1642491621}
-    - {fileID: 462755187}
-    - {fileID: 1660436108}
-    - {fileID: 1973713159}
-    - {fileID: 71022536}
-    jointBodies:
-    - {fileID: 1211426963}
-    - {fileID: 1945723380}
-    - {fileID: 236780706}
-    - {fileID: 143027716}
-    - {fileID: 84440800}
-    - {fileID: 1559450538}
-    - {fileID: 80816729}
-    - {fileID: 246457849}
-    - {fileID: 928808898}
-    - {fileID: 1120470097}
-    - {fileID: 1642491620}
-    - {fileID: 462755186}
-    - {fileID: 1660436107}
-    - {fileID: 1973713158}
-    - {fileID: 71022535}
-    jointColliders:
-    - {fileID: 1211426962}
-    - {fileID: 1945723379}
-    - {fileID: 236780704}
-    - {fileID: 143027715}
-    - {fileID: 84440799}
-    - {fileID: 1559450536}
-    - {fileID: 80816728}
-    - {fileID: 246457848}
-    - {fileID: 928808896}
-    - {fileID: 1120470096}
-    - {fileID: 1642491619}
-    - {fileID: 462755184}
-    - {fileID: 1660436106}
-    - {fileID: 1973713157}
-    - {fileID: 71022533}
-    overRotationFrameCount: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-    defaultRotations:
-    - {x: -0.66444665, y: 0.34441158, z: 0.56378216, w: 0.34934354}
-    - {x: -0.1985088, y: 0.549382, z: 0.8101427, w: 0.04942208}
-    - {x: -0.09523581, y: 0.55546176, z: 0.82590574, w: 0.01649454}
-    - {x: -0.013266281, y: 0.54483914, z: 0.8380312, w: 0.026037559}
-    - {x: 0.081206754, y: 0.50801295, z: 0.85746795, w: -0.008782235}
-    - {x: -0.12940948, y: 0.4829629, z: 0.8627299, w: 0.07547908}
-    strength: 2
-    stiffness: 100
-    forceLimit: 1000
-    boneMass: 0.6
-    physicMaterial: {fileID: 1324615029}
-  _handedness: 0
---- !u!4 &1552987640
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1552987638}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 889282513}
-  m_Father: {fileID: 1874090592}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1559450535
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1559450537}
-  - component: {fileID: 1559450536}
-  - component: {fileID: 1559450538}
-  - component: {fileID: 1559450539}
-  m_Layer: 0
-  m_Name: Left Index Joint 2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!136 &1559450536
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1559450535}
-  m_Material: {fileID: 1324615029}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.023820002
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.00791}
---- !u!4 &1559450537
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1559450535}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.02238}
-  m_LocalScale: {x: 1, y: 1.0000001, z: 1}
-  m_Children: []
-  m_Father: {fileID: 84440798}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &1559450538
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1559450535}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.0000000102445545, y: -0.000000020489109, z: 0.022380015}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1559450539
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1559450535}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 1552987639}
-  _body: {fileID: 1559450538}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 1
-  _joint: 2
---- !u!1 &1569510032
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1569510033}
-  - component: {fileID: 1569510034}
-  - component: {fileID: 1569510035}
-  - component: {fileID: 1569510036}
-  m_Layer: 0
-  m_Name: Left Thumb Joint 1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1569510033
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1569510032}
-  m_LocalRotation: {x: -0, y: -0, z: 0.00000001071021, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.046220005}
-  m_LocalScale: {x: 1.0000001, y: 0.9999999, z: 0.99999976}
-  m_Children:
-  - {fileID: 1853180999}
-  m_Father: {fileID: 2058509477}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1569510034
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1569510032}
-  m_Material: {fileID: 1690218108}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.039570004
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.015785001}
---- !u!171741748 &1569510035
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1569510032}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 9.313228e-10, y: 0.00000000651926, z: 0.046220012}
-  m_ParentAnchorRotation: {x: 0.000000014901161, y: 0, z: 0.000000029802322, w: 1.0000001}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 2
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1569510036
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1569510032}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2057484866}
-  _body: {fileID: 1569510035}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 0
-  _joint: 1
 --- !u!1 &1571827756
 GameObject:
   m_ObjectHideFlags: 0
@@ -16508,7 +10378,7 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1579406070}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &1579476875
+--- !u!1 &1584748072
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -16516,60 +10386,61 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1579476877}
-  - component: {fileID: 1579476876}
-  - component: {fileID: 1579476878}
-  - component: {fileID: 1579476879}
+  - component: {fileID: 1584748073}
+  - component: {fileID: 1584748074}
+  - component: {fileID: 1584748075}
+  - component: {fileID: 1584748076}
   m_Layer: 0
-  m_Name: Right Middle Joint 2
+  m_Name: Left Pinky Joint 1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!136 &1579476876
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1579476875}
-  m_Material: {fileID: 585538801}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.025400002
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.0087}
---- !u!4 &1579476877
+--- !u!4 &1584748073
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1579476875}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.026330002}
-  m_LocalScale: {x: 1.0000001, y: 1.0000001, z: 1.0000001}
-  m_Children: []
-  m_Father: {fileID: 1993941822}
+  m_GameObject: {fileID: 1584748072}
+  m_LocalRotation: {x: -0.0000000018626449, y: -0, z: -0.000000006053596, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.032740004}
+  m_LocalScale: {x: 0.9999999, y: 1, z: 1}
+  m_Children:
+  - {fileID: 720346353}
+  m_Father: {fileID: 1812239549}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &1579476878
+--- !u!136 &1584748074
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1584748072}
+  m_Material: {fileID: 232411772}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.02611
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.009055001}
+--- !u!171741748 &1584748075
 ArticulationBody:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1579476875}
+  m_GameObject: {fileID: 1584748072}
   m_Enabled: 1
   serializedVersion: 3
   m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 2.3283078e-10, y: 0.0000000055879377, z: 0.026330026}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
+  m_ParentAnchorPosition: {x: -0.000000017695132, y: -0.0000000137370115, z: 0.03274001}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
+  m_ComputeParentAnchor: 0
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -16607,141 +10478,24 @@ ArticulationBody:
   m_Immovable: 0
   m_UseGravity: 0
   m_CollisionDetectionMode: 3
---- !u!114 &1579476879
+--- !u!114 &1584748076
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1579476875}
+  m_GameObject: {fileID: 1584748072}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _hand: {fileID: 575778803}
-  _body: {fileID: 1579476878}
+  _hand: {fileID: 1392200166}
+  _body: {fileID: 1584748075}
   _origXDriveLimit: 0
   _currentXDriveLimit: 3.4028235e+38
-  _finger: 2
-  _joint: 2
---- !u!1 &1613455050
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1613455052}
-  - component: {fileID: 1613455051}
-  - component: {fileID: 1613455053}
-  - component: {fileID: 1613455054}
-  m_Layer: 0
-  m_Name: Right Thumb Joint 2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!136 &1613455051
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1613455050}
-  m_Material: {fileID: 585538801}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.02967
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.010835}
---- !u!4 &1613455052
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1613455050}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.031570002}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1828296616}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &1613455053
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1613455050}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.000000018626457, y: 0.000000031664985, z: 0.031570025}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1613455054
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1613455050}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 575778803}
-  _body: {fileID: 1613455053}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 0
-  _joint: 2
+  _finger: 4
+  _joint: 1
 --- !u!1001 &1622661662
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -16855,7 +10609,7 @@ PrefabInstance:
       objectReference: {fileID: 2131980833}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5fad9bc118c955741a03cf98cf3f0a46, type: 3}
---- !u!1 &1625487769
+--- !u!1 &1623982458
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -16863,57 +10617,57 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1625487771}
-  - component: {fileID: 1625487770}
-  - component: {fileID: 1625487772}
-  - component: {fileID: 1625487773}
+  - component: {fileID: 1623982460}
+  - component: {fileID: 1623982459}
+  - component: {fileID: 1623982461}
+  - component: {fileID: 1623982462}
   m_Layer: 0
-  m_Name: Right Ring Joint 2
+  m_Name: Right Pinky Joint 2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!136 &1625487770
+--- !u!136 &1623982459
 CapsuleCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1625487769}
-  m_Material: {fileID: 189111359}
+  m_GameObject: {fileID: 1623982458}
+  m_Material: {fileID: 1489137147}
   m_IsTrigger: 0
   m_Enabled: 1
   m_Radius: 0.004
-  m_Height: 0.0253
+  m_Height: 0.023960002
   m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.00865}
---- !u!4 &1625487771
+  m_Center: {x: 0, y: 0, z: 0.00798}
+--- !u!4 &1623982460
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1625487769}
+  m_GameObject: {fileID: 1623982458}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.02565}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.018110001}
+  m_LocalScale: {x: 1.0000001, y: 0.9999999, z: 1}
   m_Children: []
-  m_Father: {fileID: 676571247}
+  m_Father: {fileID: 1892537475}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &1625487772
+--- !u!171741748 &1623982461
 ArticulationBody:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1625487769}
+  m_GameObject: {fileID: 1623982458}
   m_Enabled: 1
   serializedVersion: 3
   m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.000000005587938, y: -0.000000020489102, z: 0.02565001}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
+  m_ParentAnchorPosition: {x: 0.000000015832498, y: 0.00000000884757, z: 0.018110014}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000004}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
   m_ComputeParentAnchor: 0
@@ -16929,7 +10683,7 @@ ArticulationBody:
     upperLimit: 89
     stiffness: 200
     damping: 1
-    forceLimit: 100000
+    forceLimit: 180001.81
     target: 0
     targetVelocity: 0
   m_YDrive:
@@ -16937,7 +10691,7 @@ ArticulationBody:
     upperLimit: 8
     stiffness: 200
     damping: 2
-    forceLimit: 100000
+    forceLimit: 180001.81
     target: 0
     targetVelocity: 0
   m_ZDrive:
@@ -16945,7 +10699,7 @@ ArticulationBody:
     upperLimit: 0
     stiffness: 200
     damping: 2
-    forceLimit: 100000
+    forceLimit: 180001.81
     target: 0
     targetVelocity: 0
   m_LinearDamping: 0
@@ -16954,25 +10708,25 @@ ArticulationBody:
   m_Immovable: 0
   m_UseGravity: 0
   m_CollisionDetectionMode: 3
---- !u!114 &1625487773
+--- !u!114 &1623982462
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1625487769}
+  m_GameObject: {fileID: 1623982458}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _hand: {fileID: 2045161950}
-  _body: {fileID: 1625487772}
+  _hand: {fileID: 138166228}
+  _body: {fileID: 1623982461}
   _origXDriveLimit: 0
   _currentXDriveLimit: 3.4028235e+38
-  _finger: 3
+  _finger: 4
   _joint: 2
---- !u!1 &1642491617
+--- !u!1 &1633464192
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -16980,291 +10734,58 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1642491618}
-  - component: {fileID: 1642491619}
-  - component: {fileID: 1642491620}
-  - component: {fileID: 1642491621}
+  - component: {fileID: 1633464193}
+  - component: {fileID: 1633464194}
+  - component: {fileID: 1633464195}
+  - component: {fileID: 1633464196}
   m_Layer: 0
-  m_Name: Left Ring Joint 1
+  m_Name: Left Index Joint 0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1642491618
+--- !u!4 &1633464193
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1642491617}
-  m_LocalRotation: {x: -0, y: -0, z: -4.656613e-10, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.04137}
-  m_LocalScale: {x: 0.99999976, y: 1, z: 1}
-  m_Children:
-  - {fileID: 462755185}
-  m_Father: {fileID: 1120470095}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1642491619
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1642491617}
-  m_Material: {fileID: 1324615029}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.03365
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.012825}
---- !u!171741748 &1642491620
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1642491617}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.0000000093132275, y: -0.000000015366826, z: 0.04137001}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1642491621
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1642491617}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 1552987639}
-  _body: {fileID: 1642491620}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 3
-  _joint: 1
---- !u!1 &1656071729
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1656071731}
-  - component: {fileID: 1656071730}
-  m_Layer: 0
-  m_Name: Left Hand
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1656071730
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1656071729}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 445639c80127bbd44b6bd9d34463b470, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _physicsHand:
-    triggerDistance: 0.004
-    oldPosition: {x: 0, y: 0, z: 0}
-    gameObject: {fileID: 1921003922}
-    rootObject: {fileID: 1656071729}
-    transform: {fileID: 1921003926}
-    palmBone: {fileID: 1921003925}
-    palmBody: {fileID: 1921003924}
-    palmCollider: {fileID: 1921003923}
-    jointBones:
-    - {fileID: 226590109}
-    - {fileID: 1435153066}
-    - {fileID: 1434036247}
-    - {fileID: 674034233}
-    - {fileID: 1859197416}
-    - {fileID: 931978645}
-    - {fileID: 1331277412}
-    - {fileID: 356802679}
-    - {fileID: 1883123096}
-    - {fileID: 1349590846}
-    - {fileID: 268531137}
-    - {fileID: 1523185470}
-    - {fileID: 891900970}
-    - {fileID: 315683686}
-    - {fileID: 2115103743}
-    jointBodies:
-    - {fileID: 226590108}
-    - {fileID: 1435153065}
-    - {fileID: 1434036246}
-    - {fileID: 674034232}
-    - {fileID: 1859197415}
-    - {fileID: 931978644}
-    - {fileID: 1331277411}
-    - {fileID: 356802678}
-    - {fileID: 1883123095}
-    - {fileID: 1349590845}
-    - {fileID: 268531136}
-    - {fileID: 1523185469}
-    - {fileID: 891900969}
-    - {fileID: 315683685}
-    - {fileID: 2115103742}
-    jointColliders:
-    - {fileID: 226590107}
-    - {fileID: 1435153064}
-    - {fileID: 1434036244}
-    - {fileID: 674034231}
-    - {fileID: 1859197414}
-    - {fileID: 931978642}
-    - {fileID: 1331277410}
-    - {fileID: 356802677}
-    - {fileID: 1883123093}
-    - {fileID: 1349590844}
-    - {fileID: 268531135}
-    - {fileID: 1523185467}
-    - {fileID: 891900968}
-    - {fileID: 315683684}
-    - {fileID: 2115103740}
-    overRotationFrameCount: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-    defaultRotations:
-    - {x: -0.66444665, y: 0.34441158, z: 0.56378216, w: 0.34934354}
-    - {x: -0.1985088, y: 0.549382, z: 0.8101427, w: 0.04942208}
-    - {x: -0.09523581, y: 0.55546176, z: 0.82590574, w: 0.01649454}
-    - {x: -0.013266281, y: 0.54483914, z: 0.8380312, w: 0.026037559}
-    - {x: 0.081206754, y: 0.50801295, z: 0.85746795, w: -0.008782235}
-    - {x: -0.12940948, y: 0.4829629, z: 0.8627299, w: 0.07547908}
-    strength: 2
-    stiffness: 100
-    forceLimit: 1000
-    boneMass: 0.6
-    physicMaterial: {fileID: 2041109289}
-  _handedness: 0
---- !u!4 &1656071731
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1656071729}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1921003926}
-  m_Father: {fileID: 1874090592}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1660436104
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1660436105}
-  - component: {fileID: 1660436106}
-  - component: {fileID: 1660436107}
-  - component: {fileID: 1660436108}
-  m_Layer: 0
-  m_Name: Left Pinky Joint 0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1660436105
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1660436104}
-  m_LocalRotation: {x: 0.02914566, y: -0.13843812, z: 0.17725913, w: 0.9739428}
-  m_LocalPosition: {x: -0.035337448, y: -0.000000004656613, z: 0.00972872}
+  m_GameObject: {fileID: 1633464192}
+  m_LocalRotation: {x: 0.074111804, y: 0.08401716, z: -0.006266229, w: 0.99368477}
+  m_LocalPosition: {x: 0.023181278, y: 0.0020000078, z: 0.023149362}
   m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999999}
   m_Children:
-  - {fileID: 1973713156}
-  m_Father: {fileID: 889282513}
-  m_RootOrder: 4
+  - {fileID: 981931937}
+  m_Father: {fileID: 141516357}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1660436106
+--- !u!136 &1633464194
 CapsuleCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1660436104}
-  m_Material: {fileID: 1324615029}
+  m_GameObject: {fileID: 1633464192}
+  m_Material: {fileID: 232411772}
   m_IsTrigger: 0
   m_Enabled: 1
   m_Radius: 0.004
-  m_Height: 0.040740006
+  m_Height: 0.047780003
   m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.016370002}
---- !u!171741748 &1660436107
+  m_Center: {x: 0, y: 0, z: 0.019890001}
+--- !u!171741748 &1633464195
 ArticulationBody:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1660436104}
+  m_GameObject: {fileID: 1633464192}
   m_Enabled: 1
   serializedVersion: 3
   m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.035337463, y: -0.000000008381903, z: 0.009728719}
-  m_ParentAnchorRotation: {x: 0.029145658, y: -0.13843812, z: 0.17725913, w: 0.97394294}
+  m_ParentAnchorPosition: {x: 0.023181278, y: 0.0020000078, z: 0.023149362}
+  m_ParentAnchorRotation: {x: 0.07411182, y: 0.08401718, z: -0.006266229, w: 0.9936849}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
   m_ComputeParentAnchor: 0
@@ -17305,24 +10826,141 @@ ArticulationBody:
   m_Immovable: 0
   m_UseGravity: 0
   m_CollisionDetectionMode: 3
---- !u!114 &1660436108
+--- !u!114 &1633464196
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1660436104}
+  m_GameObject: {fileID: 1633464192}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _hand: {fileID: 1552987639}
-  _body: {fileID: 1660436107}
+  _hand: {fileID: 1392200166}
+  _body: {fileID: 1633464195}
   _origXDriveLimit: 0
   _currentXDriveLimit: 3.4028235e+38
-  _finger: 4
+  _finger: 1
   _joint: 0
+--- !u!1 &1677594515
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1677594517}
+  - component: {fileID: 1677594516}
+  - component: {fileID: 1677594518}
+  - component: {fileID: 1677594519}
+  m_Layer: 0
+  m_Name: Left Middle Joint 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!136 &1677594516
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1677594515}
+  m_Material: {fileID: 232411772}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.025400002
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.0087}
+--- !u!4 &1677594517
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1677594515}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.026330002}
+  m_LocalScale: {x: 1, y: 0.9999999, z: 0.9999999}
+  m_Children: []
+  m_Father: {fileID: 1864567764}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!171741748 &1677594518
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1677594515}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 4.656617e-10, y: -0.00000000931323, z: 0.026330002}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1677594519
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1677594515}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 1392200166}
+  _body: {fileID: 1677594518}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 2
+  _joint: 2
 --- !u!1 &1678954819
 GameObject:
   m_ObjectHideFlags: 0
@@ -17450,18 +11088,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1678954819}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!134 &1690218108
-PhysicMaterial:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: HandPhysics
-  dynamicFriction: 1
-  staticFriction: 1
-  bounciness: 0
-  frictionCombine: 0
-  bounceCombine: 1
 --- !u!1 &1738364525
 GameObject:
   m_ObjectHideFlags: 0
@@ -17854,6 +11480,135 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1758430179}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!134 &1764721397
+PhysicMaterial:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Button Material
+  dynamicFriction: 1
+  staticFriction: 1
+  bounciness: 0
+  frictionCombine: 3
+  bounceCombine: 0
+--- !u!1 &1791223835
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1791223837}
+  - component: {fileID: 1791223836}
+  - component: {fileID: 1791223838}
+  - component: {fileID: 1791223839}
+  m_Layer: 0
+  m_Name: Right Index Joint 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!136 &1791223836
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1791223835}
+  m_Material: {fileID: 1489137147}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.023820002
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.00791}
+--- !u!4 &1791223837
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1791223835}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.02238}
+  m_LocalScale: {x: 1, y: 1.0000001, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2117531306}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!171741748 &1791223838
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1791223835}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.000000003725293, y: -0.00000001583249, z: 0.022380007}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1791223839
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1791223835}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 138166228}
+  _body: {fileID: 1791223838}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 1
+  _joint: 2
 --- !u!1 &1800377261
 GameObject:
   m_ObjectHideFlags: 0
@@ -17981,6 +11736,242 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1800377261}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1811146117
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1811146118}
+  - component: {fileID: 1811146119}
+  - component: {fileID: 1811146120}
+  - component: {fileID: 1811146121}
+  m_Layer: 0
+  m_Name: Left Thumb Joint 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1811146118
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1811146117}
+  m_LocalRotation: {x: 0.019904852, y: 0.35755512, z: -0.53516835, w: 0.7650836}
+  m_LocalPosition: {x: 0.019338273, y: -0.006000001, z: -0.053168494}
+  m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999999}
+  m_Children:
+  - {fileID: 1259386102}
+  m_Father: {fileID: 141516357}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1811146119
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1811146117}
+  m_Material: {fileID: 232411772}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.054220006
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.023110002}
+--- !u!171741748 &1811146120
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1811146117}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 0.019338273, y: -0.0059999935, z: -0.053168505}
+  m_ParentAnchorRotation: {x: 0.019904822, y: 0.35755518, z: -0.5351684, w: 0.7650837}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -45
+    upperLimit: 45
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -10
+    upperLimit: 50
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1811146121
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1811146117}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 1392200166}
+  _body: {fileID: 1811146120}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 0
+  _joint: 0
+--- !u!1 &1812239548
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1812239549}
+  - component: {fileID: 1812239550}
+  - component: {fileID: 1812239551}
+  - component: {fileID: 1812239552}
+  m_Layer: 0
+  m_Name: Left Pinky Joint 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1812239549
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1812239548}
+  m_LocalRotation: {x: 0.02914566, y: -0.13843812, z: 0.17725913, w: 0.9739428}
+  m_LocalPosition: {x: -0.035337448, y: -0.000000004656613, z: 0.00972872}
+  m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999999}
+  m_Children:
+  - {fileID: 1584748073}
+  m_Father: {fileID: 141516357}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1812239550
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1812239548}
+  m_Material: {fileID: 232411772}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.040740006
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.016370002}
+--- !u!171741748 &1812239551
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1812239548}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.035337463, y: -0.000000008381903, z: 0.009728719}
+  m_ParentAnchorRotation: {x: 0.029145658, y: -0.13843812, z: 0.17725913, w: 0.97394294}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -30
+    upperLimit: 80
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -15
+    upperLimit: 15
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1812239552
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1812239548}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 1392200166}
+  _body: {fileID: 1812239551}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 4
+  _joint: 0
 --- !u!1 &1812745758
 GameObject:
   m_ObjectHideFlags: 0
@@ -18025,7 +12016,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 42bf16dc17d04074399626551f65de64, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _physicsHand: {fileID: 575778803}
+  _physicsHand: {fileID: 0}
   _handModel: {fileID: 4092936678244321215}
   _alpha: 0.05
   _minimumDistance: 0.02
@@ -18126,241 +12117,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1825213261}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &1828296615
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1828296616}
-  - component: {fileID: 1828296617}
-  - component: {fileID: 1828296618}
-  - component: {fileID: 1828296619}
-  m_Layer: 0
-  m_Name: Right Thumb Joint 1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1828296616
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1828296615}
-  m_LocalRotation: {x: -0, y: -0, z: -0.0000000088475645, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.046220005}
-  m_LocalScale: {x: 1.0000001, y: 0.99999964, z: 0.9999995}
-  m_Children:
-  - {fileID: 1613455052}
-  m_Father: {fileID: 2116615599}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1828296617
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1828296615}
-  m_Material: {fileID: 585538801}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.039570004
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.015785001}
---- !u!171741748 &1828296618
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1828296615}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.0000000130385205, y: 0.0000000046566138, z: 0.046220012}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1828296619
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1828296615}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 575778803}
-  _body: {fileID: 1828296618}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 0
-  _joint: 1
---- !u!1 &1830967251
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1830967253}
-  - component: {fileID: 1830967252}
-  - component: {fileID: 1830967254}
-  - component: {fileID: 1830967255}
-  m_Layer: 0
-  m_Name: Right Index Joint 2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!136 &1830967252
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1830967251}
-  m_Material: {fileID: 189111359}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.023820002
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.00791}
---- !u!4 &1830967253
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1830967251}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.02238}
-  m_LocalScale: {x: 1, y: 1.0000001, z: 1}
-  m_Children: []
-  m_Father: {fileID: 334822913}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &1830967254
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1830967251}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.000000003725293, y: -0.00000001583249, z: 0.022380007}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1830967255
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1830967251}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2045161950}
-  _body: {fileID: 1830967254}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 1
-  _joint: 2
 --- !u!1 &1838090639
 GameObject:
   m_ObjectHideFlags: 0
@@ -18569,7 +12325,7 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1842197905}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &1853180997
+--- !u!1 &1843646417
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -18577,61 +12333,62 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1853180999}
-  - component: {fileID: 1853180998}
-  - component: {fileID: 1853181000}
-  - component: {fileID: 1853181001}
+  - component: {fileID: 1843646418}
+  - component: {fileID: 1843646419}
+  - component: {fileID: 1843646420}
+  - component: {fileID: 1843646421}
   m_Layer: 0
-  m_Name: Left Thumb Joint 2
+  m_Name: Right Thumb Joint 0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!136 &1853180998
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1853180997}
-  m_Material: {fileID: 1690218108}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.02967
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.010835}
---- !u!4 &1853180999
+--- !u!4 &1843646418
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1853180997}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.031570002}
-  m_LocalScale: {x: 1, y: 1.0000001, z: 1.0000001}
-  m_Children: []
-  m_Father: {fileID: 1569510033}
+  m_GameObject: {fileID: 1843646417}
+  m_LocalRotation: {x: 0.019904856, y: -0.35755515, z: 0.53516835, w: 0.7650837}
+  m_LocalPosition: {x: -0.01933824, y: -0.0059999824, z: -0.05316848}
+  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
+  m_Children:
+  - {fileID: 839701698}
+  m_Father: {fileID: 705853064}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &1853181000
+--- !u!136 &1843646419
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1843646417}
+  m_Material: {fileID: 1489137147}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.054220006
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.023110002}
+--- !u!171741748 &1843646420
 ArticulationBody:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1853180997}
+  m_GameObject: {fileID: 1843646417}
   m_Enabled: 1
   serializedVersion: 3
   m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.000000009313227, y: -0.0000000037252916, z: 0.03157001}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
+  m_ParentAnchorPosition: {x: -0.01933824, y: -0.0059999824, z: -0.05316848}
+  m_ParentAnchorRotation: {x: 0.019904852, y: -0.35755515, z: 0.53516847, w: 0.7650838}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
   m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 2
+  m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
   m_LinearZ: 2
@@ -18639,19 +12396,19 @@ ArticulationBody:
   m_SwingZ: 1
   m_Twist: 1
   m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
+    lowerLimit: -45
+    upperLimit: 45
     stiffness: 200
     damping: 1
-    forceLimit: 100000
+    forceLimit: 180001.81
     target: 0
     targetVelocity: 0
   m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
+    lowerLimit: -50
+    upperLimit: 10
     stiffness: 200
     damping: 2
-    forceLimit: 100000
+    forceLimit: 180001.81
     target: 0
     targetVelocity: 0
   m_ZDrive:
@@ -18659,7 +12416,7 @@ ArticulationBody:
     upperLimit: 0
     stiffness: 200
     damping: 2
-    forceLimit: 100000
+    forceLimit: 180001.81
     target: 0
     targetVelocity: 0
   m_LinearDamping: 0
@@ -18668,25 +12425,25 @@ ArticulationBody:
   m_Immovable: 0
   m_UseGravity: 0
   m_CollisionDetectionMode: 3
---- !u!114 &1853181001
+--- !u!114 &1843646421
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1853180997}
+  m_GameObject: {fileID: 1843646417}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _hand: {fileID: 2057484866}
-  _body: {fileID: 1853181000}
+  _hand: {fileID: 138166228}
+  _body: {fileID: 1843646420}
   _origXDriveLimit: 0
   _currentXDriveLimit: 3.4028235e+38
   _finger: 0
-  _joint: 2
---- !u!1 &1859197412
+  _joint: 0
+--- !u!1 &1851164602
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -18694,61 +12451,61 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1859197413}
-  - component: {fileID: 1859197414}
-  - component: {fileID: 1859197415}
-  - component: {fileID: 1859197416}
+  - component: {fileID: 1851164603}
+  - component: {fileID: 1851164604}
+  - component: {fileID: 1851164605}
+  - component: {fileID: 1851164606}
   m_Layer: 0
-  m_Name: Left Index Joint 1
+  m_Name: Right Middle Joint 1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1859197413
+--- !u!4 &1851164603
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1859197412}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.039780002}
-  m_LocalScale: {x: 0.99999964, y: 0.99999964, z: 0.99999976}
+  m_GameObject: {fileID: 1851164602}
+  m_LocalRotation: {x: -0, y: -0, z: 9.895301e-10, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.044630002}
+  m_LocalScale: {x: 0.99999976, y: 0.9999999, z: 0.99999976}
   m_Children:
-  - {fileID: 931978643}
-  m_Father: {fileID: 674034230}
+  - {fileID: 781686254}
+  m_Father: {fileID: 468922237}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1859197414
+--- !u!136 &1851164604
 CapsuleCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1859197412}
-  m_Material: {fileID: 2041109289}
+  m_GameObject: {fileID: 1851164602}
+  m_Material: {fileID: 1489137147}
   m_IsTrigger: 0
   m_Enabled: 1
   m_Radius: 0.004
-  m_Height: 0.03038
+  m_Height: 0.034330003
   m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.01119}
---- !u!171741748 &1859197415
+  m_Center: {x: 0, y: 0, z: 0.013165001}
+--- !u!171741748 &1851164605
 ArticulationBody:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1859197412}
+  m_GameObject: {fileID: 1851164602}
   m_Enabled: 1
   serializedVersion: 3
   m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.0000000041909525, y: -0.000000003725291, z: 0.039780017}
+  m_ParentAnchorPosition: {x: 0.0000000036088763, y: 0.0000000051222755, z: 0.04463001}
   m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
+  m_ComputeParentAnchor: 0
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -18786,23 +12543,141 @@ ArticulationBody:
   m_Immovable: 0
   m_UseGravity: 0
   m_CollisionDetectionMode: 3
---- !u!114 &1859197416
+--- !u!114 &1851164606
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1859197412}
+  m_GameObject: {fileID: 1851164602}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _hand: {fileID: 1656071730}
-  _body: {fileID: 1859197415}
+  _hand: {fileID: 138166228}
+  _body: {fileID: 1851164605}
   _origXDriveLimit: 0
   _currentXDriveLimit: 3.4028235e+38
-  _finger: 1
+  _finger: 2
+  _joint: 1
+--- !u!1 &1864567763
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1864567764}
+  - component: {fileID: 1864567765}
+  - component: {fileID: 1864567766}
+  - component: {fileID: 1864567767}
+  m_Layer: 0
+  m_Name: Left Middle Joint 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1864567764
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1864567763}
+  m_LocalRotation: {x: -0, y: -0, z: -0.000000001513399, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.044630002}
+  m_LocalScale: {x: 0.9999995, y: 0.99999976, z: 0.9999999}
+  m_Children:
+  - {fileID: 1677594517}
+  m_Father: {fileID: 1312042431}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1864567765
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1864567763}
+  m_Material: {fileID: 232411772}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.034330003
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.013165001}
+--- !u!171741748 &1864567766
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1864567763}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 0.0000000047730295, y: -0.000000018160794, z: 0.044630006}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1864567767
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1864567763}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 1392200166}
+  _body: {fileID: 1864567766}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 2
   _joint: 1
 --- !u!1 &1874090590
 GameObject:
@@ -18834,11 +12709,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   editTimePose: 1
-  _inputLeapProvider: {fileID: 0}
-  dataUpdateMode: 0
+  _inputLeapProvider: {fileID: 463914039}
+  dataUpdateMode: 2
   passthroughOnly: 0
-  <LeftHand>k__BackingField: {fileID: 2057484866}
-  <RightHand>k__BackingField: {fileID: 2045161950}
+  <LeftHand>k__BackingField: {fileID: 1392200166}
+  <RightHand>k__BackingField: {fileID: 138166228}
   _defaultLayer:
     layerIndex: 0
   _interactableLayers:
@@ -18873,249 +12748,11 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 1656071731}
-  - {fileID: 575778804}
-  - {fileID: 1552987640}
-  - {fileID: 2127376582}
-  - {fileID: 2057484867}
-  - {fileID: 2045161951}
+  - {fileID: 1392200167}
+  - {fileID: 138166229}
   m_Father: {fileID: 1812745759}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1878654702
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1878654704}
-  - component: {fileID: 1878654703}
-  - component: {fileID: 1878654705}
-  - component: {fileID: 1878654706}
-  m_Layer: 0
-  m_Name: Left Ring Joint 2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!136 &1878654703
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1878654702}
-  m_Material: {fileID: 1690218108}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.0253
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.00865}
---- !u!4 &1878654704
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1878654702}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.02565}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1991305267}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &1878654705
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1878654702}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 9.31323e-10, y: -0.000000025145715, z: 0.02565002}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1878654706
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1878654702}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2057484866}
-  _body: {fileID: 1878654705}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 3
-  _joint: 2
---- !u!1 &1883123092
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1883123094}
-  - component: {fileID: 1883123093}
-  - component: {fileID: 1883123095}
-  - component: {fileID: 1883123096}
-  m_Layer: 0
-  m_Name: Left Middle Joint 2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!136 &1883123093
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1883123092}
-  m_Material: {fileID: 2041109289}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.025400002
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.0087}
---- !u!4 &1883123094
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1883123092}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.026330002}
-  m_LocalScale: {x: 1, y: 0.9999999, z: 0.9999999}
-  m_Children: []
-  m_Father: {fileID: 356802676}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &1883123095
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1883123092}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 4.656617e-10, y: -0.00000000931323, z: 0.026330002}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1883123096
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1883123092}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 1656071730}
-  _body: {fileID: 1883123095}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 2
-  _joint: 2
 --- !u!1 &1883367205
 GameObject:
   m_ObjectHideFlags: 0
@@ -19211,7 +12848,7 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1883367205}
   m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &1921003922
+--- !u!1 &1892537474
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -19219,415 +12856,58 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1921003926}
-  - component: {fileID: 1921003924}
-  - component: {fileID: 1921003923}
-  - component: {fileID: 1921003925}
+  - component: {fileID: 1892537475}
+  - component: {fileID: 1892537476}
+  - component: {fileID: 1892537477}
+  - component: {fileID: 1892537478}
   m_Layer: 0
-  m_Name: Left Palm
+  m_Name: Right Pinky Joint 1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!65 &1921003923
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1921003922}
-  m_Material: {fileID: 2041109289}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 0.0833, y: 0.025, z: 0.10353848}
-  m_Center: {x: 0, y: 0.0025, z: -0.015}
---- !u!171741748 &1921003924
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1921003922}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 1.8000001
-  m_ParentAnchorPosition: {x: 0, y: 0, z: 0}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 0
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 2
-  m_SwingZ: 2
-  m_Twist: 2
-  m_XDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 0
-    damping: 0
-    forceLimit: 3.4028235e+38
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 0
-    damping: 0
-    forceLimit: 3.4028235e+38
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 0
-    damping: 0
-    forceLimit: 3.4028235e+38
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 50
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1921003925
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1921003922}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 1656071730}
-  _body: {fileID: 1921003924}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 5
-  _joint: 0
---- !u!4 &1921003926
+--- !u!4 &1892537475
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1921003922}
-  m_LocalRotation: {x: -0.12940949, y: 0.48296294, z: 0.86272997, w: 0.07547909}
-  m_LocalPosition: {x: -0.21999998, y: -0.13000001, z: 0.27000004}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 226590106}
-  - {fileID: 674034230}
-  - {fileID: 1331277409}
-  - {fileID: 1349590843}
-  - {fileID: 891900967}
-  m_Father: {fileID: 1656071731}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1930163462
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1930163463}
-  - component: {fileID: 1930163464}
-  - component: {fileID: 1930163465}
-  - component: {fileID: 1930163466}
-  m_Layer: 0
-  m_Name: Right Thumb Joint 1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1930163463
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1930163462}
-  m_LocalRotation: {x: -0, y: -0, z: -0.0000000088475645, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.046220005}
-  m_LocalScale: {x: 1.0000001, y: 0.99999964, z: 0.9999995}
-  m_Children:
-  - {fileID: 584145262}
-  m_Father: {fileID: 1193507573}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1930163464
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1930163462}
-  m_Material: {fileID: 189111359}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.039570004
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.015785001}
---- !u!171741748 &1930163465
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1930163462}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.0000000130385205, y: 0.0000000046566138, z: 0.046220012}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 2
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1930163466
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1930163462}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2045161950}
-  _body: {fileID: 1930163465}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 0
-  _joint: 1
---- !u!1 &1945723377
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1945723378}
-  - component: {fileID: 1945723379}
-  - component: {fileID: 1945723380}
-  - component: {fileID: 1945723381}
-  m_Layer: 0
-  m_Name: Left Thumb Joint 1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1945723378
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1945723377}
-  m_LocalRotation: {x: -0, y: -0, z: 0.00000001071021, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.046220005}
-  m_LocalScale: {x: 1.0000001, y: 0.9999999, z: 0.99999976}
-  m_Children:
-  - {fileID: 236780705}
-  m_Father: {fileID: 1211426961}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1945723379
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1945723377}
-  m_Material: {fileID: 1324615029}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.039570004
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.015785001}
---- !u!171741748 &1945723380
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1945723377}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 9.313228e-10, y: 0.00000000651926, z: 0.046220012}
-  m_ParentAnchorRotation: {x: 0.000000014901161, y: 0, z: 0.000000029802322, w: 1.0000001}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 2
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1945723381
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1945723377}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 1552987639}
-  _body: {fileID: 1945723380}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 0
-  _joint: 1
---- !u!1 &1973713155
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1973713156}
-  - component: {fileID: 1973713157}
-  - component: {fileID: 1973713158}
-  - component: {fileID: 1973713159}
-  m_Layer: 0
-  m_Name: Left Pinky Joint 1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1973713156
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1973713155}
-  m_LocalRotation: {x: -0.0000000018626449, y: -0, z: -0.000000006053596, w: 1}
+  m_GameObject: {fileID: 1892537474}
+  m_LocalRotation: {x: -0, y: -0, z: 4.6566123e-10, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0.032740004}
-  m_LocalScale: {x: 0.9999999, y: 1, z: 1}
+  m_LocalScale: {x: 0.9999994, y: 0.99999964, z: 0.99999976}
   m_Children:
-  - {fileID: 71022534}
-  m_Father: {fileID: 1660436105}
+  - {fileID: 1623982460}
+  m_Father: {fileID: 491256543}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1973713157
+--- !u!136 &1892537476
 CapsuleCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1973713155}
-  m_Material: {fileID: 1324615029}
+  m_GameObject: {fileID: 1892537474}
+  m_Material: {fileID: 1489137147}
   m_IsTrigger: 0
   m_Enabled: 1
   m_Radius: 0.004
   m_Height: 0.02611
   m_Direction: 2
   m_Center: {x: 0, y: 0, z: 0.009055001}
---- !u!171741748 &1973713158
+--- !u!171741748 &1892537477
 ArticulationBody:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1973713155}
+  m_GameObject: {fileID: 1892537474}
   m_Enabled: 1
   serializedVersion: 3
   m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.000000017695132, y: -0.0000000137370115, z: 0.03274001}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
+  m_ParentAnchorPosition: {x: 0.000000022817412, y: -0.000000010069928, z: 0.03274001}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000004}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
   m_ComputeParentAnchor: 0
@@ -19668,20 +12948,20 @@ ArticulationBody:
   m_Immovable: 0
   m_UseGravity: 0
   m_CollisionDetectionMode: 3
---- !u!114 &1973713159
+--- !u!114 &1892537478
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1973713155}
+  m_GameObject: {fileID: 1892537474}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _hand: {fileID: 1552987639}
-  _body: {fileID: 1973713158}
+  _hand: {fileID: 138166228}
+  _body: {fileID: 1892537477}
   _origXDriveLimit: 0
   _currentXDriveLimit: 3.4028235e+38
   _finger: 4
@@ -19781,478 +13061,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1989393195}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &1991305266
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1991305267}
-  - component: {fileID: 1991305268}
-  - component: {fileID: 1991305269}
-  - component: {fileID: 1991305270}
-  m_Layer: 0
-  m_Name: Left Ring Joint 1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1991305267
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1991305266}
-  m_LocalRotation: {x: -0, y: -0, z: -4.656613e-10, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.04137}
-  m_LocalScale: {x: 0.99999976, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1878654704}
-  m_Father: {fileID: 1280355242}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1991305268
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1991305266}
-  m_Material: {fileID: 1690218108}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.03365
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.012825}
---- !u!171741748 &1991305269
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1991305266}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.0000000093132275, y: -0.000000015366826, z: 0.04137001}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1991305270
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1991305266}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2057484866}
-  _body: {fileID: 1991305269}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 3
-  _joint: 1
---- !u!1 &1993941821
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1993941822}
-  - component: {fileID: 1993941823}
-  - component: {fileID: 1993941824}
-  - component: {fileID: 1993941825}
-  m_Layer: 0
-  m_Name: Right Middle Joint 1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1993941822
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1993941821}
-  m_LocalRotation: {x: -0, y: -0, z: 9.895301e-10, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.044630002}
-  m_LocalScale: {x: 0.99999976, y: 0.9999999, z: 0.99999976}
-  m_Children:
-  - {fileID: 1579476877}
-  m_Father: {fileID: 190012337}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1993941823
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1993941821}
-  m_Material: {fileID: 585538801}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.034330003
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.013165001}
---- !u!171741748 &1993941824
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1993941821}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.0000000036088763, y: 0.0000000051222755, z: 0.04463001}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1993941825
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1993941821}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 575778803}
-  _body: {fileID: 1993941824}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 2
-  _joint: 1
---- !u!1 &1995389691
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1995389692}
-  - component: {fileID: 1995389693}
-  - component: {fileID: 1995389694}
-  - component: {fileID: 1995389695}
-  m_Layer: 0
-  m_Name: Right Middle Joint 1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1995389692
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1995389691}
-  m_LocalRotation: {x: -0, y: -0, z: 9.895301e-10, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.044630002}
-  m_LocalScale: {x: 0.99999976, y: 0.9999999, z: 0.99999976}
-  m_Children:
-  - {fileID: 1017830911}
-  m_Father: {fileID: 65960885}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1995389693
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1995389691}
-  m_Material: {fileID: 189111359}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.034330003
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.013165001}
---- !u!171741748 &1995389694
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1995389691}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.0000000036088763, y: 0.0000000051222755, z: 0.04463001}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1995389695
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1995389691}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2045161950}
-  _body: {fileID: 1995389694}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 2
-  _joint: 1
---- !u!1 &1997924414
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1997924415}
-  - component: {fileID: 1997924416}
-  - component: {fileID: 1997924417}
-  - component: {fileID: 1997924418}
-  m_Layer: 0
-  m_Name: Left Pinky Joint 0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1997924415
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1997924414}
-  m_LocalRotation: {x: 0.02914566, y: -0.13843812, z: 0.17725913, w: 0.9739428}
-  m_LocalPosition: {x: -0.035337448, y: -0.000000004656613, z: 0.00972872}
-  m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999999}
-  m_Children:
-  - {fileID: 439291898}
-  m_Father: {fileID: 632214914}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &1997924416
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1997924414}
-  m_Material: {fileID: 1690218108}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.040740006
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.016370002}
---- !u!171741748 &1997924417
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1997924414}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.035337463, y: -0.000000008381903, z: 0.009728719}
-  m_ParentAnchorRotation: {x: 0.029145658, y: -0.13843812, z: 0.17725913, w: 0.97394294}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -30
-    upperLimit: 80
-    stiffness: 200
-    damping: 1
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -15
-    upperLimit: 15
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &1997924418
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1997924414}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2057484866}
-  _body: {fileID: 1997924417}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 4
-  _joint: 0
 --- !u!1 &1999405928
 GameObject:
   m_ObjectHideFlags: 0
@@ -20296,7 +13104,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 70fd9230a01842d419b8c6d3e8aed589, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &2000139857
+--- !u!1 &2047016338
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -20304,62 +13112,61 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2000139858}
-  - component: {fileID: 2000139859}
-  - component: {fileID: 2000139860}
-  - component: {fileID: 2000139861}
+  - component: {fileID: 2047016340}
+  - component: {fileID: 2047016339}
+  - component: {fileID: 2047016341}
+  - component: {fileID: 2047016342}
   m_Layer: 0
-  m_Name: Right Thumb Joint 1
+  m_Name: Left Index Joint 2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2000139858
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2000139857}
-  m_LocalRotation: {x: -0, y: -0, z: -0.0000000088475645, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.046220005}
-  m_LocalScale: {x: 1.0000001, y: 0.99999964, z: 0.9999995}
-  m_Children:
-  - {fileID: 2091518380}
-  m_Father: {fileID: 794028892}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &2000139859
+--- !u!136 &2047016339
 CapsuleCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2000139857}
-  m_Material: {fileID: 1081093971}
+  m_GameObject: {fileID: 2047016338}
+  m_Material: {fileID: 232411772}
   m_IsTrigger: 0
   m_Enabled: 1
   m_Radius: 0.004
-  m_Height: 0.039570004
+  m_Height: 0.023820002
   m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.015785001}
---- !u!171741748 &2000139860
+  m_Center: {x: 0, y: 0, z: 0.00791}
+--- !u!4 &2047016340
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2047016338}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.02238}
+  m_LocalScale: {x: 1, y: 1.0000001, z: 1}
+  m_Children: []
+  m_Father: {fileID: 981931937}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!171741748 &2047016341
 ArticulationBody:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2000139857}
+  m_GameObject: {fileID: 2047016338}
   m_Enabled: 1
   serializedVersion: 3
   m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.0000000130385205, y: 0.0000000046566138, z: 0.046220012}
+  m_ParentAnchorPosition: {x: 0.0000000102445545, y: -0.000000020489109, z: 0.022380015}
   m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
   m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 2
+  m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
   m_LinearZ: 2
@@ -20396,151 +13203,24 @@ ArticulationBody:
   m_Immovable: 0
   m_UseGravity: 0
   m_CollisionDetectionMode: 3
---- !u!114 &2000139861
+--- !u!114 &2047016342
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2000139857}
+  m_GameObject: {fileID: 2047016338}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _hand: {fileID: 2127376581}
-  _body: {fileID: 2000139860}
+  _hand: {fileID: 1392200166}
+  _body: {fileID: 2047016341}
   _origXDriveLimit: 0
   _currentXDriveLimit: 3.4028235e+38
-  _finger: 0
-  _joint: 1
---- !u!134 &2041109289
-PhysicMaterial:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: HandPhysics
-  dynamicFriction: 1
-  staticFriction: 1
-  bounciness: 0
-  frictionCombine: 0
-  bounceCombine: 1
---- !u!1 &2045161949
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2045161951}
-  - component: {fileID: 2045161950}
-  m_Layer: 0
-  m_Name: Right Hand
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &2045161950
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2045161949}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 445639c80127bbd44b6bd9d34463b470, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _physicsHand:
-    triggerDistance: 0.004
-    oldPosition: {x: 0, y: 0, z: 0}
-    gameObject: {fileID: 1085073647}
-    rootObject: {fileID: 2045161949}
-    transform: {fileID: 1085073651}
-    palmBone: {fileID: 1085073650}
-    palmBody: {fileID: 1085073649}
-    palmCollider: {fileID: 1085073648}
-    jointBones:
-    - {fileID: 1193507576}
-    - {fileID: 1930163466}
-    - {fileID: 584145264}
-    - {fileID: 2080805430}
-    - {fileID: 334822916}
-    - {fileID: 1830967255}
-    - {fileID: 65960888}
-    - {fileID: 1995389695}
-    - {fileID: 1017830913}
-    - {fileID: 1326941329}
-    - {fileID: 676571250}
-    - {fileID: 1625487773}
-    - {fileID: 182831397}
-    - {fileID: 1509403556}
-    - {fileID: 32345359}
-    jointBodies:
-    - {fileID: 1193507575}
-    - {fileID: 1930163465}
-    - {fileID: 584145263}
-    - {fileID: 2080805429}
-    - {fileID: 334822915}
-    - {fileID: 1830967254}
-    - {fileID: 65960887}
-    - {fileID: 1995389694}
-    - {fileID: 1017830912}
-    - {fileID: 1326941328}
-    - {fileID: 676571249}
-    - {fileID: 1625487772}
-    - {fileID: 182831396}
-    - {fileID: 1509403555}
-    - {fileID: 32345358}
-    jointColliders:
-    - {fileID: 1193507574}
-    - {fileID: 1930163464}
-    - {fileID: 584145261}
-    - {fileID: 2080805428}
-    - {fileID: 334822914}
-    - {fileID: 1830967252}
-    - {fileID: 65960886}
-    - {fileID: 1995389693}
-    - {fileID: 1017830910}
-    - {fileID: 1326941327}
-    - {fileID: 676571248}
-    - {fileID: 1625487770}
-    - {fileID: 182831395}
-    - {fileID: 1509403554}
-    - {fileID: 32345356}
-    overRotationFrameCount: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-    defaultRotations:
-    - {x: -0.6644467, y: -0.34441155, z: -0.5637821, w: 0.34934357}
-    - {x: -0.19850887, y: -0.549382, z: -0.8101427, w: 0.04942213}
-    - {x: -0.095235884, y: -0.55546176, z: -0.82590574, w: 0.016494589}
-    - {x: -0.013266354, y: -0.54483914, z: -0.8380312, w: 0.026037607}
-    - {x: 0.08120667, y: -0.50801295, z: -0.85746795, w: -0.00878219}
-    - {x: -0.12940955, y: -0.4829629, z: -0.8627299, w: 0.07547912}
-    strength: 2
-    stiffness: 100
-    forceLimit: 1000
-    boneMass: 0.6
-    physicMaterial: {fileID: 189111359}
-  _handedness: 1
---- !u!4 &2045161951
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2045161949}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1085073651}
-  m_Father: {fileID: 1874090592}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  _finger: 1
+  _joint: 2
 --- !u!1 &2047985974
 GameObject:
   m_ObjectHideFlags: 0
@@ -20653,474 +13333,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2047985974}
   m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &2057484865
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2057484867}
-  - component: {fileID: 2057484866}
-  m_Layer: 0
-  m_Name: Left Hand
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &2057484866
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2057484865}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 445639c80127bbd44b6bd9d34463b470, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _physicsHand:
-    triggerDistance: 0.004
-    oldPosition: {x: 0, y: 0, z: 0}
-    gameObject: {fileID: 632214910}
-    rootObject: {fileID: 2057484865}
-    transform: {fileID: 632214914}
-    palmBone: {fileID: 632214913}
-    palmBody: {fileID: 632214912}
-    palmCollider: {fileID: 632214911}
-    jointBones:
-    - {fileID: 2058509480}
-    - {fileID: 1569510036}
-    - {fileID: 1853181001}
-    - {fileID: 374448561}
-    - {fileID: 80499005}
-    - {fileID: 1330061739}
-    - {fileID: 1422669240}
-    - {fileID: 979227612}
-    - {fileID: 14895156}
-    - {fileID: 1280355245}
-    - {fileID: 1991305270}
-    - {fileID: 1878654706}
-    - {fileID: 1997924418}
-    - {fileID: 439291901}
-    - {fileID: 864411121}
-    jointBodies:
-    - {fileID: 2058509479}
-    - {fileID: 1569510035}
-    - {fileID: 1853181000}
-    - {fileID: 374448560}
-    - {fileID: 80499004}
-    - {fileID: 1330061738}
-    - {fileID: 1422669239}
-    - {fileID: 979227611}
-    - {fileID: 14895155}
-    - {fileID: 1280355244}
-    - {fileID: 1991305269}
-    - {fileID: 1878654705}
-    - {fileID: 1997924417}
-    - {fileID: 439291900}
-    - {fileID: 864411120}
-    jointColliders:
-    - {fileID: 2058509478}
-    - {fileID: 1569510034}
-    - {fileID: 1853180998}
-    - {fileID: 374448559}
-    - {fileID: 80499003}
-    - {fileID: 1330061736}
-    - {fileID: 1422669238}
-    - {fileID: 979227610}
-    - {fileID: 14895153}
-    - {fileID: 1280355243}
-    - {fileID: 1991305268}
-    - {fileID: 1878654703}
-    - {fileID: 1997924416}
-    - {fileID: 439291899}
-    - {fileID: 864411118}
-    overRotationFrameCount: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-    defaultRotations:
-    - {x: -0.66444665, y: 0.34441158, z: 0.56378216, w: 0.34934354}
-    - {x: -0.1985088, y: 0.549382, z: 0.8101427, w: 0.04942208}
-    - {x: -0.09523581, y: 0.55546176, z: 0.82590574, w: 0.01649454}
-    - {x: -0.013266281, y: 0.54483914, z: 0.8380312, w: 0.026037559}
-    - {x: 0.081206754, y: 0.50801295, z: 0.85746795, w: -0.008782235}
-    - {x: -0.12940948, y: 0.4829629, z: 0.8627299, w: 0.07547908}
-    strength: 2
-    stiffness: 100
-    forceLimit: 1000
-    boneMass: 0.6
-    physicMaterial: {fileID: 1690218108}
-  _handedness: 0
---- !u!4 &2057484867
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2057484865}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 632214914}
-  m_Father: {fileID: 1874090592}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2058509476
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2058509477}
-  - component: {fileID: 2058509478}
-  - component: {fileID: 2058509479}
-  - component: {fileID: 2058509480}
-  m_Layer: 0
-  m_Name: Left Thumb Joint 0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2058509477
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2058509476}
-  m_LocalRotation: {x: 0.019904852, y: 0.35755512, z: -0.53516835, w: 0.7650836}
-  m_LocalPosition: {x: 0.019338273, y: -0.006000001, z: -0.053168494}
-  m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999999}
-  m_Children:
-  - {fileID: 1569510033}
-  m_Father: {fileID: 632214914}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &2058509478
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2058509476}
-  m_Material: {fileID: 1690218108}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.054220006
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.023110002}
---- !u!171741748 &2058509479
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2058509476}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: 0.019338273, y: -0.0059999935, z: -0.053168505}
-  m_ParentAnchorRotation: {x: 0.019904822, y: 0.35755518, z: -0.5351684, w: 0.7650837}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -45
-    upperLimit: 45
-    stiffness: 200
-    damping: 1
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -10
-    upperLimit: 50
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &2058509480
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2058509476}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2057484866}
-  _body: {fileID: 2058509479}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 0
-  _joint: 0
---- !u!1 &2080805426
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2080805427}
-  - component: {fileID: 2080805428}
-  - component: {fileID: 2080805429}
-  - component: {fileID: 2080805430}
-  m_Layer: 0
-  m_Name: Right Index Joint 0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2080805427
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2080805426}
-  m_LocalRotation: {x: 0.07411184, y: -0.08401716, z: 0.0062662363, w: 0.99368477}
-  m_LocalPosition: {x: -0.023181278, y: 0.0020000078, z: 0.023149364}
-  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
-  m_Children:
-  - {fileID: 334822913}
-  m_Father: {fileID: 1085073651}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &2080805428
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2080805426}
-  m_Material: {fileID: 189111359}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.047780003
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.019890001}
---- !u!171741748 &2080805429
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2080805426}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.023181293, y: 0.0020000115, z: 0.023149366}
-  m_ParentAnchorRotation: {x: 0.07411185, y: -0.08401715, z: 0.0062662363, w: 0.9936849}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -30
-    upperLimit: 80
-    stiffness: 200
-    damping: 1
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -15
-    upperLimit: 15
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 100000
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &2080805430
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2080805426}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2045161950}
-  _body: {fileID: 2080805429}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 1
-  _joint: 0
---- !u!1 &2091518378
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2091518380}
-  - component: {fileID: 2091518379}
-  - component: {fileID: 2091518381}
-  - component: {fileID: 2091518382}
-  m_Layer: 0
-  m_Name: Right Thumb Joint 2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!136 &2091518379
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2091518378}
-  m_Material: {fileID: 1081093971}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.02967
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.010835}
---- !u!4 &2091518380
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2091518378}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.031570002}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 2000139858}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &2091518381
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2091518378}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.000000018626457, y: 0.000000031664985, z: 0.031570025}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
-  m_ArticulationJointType: 2
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -10
-    upperLimit: 89
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -8
-    upperLimit: 8
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &2091518382
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2091518378}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 2127376581}
-  _body: {fileID: 2091518381}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 0
-  _joint: 2
 --- !u!1 &2103061970
 GameObject:
   m_ObjectHideFlags: 0
@@ -21217,7 +13429,7 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2103061970}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &2115103739
+--- !u!1 &2117531305
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -21225,60 +13437,61 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2115103741}
-  - component: {fileID: 2115103740}
-  - component: {fileID: 2115103742}
-  - component: {fileID: 2115103743}
+  - component: {fileID: 2117531306}
+  - component: {fileID: 2117531307}
+  - component: {fileID: 2117531308}
+  - component: {fileID: 2117531309}
   m_Layer: 0
-  m_Name: Left Pinky Joint 2
+  m_Name: Right Index Joint 1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!136 &2115103740
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2115103739}
-  m_Material: {fileID: 2041109289}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.023960002
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.00798}
---- !u!4 &2115103741
+--- !u!4 &2117531306
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2115103739}
+  m_GameObject: {fileID: 2117531305}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.018110001}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 315683683}
+  m_LocalPosition: {x: 0, y: 0, z: 0.039780002}
+  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 0.99999976}
+  m_Children:
+  - {fileID: 1791223837}
+  m_Father: {fileID: 783923111}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!171741748 &2115103742
+--- !u!136 &2117531307
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2117531305}
+  m_Material: {fileID: 1489137147}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.03038
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.01119}
+--- !u!171741748 &2117531308
 ArticulationBody:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2115103739}
+  m_GameObject: {fileID: 2117531305}
   m_Enabled: 1
   serializedVersion: 3
   m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.000000013038521, y: 0.0000000020280109, z: 0.018110018}
-  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
+  m_ParentAnchorPosition: {x: -0.000000030267994, y: -0.00000002328307, z: 0.039780017}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
+  m_ComputeParentAnchor: 0
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -21316,257 +13529,24 @@ ArticulationBody:
   m_Immovable: 0
   m_UseGravity: 0
   m_CollisionDetectionMode: 3
---- !u!114 &2115103743
+--- !u!114 &2117531309
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2115103739}
+  m_GameObject: {fileID: 2117531305}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _hand: {fileID: 1656071730}
-  _body: {fileID: 2115103742}
+  _hand: {fileID: 138166228}
+  _body: {fileID: 2117531308}
   _origXDriveLimit: 0
   _currentXDriveLimit: 3.4028235e+38
-  _finger: 4
-  _joint: 2
---- !u!1 &2116615598
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2116615599}
-  - component: {fileID: 2116615600}
-  - component: {fileID: 2116615601}
-  - component: {fileID: 2116615602}
-  m_Layer: 0
-  m_Name: Right Thumb Joint 0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2116615599
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2116615598}
-  m_LocalRotation: {x: 0.019904856, y: -0.35755515, z: 0.53516835, w: 0.7650837}
-  m_LocalPosition: {x: -0.01933824, y: -0.0059999824, z: -0.05316848}
-  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
-  m_Children:
-  - {fileID: 1828296616}
-  m_Father: {fileID: 653981089}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &2116615600
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2116615598}
-  m_Material: {fileID: 585538801}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.004
-  m_Height: 0.054220006
-  m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.023110002}
---- !u!171741748 &2116615601
-ArticulationBody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2116615598}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Mass: 0.6
-  m_ParentAnchorPosition: {x: -0.01933824, y: -0.0059999824, z: -0.05316848}
-  m_ParentAnchorRotation: {x: 0.019904852, y: -0.35755515, z: 0.53516847, w: 0.7650838}
-  m_AnchorPosition: {x: 0, y: 0, z: 0}
-  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 1
-  m_ArticulationJointType: 3
-  m_LinearX: 2
-  m_LinearY: 2
-  m_LinearZ: 2
-  m_SwingY: 1
-  m_SwingZ: 1
-  m_Twist: 1
-  m_XDrive:
-    lowerLimit: -45
-    upperLimit: 45
-    stiffness: 200
-    damping: 1
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_YDrive:
-    lowerLimit: -50
-    upperLimit: 10
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_ZDrive:
-    lowerLimit: 0
-    upperLimit: 0
-    stiffness: 200
-    damping: 2
-    forceLimit: 180001.81
-    target: 0
-    targetVelocity: 0
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_JointFriction: 0.05
-  m_Immovable: 0
-  m_UseGravity: 0
-  m_CollisionDetectionMode: 3
---- !u!114 &2116615602
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2116615598}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _hand: {fileID: 575778803}
-  _body: {fileID: 2116615601}
-  _origXDriveLimit: 0
-  _currentXDriveLimit: 3.4028235e+38
-  _finger: 0
-  _joint: 0
---- !u!1 &2127376580
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2127376582}
-  - component: {fileID: 2127376581}
-  m_Layer: 0
-  m_Name: Right Hand
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &2127376581
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2127376580}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 445639c80127bbd44b6bd9d34463b470, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _physicsHand:
-    triggerDistance: 0.004
-    oldPosition: {x: 0, y: 0, z: 0}
-    gameObject: {fileID: 1384551527}
-    rootObject: {fileID: 2127376580}
-    transform: {fileID: 1384551531}
-    palmBone: {fileID: 1384551530}
-    palmBody: {fileID: 1384551529}
-    palmCollider: {fileID: 1384551528}
-    jointBones:
-    - {fileID: 794028895}
-    - {fileID: 2000139861}
-    - {fileID: 2091518382}
-    - {fileID: 513332376}
-    - {fileID: 517433468}
-    - {fileID: 1305726775}
-    - {fileID: 1216944355}
-    - {fileID: 1077167465}
-    - {fileID: 302522891}
-    - {fileID: 1371222478}
-    - {fileID: 1412118572}
-    - {fileID: 1530934142}
-    - {fileID: 971476551}
-    - {fileID: 436964835}
-    - {fileID: 221313060}
-    jointBodies:
-    - {fileID: 794028894}
-    - {fileID: 2000139860}
-    - {fileID: 2091518381}
-    - {fileID: 513332375}
-    - {fileID: 517433467}
-    - {fileID: 1305726774}
-    - {fileID: 1216944354}
-    - {fileID: 1077167464}
-    - {fileID: 302522890}
-    - {fileID: 1371222477}
-    - {fileID: 1412118571}
-    - {fileID: 1530934141}
-    - {fileID: 971476550}
-    - {fileID: 436964834}
-    - {fileID: 221313059}
-    jointColliders:
-    - {fileID: 794028893}
-    - {fileID: 2000139859}
-    - {fileID: 2091518379}
-    - {fileID: 513332374}
-    - {fileID: 517433466}
-    - {fileID: 1305726772}
-    - {fileID: 1216944353}
-    - {fileID: 1077167463}
-    - {fileID: 302522888}
-    - {fileID: 1371222476}
-    - {fileID: 1412118570}
-    - {fileID: 1530934139}
-    - {fileID: 971476549}
-    - {fileID: 436964833}
-    - {fileID: 221313057}
-    overRotationFrameCount: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-    defaultRotations:
-    - {x: -0.6644467, y: -0.34441155, z: -0.5637821, w: 0.34934357}
-    - {x: -0.19850887, y: -0.549382, z: -0.8101427, w: 0.04942213}
-    - {x: -0.095235884, y: -0.55546176, z: -0.82590574, w: 0.016494589}
-    - {x: -0.013266354, y: -0.54483914, z: -0.8380312, w: 0.026037607}
-    - {x: 0.08120667, y: -0.50801295, z: -0.85746795, w: -0.00878219}
-    - {x: -0.12940955, y: -0.4829629, z: -0.8627299, w: 0.07547912}
-    strength: 2
-    stiffness: 100
-    forceLimit: 1000
-    boneMass: 0.6
-    physicMaterial: {fileID: 1081093971}
-  _handedness: 1
---- !u!4 &2127376582
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2127376580}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1384551531}
-  m_Father: {fileID: 1874090592}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  _finger: 1
+  _joint: 1
 --- !u!1 &2129453843
 GameObject:
   m_ObjectHideFlags: 0
@@ -22347,7 +14327,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d5ea39e33ffd4f44cb67343be1aee061, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _leapProvider: {fileID: 888698409}
+  _leapProvider: {fileID: 463914039}
   BoundHand:
     fingers:
     - boundBones:
@@ -23490,7 +15470,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d5ea39e33ffd4f44cb67343be1aee061, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _leapProvider: {fileID: 888698409}
+  _leapProvider: {fileID: 463914039}
   BoundHand:
     fingers:
     - boundBones:

--- a/Packages/Tracking Preview/Examples~/PhysicsHands/PhysicsHands.unity
+++ b/Packages/Tracking Preview/Examples~/PhysicsHands/PhysicsHands.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -123,6 +123,123 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &14895152
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 14895154}
+  - component: {fileID: 14895153}
+  - component: {fileID: 14895155}
+  - component: {fileID: 14895156}
+  m_Layer: 0
+  m_Name: Left Middle Joint 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!136 &14895153
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 14895152}
+  m_Material: {fileID: 1690218108}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.025400002
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.0087}
+--- !u!4 &14895154
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 14895152}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.026330002}
+  m_LocalScale: {x: 1, y: 0.9999999, z: 0.9999999}
+  m_Children: []
+  m_Father: {fileID: 979227609}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!171741748 &14895155
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 14895152}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 4.656617e-10, y: -0.00000000931323, z: 0.026330002}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &14895156
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 14895152}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2057484866}
+  _body: {fileID: 14895155}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 2
+  _joint: 2
 --- !u!1 &25869035
 GameObject:
   m_ObjectHideFlags: 0
@@ -235,6 +352,123 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 25869035}
   m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &32345355
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 32345357}
+  - component: {fileID: 32345356}
+  - component: {fileID: 32345358}
+  - component: {fileID: 32345359}
+  m_Layer: 0
+  m_Name: Right Pinky Joint 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!136 &32345356
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 32345355}
+  m_Material: {fileID: 189111359}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.023960002
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.00798}
+--- !u!4 &32345357
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 32345355}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.018110001}
+  m_LocalScale: {x: 1.0000001, y: 0.9999999, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1509403553}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!171741748 &32345358
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 32345355}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 0.000000015832498, y: 0.00000000884757, z: 0.018110014}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000004}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &32345359
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 32345355}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2045161950}
+  _body: {fileID: 32345358}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 4
+  _joint: 2
 --- !u!1 &48836609
 GameObject:
   m_ObjectHideFlags: 0
@@ -375,6 +609,241 @@ Transform:
   m_Father: {fileID: 463914042}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &65960884
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 65960885}
+  - component: {fileID: 65960886}
+  - component: {fileID: 65960887}
+  - component: {fileID: 65960888}
+  m_Layer: 0
+  m_Name: Right Middle Joint 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &65960885
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 65960884}
+  m_LocalRotation: {x: 0.07527792, y: -0.009242235, z: -0.073994935, w: 0.99437046}
+  m_LocalPosition: {x: -0.002788769, y: 0.0040000016, z: 0.023252115}
+  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
+  m_Children:
+  - {fileID: 1995389692}
+  m_Father: {fileID: 1085073651}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &65960886
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 65960884}
+  m_Material: {fileID: 189111359}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.052630004
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.022315001}
+--- !u!171741748 &65960887
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 65960884}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.002788769, y: 0.0040000016, z: 0.023252115}
+  m_ParentAnchorRotation: {x: 0.075277954, y: -0.009242229, z: -0.07399494, w: 0.9943706}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -30
+    upperLimit: 80
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -15
+    upperLimit: 15
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &65960888
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 65960884}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2045161950}
+  _body: {fileID: 65960887}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 2
+  _joint: 0
+--- !u!1 &71022532
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 71022534}
+  - component: {fileID: 71022533}
+  - component: {fileID: 71022535}
+  - component: {fileID: 71022536}
+  m_Layer: 0
+  m_Name: Left Pinky Joint 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!136 &71022533
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 71022532}
+  m_Material: {fileID: 1324615029}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.023960002
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.00798}
+--- !u!4 &71022534
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 71022532}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.018110001}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1973713156}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!171741748 &71022535
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 71022532}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.000000013038521, y: 0.0000000020280109, z: 0.018110018}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &71022536
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 71022532}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 1552987639}
+  _body: {fileID: 71022535}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 4
+  _joint: 2
 --- !u!1 &77060052
 GameObject:
   m_ObjectHideFlags: 0
@@ -471,6 +940,360 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 77060052}
   m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &80499001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 80499002}
+  - component: {fileID: 80499003}
+  - component: {fileID: 80499004}
+  - component: {fileID: 80499005}
+  m_Layer: 0
+  m_Name: Left Index Joint 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &80499002
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 80499001}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.039780002}
+  m_LocalScale: {x: 0.99999964, y: 0.99999964, z: 0.99999976}
+  m_Children:
+  - {fileID: 1330061737}
+  m_Father: {fileID: 374448558}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &80499003
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 80499001}
+  m_Material: {fileID: 1690218108}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.03038
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.01119}
+--- !u!171741748 &80499004
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 80499001}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.0000000041909525, y: -0.000000003725291, z: 0.039780017}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &80499005
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 80499001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2057484866}
+  _body: {fileID: 80499004}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 1
+  _joint: 1
+--- !u!1 &80816726
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 80816727}
+  - component: {fileID: 80816728}
+  - component: {fileID: 80816729}
+  - component: {fileID: 80816730}
+  m_Layer: 0
+  m_Name: Left Middle Joint 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &80816727
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 80816726}
+  m_LocalRotation: {x: 0.07527789, y: 0.009242246, z: 0.073994935, w: 0.9943705}
+  m_LocalPosition: {x: 0.002788771, y: 0.0040000007, z: 0.023252115}
+  m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999999}
+  m_Children:
+  - {fileID: 246457847}
+  m_Father: {fileID: 889282513}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &80816728
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 80816726}
+  m_Material: {fileID: 1324615029}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.052630004
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.022315001}
+--- !u!171741748 &80816729
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 80816726}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 0.002788771, y: 0.0040000007, z: 0.023252115}
+  m_ParentAnchorRotation: {x: 0.075277895, y: 0.0092422515, z: 0.073994935, w: 0.9943706}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -30
+    upperLimit: 80
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -15
+    upperLimit: 15
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &80816730
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 80816726}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 1552987639}
+  _body: {fileID: 80816729}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 2
+  _joint: 0
+--- !u!1 &84440797
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 84440798}
+  - component: {fileID: 84440799}
+  - component: {fileID: 84440800}
+  - component: {fileID: 84440801}
+  m_Layer: 0
+  m_Name: Left Index Joint 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &84440798
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 84440797}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.039780002}
+  m_LocalScale: {x: 0.99999964, y: 0.99999964, z: 0.99999976}
+  m_Children:
+  - {fileID: 1559450537}
+  m_Father: {fileID: 143027714}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &84440799
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 84440797}
+  m_Material: {fileID: 1324615029}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.03038
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.01119}
+--- !u!171741748 &84440800
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 84440797}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.0000000041909525, y: -0.000000003725291, z: 0.039780017}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &84440801
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 84440797}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 1552987639}
+  _body: {fileID: 84440800}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 1
+  _joint: 1
 --- !u!1 &85926699
 GameObject:
   m_ObjectHideFlags: 0
@@ -662,7 +1485,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0.067679256, y: 0.06845519, z: -0.10489069, w: 0.9898139}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -819,6 +1642,124 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 135976652}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &143027713
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 143027714}
+  - component: {fileID: 143027715}
+  - component: {fileID: 143027716}
+  - component: {fileID: 143027717}
+  m_Layer: 0
+  m_Name: Left Index Joint 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &143027714
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 143027713}
+  m_LocalRotation: {x: 0.074111804, y: 0.08401716, z: -0.006266229, w: 0.99368477}
+  m_LocalPosition: {x: 0.023181278, y: 0.0020000078, z: 0.023149362}
+  m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999999}
+  m_Children:
+  - {fileID: 84440798}
+  m_Father: {fileID: 889282513}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &143027715
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 143027713}
+  m_Material: {fileID: 1324615029}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.047780003
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.019890001}
+--- !u!171741748 &143027716
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 143027713}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 0.023181278, y: 0.0020000078, z: 0.023149362}
+  m_ParentAnchorRotation: {x: 0.07411182, y: 0.08401718, z: -0.006266229, w: 0.9936849}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -30
+    upperLimit: 80
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -15
+    upperLimit: 15
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &143027717
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 143027713}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 1552987639}
+  _body: {fileID: 143027716}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 1
+  _joint: 0
 --- !u!1 &149014349
 GameObject:
   m_ObjectHideFlags: 0
@@ -1018,6 +1959,124 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 178749804}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &182831393
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 182831394}
+  - component: {fileID: 182831395}
+  - component: {fileID: 182831396}
+  - component: {fileID: 182831397}
+  m_Layer: 0
+  m_Name: Right Pinky Joint 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &182831394
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 182831393}
+  m_LocalRotation: {x: 0.029145695, y: 0.13843815, z: -0.17725913, w: 0.9739429}
+  m_LocalPosition: {x: 0.035337448, y: -0.000000009313226, z: 0.009728717}
+  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
+  m_Children:
+  - {fileID: 1509403553}
+  m_Father: {fileID: 1085073651}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &182831395
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 182831393}
+  m_Material: {fileID: 189111359}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.040740006
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.016370002}
+--- !u!171741748 &182831396
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 182831393}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 0.035337463, y: -0.000000013038516, z: 0.009728714}
+  m_ParentAnchorRotation: {x: 0.029145688, y: 0.13843818, z: -0.17725915, w: 0.973943}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -30
+    upperLimit: 80
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -15
+    upperLimit: 15
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &182831397
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 182831393}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2045161950}
+  _body: {fileID: 182831396}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 4
+  _joint: 0
 --- !u!1 &187038646
 GameObject:
   m_ObjectHideFlags: 0
@@ -1130,6 +2189,18 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 187038646}
   m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!134 &189111359
+PhysicMaterial:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: HandPhysics
+  dynamicFriction: 1
+  staticFriction: 1
+  bounciness: 0
+  frictionCombine: 0
+  bounceCombine: 1
 --- !u!1 &190012336
 GameObject:
   m_ObjectHideFlags: 0
@@ -1192,7 +2263,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0.075277954, y: -0.009242229, z: -0.07399494, w: 0.9943706}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -1405,7 +2476,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000004}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -1629,6 +2700,123 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 217433089}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &221313056
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 221313058}
+  - component: {fileID: 221313057}
+  - component: {fileID: 221313059}
+  - component: {fileID: 221313060}
+  m_Layer: 0
+  m_Name: Right Pinky Joint 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!136 &221313057
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 221313056}
+  m_Material: {fileID: 1081093971}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.023960002
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.00798}
+--- !u!4 &221313058
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 221313056}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.018110001}
+  m_LocalScale: {x: 1.0000001, y: 0.9999999, z: 1}
+  m_Children: []
+  m_Father: {fileID: 436964832}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!171741748 &221313059
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 221313056}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 0.000000015832498, y: 0.00000000884757, z: 0.018110014}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000004}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &221313060
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 221313056}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2127376581}
+  _body: {fileID: 221313059}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 4
+  _joint: 2
 --- !u!1 &221939407
 GameObject:
   m_ObjectHideFlags: 0
@@ -1786,7 +2974,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0.019904822, y: 0.35755518, z: -0.5351684, w: 0.7650837}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -1842,6 +3030,123 @@ MonoBehaviour:
   _currentXDriveLimit: 3.4028235e+38
   _finger: 0
   _joint: 0
+--- !u!1 &236780703
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 236780705}
+  - component: {fileID: 236780704}
+  - component: {fileID: 236780706}
+  - component: {fileID: 236780707}
+  m_Layer: 0
+  m_Name: Left Thumb Joint 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!136 &236780704
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 236780703}
+  m_Material: {fileID: 1324615029}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.02967
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.010835}
+--- !u!4 &236780705
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 236780703}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.031570002}
+  m_LocalScale: {x: 1, y: 1.0000001, z: 1.0000001}
+  m_Children: []
+  m_Father: {fileID: 1945723378}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!171741748 &236780706
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 236780703}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.000000009313227, y: -0.0000000037252916, z: 0.03157001}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 2
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &236780707
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 236780703}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 1552987639}
+  _body: {fileID: 236780706}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 0
+  _joint: 2
 --- !u!1 &239016654
 GameObject:
   m_ObjectHideFlags: 0
@@ -2000,6 +3305,124 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   anchor: {fileID: 2129453843}
   player: {fileID: 463914037}
+--- !u!1 &246457846
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 246457847}
+  - component: {fileID: 246457848}
+  - component: {fileID: 246457849}
+  - component: {fileID: 246457850}
+  m_Layer: 0
+  m_Name: Left Middle Joint 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &246457847
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 246457846}
+  m_LocalRotation: {x: -0, y: -0, z: -0.000000001513399, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.044630002}
+  m_LocalScale: {x: 0.9999995, y: 0.99999976, z: 0.9999999}
+  m_Children:
+  - {fileID: 928808897}
+  m_Father: {fileID: 80816727}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &246457848
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 246457846}
+  m_Material: {fileID: 1324615029}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.034330003
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.013165001}
+--- !u!171741748 &246457849
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 246457846}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 0.0000000047730295, y: -0.000000018160794, z: 0.044630006}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &246457850
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 246457846}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 1552987639}
+  _body: {fileID: 246457849}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 2
+  _joint: 1
 --- !u!1 &254592135
 GameObject:
   m_ObjectHideFlags: 0
@@ -2269,7 +3692,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -2325,6 +3748,123 @@ MonoBehaviour:
   _currentXDriveLimit: 3.4028235e+38
   _finger: 3
   _joint: 1
+--- !u!1 &302522887
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 302522889}
+  - component: {fileID: 302522888}
+  - component: {fileID: 302522890}
+  - component: {fileID: 302522891}
+  m_Layer: 0
+  m_Name: Right Middle Joint 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!136 &302522888
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 302522887}
+  m_Material: {fileID: 1081093971}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.025400002
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.0087}
+--- !u!4 &302522889
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 302522887}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.026330002}
+  m_LocalScale: {x: 1.0000001, y: 1.0000001, z: 1.0000001}
+  m_Children: []
+  m_Father: {fileID: 1077167462}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!171741748 &302522890
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 302522887}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 2.3283078e-10, y: 0.0000000055879377, z: 0.026330026}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &302522891
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 302522887}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2127376581}
+  _body: {fileID: 302522890}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 2
+  _joint: 2
 --- !u!1 &315683682
 GameObject:
   m_ObjectHideFlags: 0
@@ -2387,7 +3927,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -2538,6 +4078,124 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 320794400}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &334822912
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 334822913}
+  - component: {fileID: 334822914}
+  - component: {fileID: 334822915}
+  - component: {fileID: 334822916}
+  m_Layer: 0
+  m_Name: Right Index Joint 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &334822913
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 334822912}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.039780002}
+  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 0.99999976}
+  m_Children:
+  - {fileID: 1830967253}
+  m_Father: {fileID: 2080805427}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &334822914
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 334822912}
+  m_Material: {fileID: 189111359}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.03038
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.01119}
+--- !u!171741748 &334822915
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 334822912}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.000000030267994, y: -0.00000002328307, z: 0.039780017}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &334822916
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 334822912}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2045161950}
+  _body: {fileID: 334822915}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 1
+  _joint: 1
 --- !u!1 &356802675
 GameObject:
   m_ObjectHideFlags: 0
@@ -2600,7 +4258,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -2656,6 +4314,124 @@ MonoBehaviour:
   _currentXDriveLimit: 3.4028235e+38
   _finger: 2
   _joint: 1
+--- !u!1 &374448557
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 374448558}
+  - component: {fileID: 374448559}
+  - component: {fileID: 374448560}
+  - component: {fileID: 374448561}
+  m_Layer: 0
+  m_Name: Left Index Joint 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &374448558
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 374448557}
+  m_LocalRotation: {x: 0.074111804, y: 0.08401716, z: -0.006266229, w: 0.99368477}
+  m_LocalPosition: {x: 0.023181278, y: 0.0020000078, z: 0.023149362}
+  m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999999}
+  m_Children:
+  - {fileID: 80499002}
+  m_Father: {fileID: 632214914}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &374448559
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 374448557}
+  m_Material: {fileID: 1690218108}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.047780003
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.019890001}
+--- !u!171741748 &374448560
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 374448557}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 0.023181278, y: 0.0020000078, z: 0.023149362}
+  m_ParentAnchorRotation: {x: 0.07411182, y: 0.08401718, z: -0.006266229, w: 0.9936849}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -30
+    upperLimit: 80
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -15
+    upperLimit: 15
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &374448561
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 374448557}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2057484866}
+  _body: {fileID: 374448560}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 1
+  _joint: 0
 --- !u!1001 &395359349
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2669,7 +4445,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 10524259945079648, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.00047622164
+      value: -0.0004762259
       objectReference: {fileID: 0}
     - target: {fileID: 10524259945079648, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.z
@@ -2677,7 +4453,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 10524259945079648, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.17912485
+      value: 0.17912486
       objectReference: {fileID: 0}
     - target: {fileID: 10524259945079648, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalRotation.y
@@ -2685,7 +4461,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 10524259945079648, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.013585598
+      value: 0.013585571
       objectReference: {fileID: 0}
     - target: {fileID: 344091136451128432, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2781,11 +4557,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2069468163715716617, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.000000014551915
+      value: 0.000000014901161
       objectReference: {fileID: 0}
     - target: {fileID: 2069468163715716617, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.0000000119325705
+      value: -0.000000011990778
       objectReference: {fileID: 0}
     - target: {fileID: 2069468163715716617, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalRotation.x
@@ -2793,7 +4569,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2069468163715716617, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.000000001396984
+      value: 0.000000002793968
       objectReference: {fileID: 0}
     - target: {fileID: 2607279791139293985, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2801,11 +4577,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2607279791139293985, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.000000030733645
+      value: -0.000000030267984
       objectReference: {fileID: 0}
     - target: {fileID: 2607279791139293985, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.000000018626451
+      value: -0.00000001816079
       objectReference: {fileID: 0}
     - target: {fileID: 2607279791139293985, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalRotation.x
@@ -2829,15 +4605,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2620977356224777572, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.03006893
+      value: -0.030068927
       objectReference: {fileID: 0}
     - target: {fileID: 2620977356224777572, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.000000029802322
+      value: 0.000000031664968
       objectReference: {fileID: 0}
     - target: {fileID: 2620977356224777572, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.00000005029142
+      value: -0.00000004656613
       objectReference: {fileID: 0}
     - target: {fileID: 3165001898688010464, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2845,7 +4621,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3165001898688010464, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.004286062
+      value: -0.004286067
       objectReference: {fileID: 0}
     - target: {fileID: 3165001898688010464, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.z
@@ -2857,7 +4633,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3165001898688010464, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.11039019
+      value: 0.1103902
       objectReference: {fileID: 0}
     - target: {fileID: 3165001898688010464, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalRotation.y
@@ -2865,7 +4641,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3165001898688010464, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.05827984
+      value: 0.05827981
       objectReference: {fileID: 0}
     - target: {fileID: 3189378369247214550, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalScale.x
@@ -2897,7 +4673,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3259260511750514255, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.005238473
+      value: 0.0052384706
       objectReference: {fileID: 0}
     - target: {fileID: 3259260511750514255, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.z
@@ -2917,7 +4693,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3259260511750514255, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.06647218
+      value: 0.06647214
       objectReference: {fileID: 0}
     - target: {fileID: 3519485581888210598, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.x
@@ -3709,15 +5485,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4593025366407807091, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.0000000023283064
+      value: 0.0000000020954758
       objectReference: {fileID: 0}
     - target: {fileID: 4593025366407807091, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.00000001094304
+      value: -0.000000011234079
       objectReference: {fileID: 0}
     - target: {fileID: 4593025366407807091, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.0000000018626451
+      value: 0.0000000037252903
       objectReference: {fileID: 0}
     - target: {fileID: 4601032796709982890, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalScale.x
@@ -3737,11 +5513,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4601032796709982890, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.0000000174381
+      value: 0.00000001697244
       objectReference: {fileID: 0}
     - target: {fileID: 4601032796709982890, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.000000012572856
+      value: 0.000000011292287
       objectReference: {fileID: 0}
     - target: {fileID: 4809008596489298730, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.x
@@ -3749,7 +5525,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4809008596489298730, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.0023811292
+      value: -0.0023811362
       objectReference: {fileID: 0}
     - target: {fileID: 4809008596489298730, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.z
@@ -3757,7 +5533,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4809008596489298730, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.00021689646
+      value: 0.00021690848
       objectReference: {fileID: 0}
     - target: {fileID: 4809008596489298730, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalRotation.y
@@ -3765,7 +5541,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4809008596489298730, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.07437596
+      value: 0.07437592
       objectReference: {fileID: 0}
     - target: {fileID: 5086803315480833604, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.x
@@ -3773,7 +5549,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5086803315480833604, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.0042860326
+      value: -0.004286039
       objectReference: {fileID: 0}
     - target: {fileID: 5086803315480833604, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.z
@@ -3785,7 +5561,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5086803315480833604, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.080274284
+      value: 0.0802743
       objectReference: {fileID: 0}
     - target: {fileID: 5086803315480833604, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalRotation.y
@@ -3793,7 +5569,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5086803315480833604, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.06854234
+      value: 0.06854231
       objectReference: {fileID: 0}
     - target: {fileID: 5107488038122085726, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.x
@@ -3833,7 +5609,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5111165689212994408, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.000000029802322
+      value: -0.000000044703484
       objectReference: {fileID: 0}
     - target: {fileID: 5111165689212994408, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalRotation.y
@@ -3841,7 +5617,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5111165689212994408, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.000000014901161
+      value: 0.000000014901161
       objectReference: {fileID: 0}
     - target: {fileID: 5411588042065055063, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalScale.x
@@ -3869,15 +5645,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5603408543180366600, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.044022348
+      value: -0.04402235
       objectReference: {fileID: 0}
     - target: {fileID: 5603408543180366600, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.000000022351742
+      value: -0.000000020489097
       objectReference: {fileID: 0}
     - target: {fileID: 5603408543180366600, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.000000013038516
+      value: -0.000000007450581
       objectReference: {fileID: 0}
     - target: {fileID: 5603408543180366600, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalRotation.x
@@ -3949,15 +5725,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6269058921456979496, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.000000012992168
+      value: 0.000000012596574
       objectReference: {fileID: 0}
     - target: {fileID: 6269058921456979496, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.0000000281143
+      value: 0.000000027939677
       objectReference: {fileID: 0}
     - target: {fileID: 6269058921456979496, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 8.271807e-25
+      value: 1.6543614e-24
       objectReference: {fileID: 0}
     - target: {fileID: 6499111511864390549, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4069,15 +5845,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6856558369867189689, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.021315891
+      value: -0.021315895
       objectReference: {fileID: 0}
     - target: {fileID: 6856558369867189689, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.00000001334465
+      value: -0.000000013292228
       objectReference: {fileID: 0}
     - target: {fileID: 6856558369867189689, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.000000010414501
+      value: 0.00000001140773
       objectReference: {fileID: 0}
     - target: {fileID: 7337961843798470890, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: _leapProvider
@@ -4877,19 +6653,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8049219267383934633, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.037888523
+      value: -0.03788852
       objectReference: {fileID: 0}
     - target: {fileID: 8049219267383934633, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.000000012601959
+      value: -0.0000000115906005
       objectReference: {fileID: 0}
     - target: {fileID: 8049219267383934633, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.000000010857862
+      value: 0.000000009989725
       objectReference: {fileID: 0}
     - target: {fileID: 8049219267383934633, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.00000000257279
+      value: -0.0000000025378313
       objectReference: {fileID: 0}
     - target: {fileID: 8726910147189952524, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4937,11 +6713,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8960369879201332238, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.0000000042819623
+      value: 0.000000004140142
       objectReference: {fileID: 0}
     - target: {fileID: 8960369879201332238, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.000000023166649
+      value: -0.000000023457687
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 85bdae4f36eb5b14c9fac95aec79bf2f, type: 3}
@@ -5205,6 +6981,242 @@ MonoBehaviour:
   _minimumDistance: 0.02
   _maximumDistance: 0.08
   _lerpTime: 0.1
+--- !u!1 &436964831
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 436964832}
+  - component: {fileID: 436964833}
+  - component: {fileID: 436964834}
+  - component: {fileID: 436964835}
+  m_Layer: 0
+  m_Name: Right Pinky Joint 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &436964832
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 436964831}
+  m_LocalRotation: {x: -0, y: -0, z: 4.6566123e-10, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.032740004}
+  m_LocalScale: {x: 0.9999994, y: 0.99999964, z: 0.99999976}
+  m_Children:
+  - {fileID: 221313058}
+  m_Father: {fileID: 971476548}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &436964833
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 436964831}
+  m_Material: {fileID: 1081093971}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.02611
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.009055001}
+--- !u!171741748 &436964834
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 436964831}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 0.000000022817412, y: -0.000000010069928, z: 0.03274001}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000004}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &436964835
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 436964831}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2127376581}
+  _body: {fileID: 436964834}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 4
+  _joint: 1
+--- !u!1 &439291897
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 439291898}
+  - component: {fileID: 439291899}
+  - component: {fileID: 439291900}
+  - component: {fileID: 439291901}
+  m_Layer: 0
+  m_Name: Left Pinky Joint 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &439291898
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 439291897}
+  m_LocalRotation: {x: -0.0000000018626449, y: -0, z: -0.000000006053596, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.032740004}
+  m_LocalScale: {x: 0.9999999, y: 1, z: 1}
+  m_Children:
+  - {fileID: 864411119}
+  m_Father: {fileID: 1997924415}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &439291899
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 439291897}
+  m_Material: {fileID: 1690218108}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.02611
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.009055001}
+--- !u!171741748 &439291900
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 439291897}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.000000017695132, y: -0.0000000137370115, z: 0.03274001}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &439291901
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 439291897}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2057484866}
+  _body: {fileID: 439291900}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 4
+  _joint: 1
 --- !u!1 &461023103
 GameObject:
   m_ObjectHideFlags: 0
@@ -5256,6 +7268,123 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 87e704a32bb13db4381cb8507400082c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &462755183
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 462755185}
+  - component: {fileID: 462755184}
+  - component: {fileID: 462755186}
+  - component: {fileID: 462755187}
+  m_Layer: 0
+  m_Name: Left Ring Joint 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!136 &462755184
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 462755183}
+  m_Material: {fileID: 1324615029}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.0253
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.00865}
+--- !u!4 &462755185
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 462755183}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.02565}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1642491618}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!171741748 &462755186
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 462755183}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 9.31323e-10, y: -0.000000025145715, z: 0.02565002}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &462755187
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 462755183}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 1552987639}
+  _body: {fileID: 462755186}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 3
+  _joint: 2
 --- !u!1 &463914037
 GameObject:
   m_ObjectHideFlags: 0
@@ -5554,6 +7683,124 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &513332372
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 513332373}
+  - component: {fileID: 513332374}
+  - component: {fileID: 513332375}
+  - component: {fileID: 513332376}
+  m_Layer: 0
+  m_Name: Right Index Joint 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &513332373
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 513332372}
+  m_LocalRotation: {x: 0.07411184, y: -0.08401716, z: 0.0062662363, w: 0.99368477}
+  m_LocalPosition: {x: -0.023181278, y: 0.0020000078, z: 0.023149364}
+  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
+  m_Children:
+  - {fileID: 517433465}
+  m_Father: {fileID: 1384551531}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &513332374
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 513332372}
+  m_Material: {fileID: 1081093971}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.047780003
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.019890001}
+--- !u!171741748 &513332375
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 513332372}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.023181293, y: 0.0020000115, z: 0.023149366}
+  m_ParentAnchorRotation: {x: 0.07411185, y: -0.08401715, z: 0.0062662363, w: 0.9936849}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -30
+    upperLimit: 80
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -15
+    upperLimit: 15
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &513332376
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 513332372}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2127376581}
+  _body: {fileID: 513332375}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 1
+  _joint: 0
 --- !u!1 &513771341
 GameObject:
   m_ObjectHideFlags: 0
@@ -5649,6 +7896,124 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 513771341}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &517433464
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 517433465}
+  - component: {fileID: 517433466}
+  - component: {fileID: 517433467}
+  - component: {fileID: 517433468}
+  m_Layer: 0
+  m_Name: Right Index Joint 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &517433465
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 517433464}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.039780002}
+  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 0.99999976}
+  m_Children:
+  - {fileID: 1305726773}
+  m_Father: {fileID: 513332373}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &517433466
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 517433464}
+  m_Material: {fileID: 1081093971}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.03038
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.01119}
+--- !u!171741748 &517433467
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 517433464}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.000000030267994, y: -0.00000002328307, z: 0.039780017}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &517433468
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 517433464}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2127376581}
+  _body: {fileID: 517433467}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 1
+  _joint: 1
 --- !u!1 &518429782
 GameObject:
   m_ObjectHideFlags: 0
@@ -5796,6 +8161,135 @@ Transform:
   m_Father: {fileID: 1874090592}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!134 &578926404
+PhysicMaterial:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Button Material
+  dynamicFriction: 1
+  staticFriction: 1
+  bounciness: 0
+  frictionCombine: 3
+  bounceCombine: 0
+--- !u!1 &584145260
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 584145262}
+  - component: {fileID: 584145261}
+  - component: {fileID: 584145263}
+  - component: {fileID: 584145264}
+  m_Layer: 0
+  m_Name: Right Thumb Joint 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!136 &584145261
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 584145260}
+  m_Material: {fileID: 189111359}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.02967
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.010835}
+--- !u!4 &584145262
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 584145260}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.031570002}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1930163463}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!171741748 &584145263
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 584145260}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.000000018626457, y: 0.000000031664985, z: 0.031570025}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 2
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &584145264
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 584145260}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2045161950}
+  _body: {fileID: 584145263}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 0
+  _joint: 2
 --- !u!1 &585023814
 GameObject:
   m_ObjectHideFlags: 0
@@ -5857,7 +8351,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -6097,6 +8591,127 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &632214910
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 632214914}
+  - component: {fileID: 632214912}
+  - component: {fileID: 632214911}
+  - component: {fileID: 632214913}
+  m_Layer: 0
+  m_Name: Left Palm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &632214911
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 632214910}
+  m_Material: {fileID: 1690218108}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.0833, y: 0.025, z: 0.10353848}
+  m_Center: {x: 0, y: 0.0025, z: -0.015}
+--- !u!171741748 &632214912
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 632214910}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 1.8000001
+  m_ParentAnchorPosition: {x: 0, y: 0, z: 0}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_ComputeParentAnchor: 1
+  m_ArticulationJointType: 0
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 2
+  m_SwingZ: 2
+  m_Twist: 2
+  m_XDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 0
+    damping: 0
+    forceLimit: 3.4028235e+38
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 0
+    damping: 0
+    forceLimit: 3.4028235e+38
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 0
+    damping: 0
+    forceLimit: 3.4028235e+38
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 50
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &632214913
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 632214910}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2057484866}
+  _body: {fileID: 632214912}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 5
+  _joint: 0
+--- !u!4 &632214914
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 632214910}
+  m_LocalRotation: {x: -0.12940949, y: 0.48296294, z: 0.86272997, w: 0.07547909}
+  m_LocalPosition: {x: -0.21999998, y: -0.13000001, z: 0.27000004}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2058509477}
+  - {fileID: 374448558}
+  - {fileID: 1422669237}
+  - {fileID: 1280355242}
+  - {fileID: 1997924415}
+  m_Father: {fileID: 2057484867}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &653981085
 GameObject:
   m_ObjectHideFlags: 0
@@ -6280,7 +8895,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -6398,7 +9013,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0.07411182, y: 0.08401718, z: -0.006266229, w: 0.9936849}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -6454,6 +9069,124 @@ MonoBehaviour:
   _currentXDriveLimit: 3.4028235e+38
   _finger: 1
   _joint: 0
+--- !u!1 &676571246
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 676571247}
+  - component: {fileID: 676571248}
+  - component: {fileID: 676571249}
+  - component: {fileID: 676571250}
+  m_Layer: 0
+  m_Name: Right Ring Joint 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &676571247
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 676571246}
+  m_LocalRotation: {x: -0, y: -0, z: -0.0000000018626451, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.04137}
+  m_LocalScale: {x: 0.9999999, y: 1, z: 0.9999999}
+  m_Children:
+  - {fileID: 1625487771}
+  m_Father: {fileID: 1326941326}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &676571248
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 676571246}
+  m_Material: {fileID: 189111359}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.03365
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.012825}
+--- !u!171741748 &676571249
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 676571246}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 0.000000012107198, y: -0.000000013504181, z: 0.041370012}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &676571250
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 676571246}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2045161950}
+  _body: {fileID: 676571249}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 3
+  _joint: 1
 --- !u!1 &689004047
 GameObject:
   m_ObjectHideFlags: 0
@@ -6637,6 +9370,124 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 89a6155d1ade3a442a3c9a1ff5aa29c0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &794028891
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 794028892}
+  - component: {fileID: 794028893}
+  - component: {fileID: 794028894}
+  - component: {fileID: 794028895}
+  m_Layer: 0
+  m_Name: Right Thumb Joint 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &794028892
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 794028891}
+  m_LocalRotation: {x: 0.019904856, y: -0.35755515, z: 0.53516835, w: 0.7650837}
+  m_LocalPosition: {x: -0.01933824, y: -0.0059999824, z: -0.05316848}
+  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
+  m_Children:
+  - {fileID: 2000139858}
+  m_Father: {fileID: 1384551531}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &794028893
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 794028891}
+  m_Material: {fileID: 1081093971}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.054220006
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.023110002}
+--- !u!171741748 &794028894
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 794028891}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.01933824, y: -0.0059999824, z: -0.05316848}
+  m_ParentAnchorRotation: {x: 0.019904852, y: -0.35755515, z: 0.53516847, w: 0.7650838}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -45
+    upperLimit: 45
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -50
+    upperLimit: 10
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &794028895
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 794028891}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2127376581}
+  _body: {fileID: 794028894}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 0
+  _joint: 0
 --- !u!114 &799113158 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 882061859479617650, guid: 5fad9bc118c955741a03cf98cf3f0a46, type: 3}
@@ -6648,6 +9499,135 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 89a6155d1ade3a442a3c9a1ff5aa29c0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!134 &861115678
+PhysicMaterial:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Button Material
+  dynamicFriction: 1
+  staticFriction: 1
+  bounciness: 0
+  frictionCombine: 3
+  bounceCombine: 0
+--- !u!1 &864411117
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 864411119}
+  - component: {fileID: 864411118}
+  - component: {fileID: 864411120}
+  - component: {fileID: 864411121}
+  m_Layer: 0
+  m_Name: Left Pinky Joint 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!136 &864411118
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 864411117}
+  m_Material: {fileID: 1690218108}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.023960002
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.00798}
+--- !u!4 &864411119
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 864411117}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.018110001}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 439291898}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!171741748 &864411120
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 864411117}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.000000013038521, y: 0.0000000020280109, z: 0.018110018}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &864411121
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 864411117}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2057484866}
+  _body: {fileID: 864411120}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 4
+  _joint: 2
 --- !u!1 &888698408
 GameObject:
   m_ObjectHideFlags: 0
@@ -6714,6 +9694,127 @@ Transform:
   m_Father: {fileID: 463914042}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &889282509
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 889282513}
+  - component: {fileID: 889282511}
+  - component: {fileID: 889282510}
+  - component: {fileID: 889282512}
+  m_Layer: 0
+  m_Name: Left Palm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &889282510
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 889282509}
+  m_Material: {fileID: 1324615029}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.0833, y: 0.025, z: 0.10353848}
+  m_Center: {x: 0, y: 0.0025, z: -0.015}
+--- !u!171741748 &889282511
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 889282509}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 1.8000001
+  m_ParentAnchorPosition: {x: 0, y: 0, z: 0}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_ComputeParentAnchor: 1
+  m_ArticulationJointType: 0
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 2
+  m_SwingZ: 2
+  m_Twist: 2
+  m_XDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 0
+    damping: 0
+    forceLimit: 3.4028235e+38
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 0
+    damping: 0
+    forceLimit: 3.4028235e+38
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 0
+    damping: 0
+    forceLimit: 3.4028235e+38
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 50
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &889282512
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 889282509}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 1552987639}
+  _body: {fileID: 889282511}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 5
+  _joint: 0
+--- !u!4 &889282513
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 889282509}
+  m_LocalRotation: {x: -0.12940949, y: 0.48296294, z: 0.86272997, w: 0.07547909}
+  m_LocalPosition: {x: -0.21999998, y: -0.13000001, z: 0.27000004}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1211426961}
+  - {fileID: 143027714}
+  - {fileID: 80816727}
+  - {fileID: 1120470095}
+  - {fileID: 1660436105}
+  m_Father: {fileID: 1552987640}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &891900966
 GameObject:
   m_ObjectHideFlags: 0
@@ -6776,7 +9877,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0.029145658, y: -0.13843812, z: 0.17725913, w: 0.97394294}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -7071,18 +10172,123 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 910863327}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!134 &913153326
-PhysicMaterial:
+--- !u!1 &928808895
+GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: Button Material
-  dynamicFriction: 1
-  staticFriction: 1
-  bounciness: 0
-  frictionCombine: 3
-  bounceCombine: 0
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 928808897}
+  - component: {fileID: 928808896}
+  - component: {fileID: 928808898}
+  - component: {fileID: 928808899}
+  m_Layer: 0
+  m_Name: Left Middle Joint 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!136 &928808896
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 928808895}
+  m_Material: {fileID: 1324615029}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.025400002
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.0087}
+--- !u!4 &928808897
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 928808895}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.026330002}
+  m_LocalScale: {x: 1, y: 0.9999999, z: 0.9999999}
+  m_Children: []
+  m_Father: {fileID: 246457847}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!171741748 &928808898
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 928808895}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 4.656617e-10, y: -0.00000000931323, z: 0.026330002}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &928808899
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 928808895}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 1552987639}
+  _body: {fileID: 928808898}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 2
+  _joint: 2
 --- !u!1 &929646170
 GameObject:
   m_ObjectHideFlags: 0
@@ -7316,7 +10522,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -7433,7 +10639,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -7661,6 +10867,124 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &971476547
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 971476548}
+  - component: {fileID: 971476549}
+  - component: {fileID: 971476550}
+  - component: {fileID: 971476551}
+  m_Layer: 0
+  m_Name: Right Pinky Joint 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &971476548
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 971476547}
+  m_LocalRotation: {x: 0.029145695, y: 0.13843815, z: -0.17725913, w: 0.9739429}
+  m_LocalPosition: {x: 0.035337448, y: -0.000000009313226, z: 0.009728717}
+  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
+  m_Children:
+  - {fileID: 436964832}
+  m_Father: {fileID: 1384551531}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &971476549
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 971476547}
+  m_Material: {fileID: 1081093971}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.040740006
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.016370002}
+--- !u!171741748 &971476550
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 971476547}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 0.035337463, y: -0.000000013038516, z: 0.009728714}
+  m_ParentAnchorRotation: {x: 0.029145688, y: 0.13843818, z: -0.17725915, w: 0.973943}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -30
+    upperLimit: 80
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -15
+    upperLimit: 15
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &971476551
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 971476547}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2127376581}
+  _body: {fileID: 971476550}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 4
+  _joint: 0
 --- !u!1 &976655189
 GameObject:
   m_ObjectHideFlags: 0
@@ -7773,6 +11097,124 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 976655189}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &979227608
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 979227609}
+  - component: {fileID: 979227610}
+  - component: {fileID: 979227611}
+  - component: {fileID: 979227612}
+  m_Layer: 0
+  m_Name: Left Middle Joint 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &979227609
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 979227608}
+  m_LocalRotation: {x: -0, y: -0, z: -0.000000001513399, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.044630002}
+  m_LocalScale: {x: 0.9999995, y: 0.99999976, z: 0.9999999}
+  m_Children:
+  - {fileID: 14895154}
+  m_Father: {fileID: 1422669237}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &979227610
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 979227608}
+  m_Material: {fileID: 1690218108}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.034330003
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.013165001}
+--- !u!171741748 &979227611
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 979227608}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 0.0000000047730295, y: -0.000000018160794, z: 0.044630006}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &979227612
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 979227608}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2057484866}
+  _body: {fileID: 979227611}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 2
+  _joint: 1
 --- !u!1 &980869086
 GameObject:
   m_ObjectHideFlags: 0
@@ -7945,6 +11387,123 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &1017830909
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1017830911}
+  - component: {fileID: 1017830910}
+  - component: {fileID: 1017830912}
+  - component: {fileID: 1017830913}
+  m_Layer: 0
+  m_Name: Right Middle Joint 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!136 &1017830910
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1017830909}
+  m_Material: {fileID: 189111359}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.025400002
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.0087}
+--- !u!4 &1017830911
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1017830909}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.026330002}
+  m_LocalScale: {x: 1.0000001, y: 1.0000001, z: 1.0000001}
+  m_Children: []
+  m_Father: {fileID: 1995389692}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!171741748 &1017830912
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1017830909}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 2.3283078e-10, y: 0.0000000055879377, z: 0.026330026}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1017830913
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1017830909}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2045161950}
+  _body: {fileID: 1017830912}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 2
+  _joint: 2
 --- !u!1 &1031752490
 GameObject:
   m_ObjectHideFlags: 0
@@ -8160,7 +11719,7 @@ PrefabInstance:
     - target: {fileID: 882061857553901801, guid: 5fad9bc118c955741a03cf98cf3f0a46, type: 3}
       propertyPath: m_Material
       value: 
-      objectReference: {fileID: 913153326}
+      objectReference: {fileID: 578926404}
     - target: {fileID: 882061857767179480, guid: 5fad9bc118c955741a03cf98cf3f0a46, type: 3}
       propertyPath: m_text
       value: Clean The Table!
@@ -8284,7 +11843,7 @@ PrefabInstance:
     - target: {fileID: 6928925247276963121, guid: 5fad9bc118c955741a03cf98cf3f0a46, type: 3}
       propertyPath: _material
       value: 
-      objectReference: {fileID: 913153326}
+      objectReference: {fileID: 578926404}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5fad9bc118c955741a03cf98cf3f0a46, type: 3}
 --- !u!4 &1051681185 stripped
@@ -8303,6 +11862,257 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 89a6155d1ade3a442a3c9a1ff5aa29c0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1077167461
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1077167462}
+  - component: {fileID: 1077167463}
+  - component: {fileID: 1077167464}
+  - component: {fileID: 1077167465}
+  m_Layer: 0
+  m_Name: Right Middle Joint 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1077167462
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1077167461}
+  m_LocalRotation: {x: -0, y: -0, z: 9.895301e-10, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.044630002}
+  m_LocalScale: {x: 0.99999976, y: 0.9999999, z: 0.99999976}
+  m_Children:
+  - {fileID: 302522889}
+  m_Father: {fileID: 1216944352}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1077167463
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1077167461}
+  m_Material: {fileID: 1081093971}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.034330003
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.013165001}
+--- !u!171741748 &1077167464
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1077167461}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 0.0000000036088763, y: 0.0000000051222755, z: 0.04463001}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1077167465
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1077167461}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2127376581}
+  _body: {fileID: 1077167464}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 2
+  _joint: 1
+--- !u!134 &1081093971
+PhysicMaterial:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: HandPhysics
+  dynamicFriction: 1
+  staticFriction: 1
+  bounciness: 0
+  frictionCombine: 0
+  bounceCombine: 1
+--- !u!1 &1085073647
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1085073651}
+  - component: {fileID: 1085073649}
+  - component: {fileID: 1085073648}
+  - component: {fileID: 1085073650}
+  m_Layer: 0
+  m_Name: Right Palm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &1085073648
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1085073647}
+  m_Material: {fileID: 189111359}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.0833, y: 0.025, z: 0.103538476}
+  m_Center: {x: 0, y: 0.0025, z: -0.015}
+--- !u!171741748 &1085073649
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1085073647}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 1.8000001
+  m_ParentAnchorPosition: {x: 0, y: 0, z: 0}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_ComputeParentAnchor: 1
+  m_ArticulationJointType: 0
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 2
+  m_SwingZ: 2
+  m_Twist: 2
+  m_XDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 0
+    damping: 0
+    forceLimit: 3.4028235e+38
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 0
+    damping: 0
+    forceLimit: 3.4028235e+38
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 0
+    damping: 0
+    forceLimit: 3.4028235e+38
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 50
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1085073650
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1085073647}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2045161950}
+  _body: {fileID: 1085073649}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 5
+  _joint: 0
+--- !u!4 &1085073651
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1085073647}
+  m_LocalRotation: {x: -0.12940957, y: -0.4829629, z: -0.86272997, w: 0.07547912}
+  m_LocalPosition: {x: 0.22000004, y: -0.13000001, z: 0.26999998}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1193507573}
+  - {fileID: 2080805427}
+  - {fileID: 65960885}
+  - {fileID: 1326941326}
+  - {fileID: 182831394}
+  m_Father: {fileID: 2045161951}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1092288546
 GameObject:
   m_ObjectHideFlags: 0
@@ -8451,6 +12261,124 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
+--- !u!1 &1120470094
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1120470095}
+  - component: {fileID: 1120470096}
+  - component: {fileID: 1120470097}
+  - component: {fileID: 1120470098}
+  m_Layer: 0
+  m_Name: Left Ring Joint 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1120470095
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1120470094}
+  m_LocalRotation: {x: 0.06767923, y: -0.06845519, z: 0.104890674, w: 0.9898138}
+  m_LocalPosition: {x: -0.017447187, y: 0.0040000137, z: 0.01727916}
+  m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999999}
+  m_Children:
+  - {fileID: 1642491618}
+  m_Father: {fileID: 889282513}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1120470096
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1120470094}
+  m_Material: {fileID: 1324615029}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.049370002
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.020685}
+--- !u!171741748 &1120470097
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1120470094}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.017447187, y: 0.0040000137, z: 0.01727916}
+  m_ParentAnchorRotation: {x: 0.067679256, y: -0.06845519, z: 0.10489069, w: 0.9898139}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -30
+    upperLimit: 80
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -15
+    upperLimit: 15
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1120470098
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1120470094}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 1552987639}
+  _body: {fileID: 1120470097}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 3
+  _joint: 0
 --- !u!1 &1141051099
 GameObject:
   m_ObjectHideFlags: 0
@@ -8770,6 +12698,124 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1152218872}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1193507572
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1193507573}
+  - component: {fileID: 1193507574}
+  - component: {fileID: 1193507575}
+  - component: {fileID: 1193507576}
+  m_Layer: 0
+  m_Name: Right Thumb Joint 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1193507573
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1193507572}
+  m_LocalRotation: {x: 0.019904856, y: -0.35755515, z: 0.53516835, w: 0.7650837}
+  m_LocalPosition: {x: -0.01933824, y: -0.0059999824, z: -0.05316848}
+  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
+  m_Children:
+  - {fileID: 1930163463}
+  m_Father: {fileID: 1085073651}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1193507574
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1193507572}
+  m_Material: {fileID: 189111359}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.054220006
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.023110002}
+--- !u!171741748 &1193507575
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1193507572}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.01933824, y: -0.0059999824, z: -0.05316848}
+  m_ParentAnchorRotation: {x: 0.019904852, y: -0.35755515, z: 0.53516847, w: 0.7650838}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -45
+    upperLimit: 45
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -50
+    upperLimit: 10
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1193507576
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1193507572}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2045161950}
+  _body: {fileID: 1193507575}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 0
+  _joint: 0
 --- !u!1 &1204820712
 GameObject:
   m_ObjectHideFlags: 0
@@ -8942,18 +12988,242 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!134 &1247594335
-PhysicMaterial:
+--- !u!1 &1211426960
+GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: Button Material
-  dynamicFriction: 1
-  staticFriction: 1
-  bounciness: 0
-  frictionCombine: 3
-  bounceCombine: 0
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1211426961}
+  - component: {fileID: 1211426962}
+  - component: {fileID: 1211426963}
+  - component: {fileID: 1211426964}
+  m_Layer: 0
+  m_Name: Left Thumb Joint 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1211426961
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1211426960}
+  m_LocalRotation: {x: 0.019904852, y: 0.35755512, z: -0.53516835, w: 0.7650836}
+  m_LocalPosition: {x: 0.019338273, y: -0.006000001, z: -0.053168494}
+  m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999999}
+  m_Children:
+  - {fileID: 1945723378}
+  m_Father: {fileID: 889282513}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1211426962
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1211426960}
+  m_Material: {fileID: 1324615029}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.054220006
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.023110002}
+--- !u!171741748 &1211426963
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1211426960}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 0.019338273, y: -0.0059999935, z: -0.053168505}
+  m_ParentAnchorRotation: {x: 0.019904822, y: 0.35755518, z: -0.5351684, w: 0.7650837}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -45
+    upperLimit: 45
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -10
+    upperLimit: 50
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1211426964
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1211426960}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 1552987639}
+  _body: {fileID: 1211426963}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 0
+  _joint: 0
+--- !u!1 &1216944351
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1216944352}
+  - component: {fileID: 1216944353}
+  - component: {fileID: 1216944354}
+  - component: {fileID: 1216944355}
+  m_Layer: 0
+  m_Name: Right Middle Joint 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1216944352
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1216944351}
+  m_LocalRotation: {x: 0.07527792, y: -0.009242235, z: -0.073994935, w: 0.99437046}
+  m_LocalPosition: {x: -0.002788769, y: 0.0040000016, z: 0.023252115}
+  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
+  m_Children:
+  - {fileID: 1077167462}
+  m_Father: {fileID: 1384551531}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1216944353
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1216944351}
+  m_Material: {fileID: 1081093971}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.052630004
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.022315001}
+--- !u!171741748 &1216944354
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1216944351}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.002788769, y: 0.0040000016, z: 0.023252115}
+  m_ParentAnchorRotation: {x: 0.075277954, y: -0.009242229, z: -0.07399494, w: 0.9943706}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -30
+    upperLimit: 80
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -15
+    upperLimit: 15
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1216944355
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1216944351}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2127376581}
+  _body: {fileID: 1216944354}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 2
+  _joint: 0
 --- !u!1 &1265756910
 GameObject:
   m_ObjectHideFlags: 0
@@ -8990,18 +13260,124 @@ Transform:
   m_Father: {fileID: 461023104}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!134 &1280980662
-PhysicMaterial:
+--- !u!1 &1280355241
+GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: Button Material
-  dynamicFriction: 1
-  staticFriction: 1
-  bounciness: 0
-  frictionCombine: 3
-  bounceCombine: 0
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1280355242}
+  - component: {fileID: 1280355243}
+  - component: {fileID: 1280355244}
+  - component: {fileID: 1280355245}
+  m_Layer: 0
+  m_Name: Left Ring Joint 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1280355242
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1280355241}
+  m_LocalRotation: {x: 0.06767923, y: -0.06845519, z: 0.104890674, w: 0.9898138}
+  m_LocalPosition: {x: -0.017447187, y: 0.0040000137, z: 0.01727916}
+  m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999999}
+  m_Children:
+  - {fileID: 1991305267}
+  m_Father: {fileID: 632214914}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1280355243
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1280355241}
+  m_Material: {fileID: 1690218108}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.049370002
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.020685}
+--- !u!171741748 &1280355244
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1280355241}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.017447187, y: 0.0040000137, z: 0.01727916}
+  m_ParentAnchorRotation: {x: 0.067679256, y: -0.06845519, z: 0.10489069, w: 0.9898139}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -30
+    upperLimit: 80
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -15
+    upperLimit: 15
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1280355245
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1280355241}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2057484866}
+  _body: {fileID: 1280355244}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 3
+  _joint: 0
 --- !u!1 &1288267143
 GameObject:
   m_ObjectHideFlags: 0
@@ -9064,7 +13440,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0.07411185, y: -0.08401715, z: 0.0062662363, w: 0.9936849}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -9182,7 +13558,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0.029145688, y: 0.13843818, z: -0.17725915, w: 0.973943}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -9238,6 +13614,370 @@ MonoBehaviour:
   _currentXDriveLimit: 3.4028235e+38
   _finger: 4
   _joint: 0
+--- !u!1 &1305726771
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1305726773}
+  - component: {fileID: 1305726772}
+  - component: {fileID: 1305726774}
+  - component: {fileID: 1305726775}
+  m_Layer: 0
+  m_Name: Right Index Joint 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!136 &1305726772
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1305726771}
+  m_Material: {fileID: 1081093971}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.023820002
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.00791}
+--- !u!4 &1305726773
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1305726771}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.02238}
+  m_LocalScale: {x: 1, y: 1.0000001, z: 1}
+  m_Children: []
+  m_Father: {fileID: 517433465}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!171741748 &1305726774
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1305726771}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.000000003725293, y: -0.00000001583249, z: 0.022380007}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1305726775
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1305726771}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2127376581}
+  _body: {fileID: 1305726774}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 1
+  _joint: 2
+--- !u!134 &1324615029
+PhysicMaterial:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: HandPhysics
+  dynamicFriction: 1
+  staticFriction: 1
+  bounciness: 0
+  frictionCombine: 0
+  bounceCombine: 1
+--- !u!1 &1326941325
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1326941326}
+  - component: {fileID: 1326941327}
+  - component: {fileID: 1326941328}
+  - component: {fileID: 1326941329}
+  m_Layer: 0
+  m_Name: Right Ring Joint 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1326941326
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1326941325}
+  m_LocalRotation: {x: 0.067679256, y: 0.06845519, z: -0.104890674, w: 0.9898138}
+  m_LocalPosition: {x: 0.017447188, y: 0.004000012, z: 0.017279157}
+  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
+  m_Children:
+  - {fileID: 676571247}
+  m_Father: {fileID: 1085073651}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1326941327
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1326941325}
+  m_Material: {fileID: 189111359}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.049370002
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.020685}
+--- !u!171741748 &1326941328
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1326941325}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 0.017447188, y: 0.004000012, z: 0.017279157}
+  m_ParentAnchorRotation: {x: 0.067679256, y: 0.06845519, z: -0.10489069, w: 0.9898139}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -30
+    upperLimit: 80
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -15
+    upperLimit: 15
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1326941329
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1326941325}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2045161950}
+  _body: {fileID: 1326941328}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 3
+  _joint: 0
+--- !u!1 &1330061735
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1330061737}
+  - component: {fileID: 1330061736}
+  - component: {fileID: 1330061738}
+  - component: {fileID: 1330061739}
+  m_Layer: 0
+  m_Name: Left Index Joint 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!136 &1330061736
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1330061735}
+  m_Material: {fileID: 1690218108}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.023820002
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.00791}
+--- !u!4 &1330061737
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1330061735}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.02238}
+  m_LocalScale: {x: 1, y: 1.0000001, z: 1}
+  m_Children: []
+  m_Father: {fileID: 80499002}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!171741748 &1330061738
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1330061735}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 0.0000000102445545, y: -0.000000020489109, z: 0.022380015}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1330061739
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1330061735}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2057484866}
+  _body: {fileID: 1330061738}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 1
+  _joint: 2
 --- !u!1 &1331277408
 GameObject:
   m_ObjectHideFlags: 0
@@ -9300,7 +14040,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0.075277895, y: 0.0092422515, z: 0.073994935, w: 0.9943706}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -9418,7 +14158,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0.067679256, y: -0.06845519, z: 0.10489069, w: 0.9898139}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -9698,6 +14438,363 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1364199983}
   m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1371222474
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1371222475}
+  - component: {fileID: 1371222476}
+  - component: {fileID: 1371222477}
+  - component: {fileID: 1371222478}
+  m_Layer: 0
+  m_Name: Right Ring Joint 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1371222475
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1371222474}
+  m_LocalRotation: {x: 0.067679256, y: 0.06845519, z: -0.104890674, w: 0.9898138}
+  m_LocalPosition: {x: 0.017447188, y: 0.004000012, z: 0.017279157}
+  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
+  m_Children:
+  - {fileID: 1412118569}
+  m_Father: {fileID: 1384551531}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1371222476
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1371222474}
+  m_Material: {fileID: 1081093971}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.049370002
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.020685}
+--- !u!171741748 &1371222477
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1371222474}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 0.017447188, y: 0.004000012, z: 0.017279157}
+  m_ParentAnchorRotation: {x: 0.067679256, y: 0.06845519, z: -0.10489069, w: 0.9898139}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -30
+    upperLimit: 80
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -15
+    upperLimit: 15
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1371222478
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1371222474}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2127376581}
+  _body: {fileID: 1371222477}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 3
+  _joint: 0
+--- !u!1 &1384551527
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1384551531}
+  - component: {fileID: 1384551529}
+  - component: {fileID: 1384551528}
+  - component: {fileID: 1384551530}
+  m_Layer: 0
+  m_Name: Right Palm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &1384551528
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1384551527}
+  m_Material: {fileID: 1081093971}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.0833, y: 0.025, z: 0.103538476}
+  m_Center: {x: 0, y: 0.0025, z: -0.015}
+--- !u!171741748 &1384551529
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1384551527}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 1.8000001
+  m_ParentAnchorPosition: {x: 0, y: 0, z: 0}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_ComputeParentAnchor: 1
+  m_ArticulationJointType: 0
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 2
+  m_SwingZ: 2
+  m_Twist: 2
+  m_XDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 0
+    damping: 0
+    forceLimit: 3.4028235e+38
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 0
+    damping: 0
+    forceLimit: 3.4028235e+38
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 0
+    damping: 0
+    forceLimit: 3.4028235e+38
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 50
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1384551530
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1384551527}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2127376581}
+  _body: {fileID: 1384551529}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 5
+  _joint: 0
+--- !u!4 &1384551531
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1384551527}
+  m_LocalRotation: {x: -0.12940957, y: -0.4829629, z: -0.86272997, w: 0.07547912}
+  m_LocalPosition: {x: 0.22000004, y: -0.13000001, z: 0.26999998}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 794028892}
+  - {fileID: 513332373}
+  - {fileID: 1216944352}
+  - {fileID: 1371222475}
+  - {fileID: 971476548}
+  m_Father: {fileID: 2127376582}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1412118568
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1412118569}
+  - component: {fileID: 1412118570}
+  - component: {fileID: 1412118571}
+  - component: {fileID: 1412118572}
+  m_Layer: 0
+  m_Name: Right Ring Joint 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1412118569
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1412118568}
+  m_LocalRotation: {x: -0, y: -0, z: -0.0000000018626451, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.04137}
+  m_LocalScale: {x: 0.9999999, y: 1, z: 0.9999999}
+  m_Children:
+  - {fileID: 1530934140}
+  m_Father: {fileID: 1371222475}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1412118570
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1412118568}
+  m_Material: {fileID: 1081093971}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.03365
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.012825}
+--- !u!171741748 &1412118571
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1412118568}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 0.000000012107198, y: -0.000000013504181, z: 0.041370012}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1412118572
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1412118568}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2127376581}
+  _body: {fileID: 1412118571}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 3
+  _joint: 1
 --- !u!1 &1414173479
 GameObject:
   m_ObjectHideFlags: 0
@@ -9810,6 +14907,124 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1414173479}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1422669236
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1422669237}
+  - component: {fileID: 1422669238}
+  - component: {fileID: 1422669239}
+  - component: {fileID: 1422669240}
+  m_Layer: 0
+  m_Name: Left Middle Joint 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1422669237
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1422669236}
+  m_LocalRotation: {x: 0.07527789, y: 0.009242246, z: 0.073994935, w: 0.9943705}
+  m_LocalPosition: {x: 0.002788771, y: 0.0040000007, z: 0.023252115}
+  m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999999}
+  m_Children:
+  - {fileID: 979227609}
+  m_Father: {fileID: 632214914}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1422669238
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1422669236}
+  m_Material: {fileID: 1690218108}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.052630004
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.022315001}
+--- !u!171741748 &1422669239
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1422669236}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 0.002788771, y: 0.0040000007, z: 0.023252115}
+  m_ParentAnchorRotation: {x: 0.075277895, y: 0.0092422515, z: 0.073994935, w: 0.9943706}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -30
+    upperLimit: 80
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -15
+    upperLimit: 15
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1422669240
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1422669236}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2057484866}
+  _body: {fileID: 1422669239}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 2
+  _joint: 0
 --- !u!1 &1434036243
 GameObject:
   m_ObjectHideFlags: 0
@@ -9871,7 +15086,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -9989,7 +15204,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0.000000014901161, y: 0, z: 0.000000029802322, w: 1.0000001}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -10106,7 +15321,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000004}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -10162,6 +15377,124 @@ MonoBehaviour:
   _currentXDriveLimit: 3.4028235e+38
   _finger: 4
   _joint: 2
+--- !u!1 &1509403552
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1509403553}
+  - component: {fileID: 1509403554}
+  - component: {fileID: 1509403555}
+  - component: {fileID: 1509403556}
+  m_Layer: 0
+  m_Name: Right Pinky Joint 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1509403553
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1509403552}
+  m_LocalRotation: {x: -0, y: -0, z: 4.6566123e-10, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.032740004}
+  m_LocalScale: {x: 0.9999994, y: 0.99999964, z: 0.99999976}
+  m_Children:
+  - {fileID: 32345357}
+  m_Father: {fileID: 182831394}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1509403554
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1509403552}
+  m_Material: {fileID: 189111359}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.02611
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.009055001}
+--- !u!171741748 &1509403555
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1509403552}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 0.000000022817412, y: -0.000000010069928, z: 0.03274001}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000004}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1509403556
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1509403552}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2045161950}
+  _body: {fileID: 1509403555}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 4
+  _joint: 1
 --- !u!1 &1523185466
 GameObject:
   m_ObjectHideFlags: 0
@@ -10223,7 +15556,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -10275,6 +15608,123 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _hand: {fileID: 1656071730}
   _body: {fileID: 1523185469}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 3
+  _joint: 2
+--- !u!1 &1530934138
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1530934140}
+  - component: {fileID: 1530934139}
+  - component: {fileID: 1530934141}
+  - component: {fileID: 1530934142}
+  m_Layer: 0
+  m_Name: Right Ring Joint 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!136 &1530934139
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1530934138}
+  m_Material: {fileID: 1081093971}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.0253
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.00865}
+--- !u!4 &1530934140
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1530934138}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.02565}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1412118569}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!171741748 &1530934141
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1530934138}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 0.000000005587938, y: -0.000000020489102, z: 0.02565001}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1530934142
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1530934138}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2127376581}
+  _body: {fileID: 1530934141}
   _origXDriveLimit: 0
   _currentXDriveLimit: 3.4028235e+38
   _finger: 3
@@ -10341,7 +15791,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -10439,7 +15889,7 @@ PrefabInstance:
     - target: {fileID: 882061857553901801, guid: 5fad9bc118c955741a03cf98cf3f0a46, type: 3}
       propertyPath: m_Material
       value: 
-      objectReference: {fileID: 1280980662}
+      objectReference: {fileID: 861115678}
     - target: {fileID: 882061857767179480, guid: 5fad9bc118c955741a03cf98cf3f0a46, type: 3}
       propertyPath: m_text
       value: Destroy All Cubes!
@@ -10539,9 +15989,359 @@ PrefabInstance:
     - target: {fileID: 6928925247276963121, guid: 5fad9bc118c955741a03cf98cf3f0a46, type: 3}
       propertyPath: _material
       value: 
-      objectReference: {fileID: 1280980662}
+      objectReference: {fileID: 861115678}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5fad9bc118c955741a03cf98cf3f0a46, type: 3}
+--- !u!1 &1552987638
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1552987640}
+  - component: {fileID: 1552987639}
+  m_Layer: 0
+  m_Name: Left Hand
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1552987639
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1552987638}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 445639c80127bbd44b6bd9d34463b470, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _physicsHand:
+    triggerDistance: 0.004
+    oldPosition: {x: 0, y: 0, z: 0}
+    gameObject: {fileID: 889282509}
+    rootObject: {fileID: 1552987638}
+    transform: {fileID: 889282513}
+    palmBone: {fileID: 889282512}
+    palmBody: {fileID: 889282511}
+    palmCollider: {fileID: 889282510}
+    jointBones:
+    - {fileID: 1211426964}
+    - {fileID: 1945723381}
+    - {fileID: 236780707}
+    - {fileID: 143027717}
+    - {fileID: 84440801}
+    - {fileID: 1559450539}
+    - {fileID: 80816730}
+    - {fileID: 246457850}
+    - {fileID: 928808899}
+    - {fileID: 1120470098}
+    - {fileID: 1642491621}
+    - {fileID: 462755187}
+    - {fileID: 1660436108}
+    - {fileID: 1973713159}
+    - {fileID: 71022536}
+    jointBodies:
+    - {fileID: 1211426963}
+    - {fileID: 1945723380}
+    - {fileID: 236780706}
+    - {fileID: 143027716}
+    - {fileID: 84440800}
+    - {fileID: 1559450538}
+    - {fileID: 80816729}
+    - {fileID: 246457849}
+    - {fileID: 928808898}
+    - {fileID: 1120470097}
+    - {fileID: 1642491620}
+    - {fileID: 462755186}
+    - {fileID: 1660436107}
+    - {fileID: 1973713158}
+    - {fileID: 71022535}
+    jointColliders:
+    - {fileID: 1211426962}
+    - {fileID: 1945723379}
+    - {fileID: 236780704}
+    - {fileID: 143027715}
+    - {fileID: 84440799}
+    - {fileID: 1559450536}
+    - {fileID: 80816728}
+    - {fileID: 246457848}
+    - {fileID: 928808896}
+    - {fileID: 1120470096}
+    - {fileID: 1642491619}
+    - {fileID: 462755184}
+    - {fileID: 1660436106}
+    - {fileID: 1973713157}
+    - {fileID: 71022533}
+    overRotationFrameCount: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+    defaultRotations:
+    - {x: -0.66444665, y: 0.34441158, z: 0.56378216, w: 0.34934354}
+    - {x: -0.1985088, y: 0.549382, z: 0.8101427, w: 0.04942208}
+    - {x: -0.09523581, y: 0.55546176, z: 0.82590574, w: 0.01649454}
+    - {x: -0.013266281, y: 0.54483914, z: 0.8380312, w: 0.026037559}
+    - {x: 0.081206754, y: 0.50801295, z: 0.85746795, w: -0.008782235}
+    - {x: -0.12940948, y: 0.4829629, z: 0.8627299, w: 0.07547908}
+    strength: 2
+    stiffness: 100
+    forceLimit: 1000
+    boneMass: 0.6
+    physicMaterial: {fileID: 1324615029}
+  _handedness: 0
+--- !u!4 &1552987640
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1552987638}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 889282513}
+  m_Father: {fileID: 1874090592}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1559450535
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1559450537}
+  - component: {fileID: 1559450536}
+  - component: {fileID: 1559450538}
+  - component: {fileID: 1559450539}
+  m_Layer: 0
+  m_Name: Left Index Joint 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!136 &1559450536
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1559450535}
+  m_Material: {fileID: 1324615029}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.023820002
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.00791}
+--- !u!4 &1559450537
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1559450535}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.02238}
+  m_LocalScale: {x: 1, y: 1.0000001, z: 1}
+  m_Children: []
+  m_Father: {fileID: 84440798}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!171741748 &1559450538
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1559450535}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 0.0000000102445545, y: -0.000000020489109, z: 0.022380015}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1559450539
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1559450535}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 1552987639}
+  _body: {fileID: 1559450538}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 1
+  _joint: 2
+--- !u!1 &1569510032
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1569510033}
+  - component: {fileID: 1569510034}
+  - component: {fileID: 1569510035}
+  - component: {fileID: 1569510036}
+  m_Layer: 0
+  m_Name: Left Thumb Joint 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1569510033
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1569510032}
+  m_LocalRotation: {x: -0, y: -0, z: 0.00000001071021, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.046220005}
+  m_LocalScale: {x: 1.0000001, y: 0.9999999, z: 0.99999976}
+  m_Children:
+  - {fileID: 1853180999}
+  m_Father: {fileID: 2058509477}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1569510034
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1569510032}
+  m_Material: {fileID: 1690218108}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.039570004
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.015785001}
+--- !u!171741748 &1569510035
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1569510032}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 9.313228e-10, y: 0.00000000651926, z: 0.046220012}
+  m_ParentAnchorRotation: {x: 0.000000014901161, y: 0, z: 0.000000029802322, w: 1.0000001}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 2
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1569510036
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1569510032}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2057484866}
+  _body: {fileID: 1569510035}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 0
+  _joint: 1
 --- !u!1 &1571827756
 GameObject:
   m_ObjectHideFlags: 0
@@ -10769,7 +16569,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -10886,7 +16686,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -10952,7 +16752,7 @@ PrefabInstance:
     - target: {fileID: 882061857553901801, guid: 5fad9bc118c955741a03cf98cf3f0a46, type: 3}
       propertyPath: m_Material
       value: 
-      objectReference: {fileID: 1247594335}
+      objectReference: {fileID: 2131980833}
     - target: {fileID: 882061857767179480, guid: 5fad9bc118c955741a03cf98cf3f0a46, type: 3}
       propertyPath: m_text
       value: Spawn a Cube!
@@ -11052,9 +16852,244 @@ PrefabInstance:
     - target: {fileID: 6928925247276963121, guid: 5fad9bc118c955741a03cf98cf3f0a46, type: 3}
       propertyPath: _material
       value: 
-      objectReference: {fileID: 1247594335}
+      objectReference: {fileID: 2131980833}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5fad9bc118c955741a03cf98cf3f0a46, type: 3}
+--- !u!1 &1625487769
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1625487771}
+  - component: {fileID: 1625487770}
+  - component: {fileID: 1625487772}
+  - component: {fileID: 1625487773}
+  m_Layer: 0
+  m_Name: Right Ring Joint 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!136 &1625487770
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1625487769}
+  m_Material: {fileID: 189111359}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.0253
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.00865}
+--- !u!4 &1625487771
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1625487769}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.02565}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 676571247}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!171741748 &1625487772
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1625487769}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 0.000000005587938, y: -0.000000020489102, z: 0.02565001}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1625487773
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1625487769}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2045161950}
+  _body: {fileID: 1625487772}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 3
+  _joint: 2
+--- !u!1 &1642491617
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1642491618}
+  - component: {fileID: 1642491619}
+  - component: {fileID: 1642491620}
+  - component: {fileID: 1642491621}
+  m_Layer: 0
+  m_Name: Left Ring Joint 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1642491618
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1642491617}
+  m_LocalRotation: {x: -0, y: -0, z: -4.656613e-10, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.04137}
+  m_LocalScale: {x: 0.99999976, y: 1, z: 1}
+  m_Children:
+  - {fileID: 462755185}
+  m_Father: {fileID: 1120470095}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1642491619
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1642491617}
+  m_Material: {fileID: 1324615029}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.03365
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.012825}
+--- !u!171741748 &1642491620
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1642491617}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.0000000093132275, y: -0.000000015366826, z: 0.04137001}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1642491621
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1642491617}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 1552987639}
+  _body: {fileID: 1642491620}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 3
+  _joint: 1
 --- !u!1 &1656071729
 GameObject:
   m_ObjectHideFlags: 0
@@ -11170,6 +17205,124 @@ Transform:
   m_Father: {fileID: 1874090592}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1660436104
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1660436105}
+  - component: {fileID: 1660436106}
+  - component: {fileID: 1660436107}
+  - component: {fileID: 1660436108}
+  m_Layer: 0
+  m_Name: Left Pinky Joint 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1660436105
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1660436104}
+  m_LocalRotation: {x: 0.02914566, y: -0.13843812, z: 0.17725913, w: 0.9739428}
+  m_LocalPosition: {x: -0.035337448, y: -0.000000004656613, z: 0.00972872}
+  m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999999}
+  m_Children:
+  - {fileID: 1973713156}
+  m_Father: {fileID: 889282513}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1660436106
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1660436104}
+  m_Material: {fileID: 1324615029}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.040740006
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.016370002}
+--- !u!171741748 &1660436107
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1660436104}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.035337463, y: -0.000000008381903, z: 0.009728719}
+  m_ParentAnchorRotation: {x: 0.029145658, y: -0.13843812, z: 0.17725913, w: 0.97394294}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -30
+    upperLimit: 80
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -15
+    upperLimit: 15
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1660436108
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1660436104}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 1552987639}
+  _body: {fileID: 1660436107}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 4
+  _joint: 0
 --- !u!1 &1678954819
 GameObject:
   m_ObjectHideFlags: 0
@@ -11297,6 +17450,18 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1678954819}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!134 &1690218108
+PhysicMaterial:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: HandPhysics
+  dynamicFriction: 1
+  staticFriction: 1
+  bounciness: 0
+  frictionCombine: 0
+  bounceCombine: 1
 --- !u!1 &1738364525
 GameObject:
   m_ObjectHideFlags: 0
@@ -12023,7 +18188,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -12079,6 +18244,123 @@ MonoBehaviour:
   _currentXDriveLimit: 3.4028235e+38
   _finger: 0
   _joint: 1
+--- !u!1 &1830967251
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1830967253}
+  - component: {fileID: 1830967252}
+  - component: {fileID: 1830967254}
+  - component: {fileID: 1830967255}
+  m_Layer: 0
+  m_Name: Right Index Joint 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!136 &1830967252
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1830967251}
+  m_Material: {fileID: 189111359}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.023820002
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.00791}
+--- !u!4 &1830967253
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1830967251}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.02238}
+  m_LocalScale: {x: 1, y: 1.0000001, z: 1}
+  m_Children: []
+  m_Father: {fileID: 334822913}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!171741748 &1830967254
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1830967251}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.000000003725293, y: -0.00000001583249, z: 0.022380007}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1830967255
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1830967251}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2045161950}
+  _body: {fileID: 1830967254}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 1
+  _joint: 2
 --- !u!1 &1838090639
 GameObject:
   m_ObjectHideFlags: 0
@@ -12287,6 +18569,123 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1842197905}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1853180997
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1853180999}
+  - component: {fileID: 1853180998}
+  - component: {fileID: 1853181000}
+  - component: {fileID: 1853181001}
+  m_Layer: 0
+  m_Name: Left Thumb Joint 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!136 &1853180998
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1853180997}
+  m_Material: {fileID: 1690218108}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.02967
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.010835}
+--- !u!4 &1853180999
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1853180997}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.031570002}
+  m_LocalScale: {x: 1, y: 1.0000001, z: 1.0000001}
+  m_Children: []
+  m_Father: {fileID: 1569510033}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!171741748 &1853181000
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1853180997}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.000000009313227, y: -0.0000000037252916, z: 0.03157001}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 2
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1853181001
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1853180997}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2057484866}
+  _body: {fileID: 1853181000}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 0
+  _joint: 2
 --- !u!1 &1859197412
 GameObject:
   m_ObjectHideFlags: 0
@@ -12349,7 +18748,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -12435,11 +18834,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   editTimePose: 1
-  _inputLeapProvider: {fileID: 463914039}
-  dataUpdateMode: 2
+  _inputLeapProvider: {fileID: 0}
+  dataUpdateMode: 0
   passthroughOnly: 0
-  <LeftHand>k__BackingField: {fileID: 1656071730}
-  <RightHand>k__BackingField: {fileID: 575778803}
+  <LeftHand>k__BackingField: {fileID: 2057484866}
+  <RightHand>k__BackingField: {fileID: 2045161950}
   _defaultLayer:
     layerIndex: 0
   _interactableLayers:
@@ -12456,8 +18855,8 @@ MonoBehaviour:
   _perBoneMass: 0.6
   _handTeleportDistance: 0.1
   _handGraspTeleportDistance: 0.2
-  _handSolverIterations: 15
-  _handSolverVelocityIterations: 5
+  _handSolverIterations: 20
+  _handSolverVelocityIterations: 15
   _enableHelpers: 1
   _helperMovesObjects: 1
   _interpolateMass: 1
@@ -12476,9 +18875,130 @@ Transform:
   m_Children:
   - {fileID: 1656071731}
   - {fileID: 575778804}
+  - {fileID: 1552987640}
+  - {fileID: 2127376582}
+  - {fileID: 2057484867}
+  - {fileID: 2045161951}
   m_Father: {fileID: 1812745759}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1878654702
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1878654704}
+  - component: {fileID: 1878654703}
+  - component: {fileID: 1878654705}
+  - component: {fileID: 1878654706}
+  m_Layer: 0
+  m_Name: Left Ring Joint 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!136 &1878654703
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1878654702}
+  m_Material: {fileID: 1690218108}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.0253
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.00865}
+--- !u!4 &1878654704
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1878654702}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.02565}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1991305267}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!171741748 &1878654705
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1878654702}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 9.31323e-10, y: -0.000000025145715, z: 0.02565002}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1878654706
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1878654702}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2057484866}
+  _body: {fileID: 1878654705}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 3
+  _joint: 2
 --- !u!1 &1883123092
 GameObject:
   m_ObjectHideFlags: 0
@@ -12540,7 +19060,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -12812,6 +19332,360 @@ Transform:
   m_Father: {fileID: 1656071731}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1930163462
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1930163463}
+  - component: {fileID: 1930163464}
+  - component: {fileID: 1930163465}
+  - component: {fileID: 1930163466}
+  m_Layer: 0
+  m_Name: Right Thumb Joint 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1930163463
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1930163462}
+  m_LocalRotation: {x: -0, y: -0, z: -0.0000000088475645, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.046220005}
+  m_LocalScale: {x: 1.0000001, y: 0.99999964, z: 0.9999995}
+  m_Children:
+  - {fileID: 584145262}
+  m_Father: {fileID: 1193507573}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1930163464
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1930163462}
+  m_Material: {fileID: 189111359}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.039570004
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.015785001}
+--- !u!171741748 &1930163465
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1930163462}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.0000000130385205, y: 0.0000000046566138, z: 0.046220012}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 2
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1930163466
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1930163462}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2045161950}
+  _body: {fileID: 1930163465}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 0
+  _joint: 1
+--- !u!1 &1945723377
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1945723378}
+  - component: {fileID: 1945723379}
+  - component: {fileID: 1945723380}
+  - component: {fileID: 1945723381}
+  m_Layer: 0
+  m_Name: Left Thumb Joint 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1945723378
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1945723377}
+  m_LocalRotation: {x: -0, y: -0, z: 0.00000001071021, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.046220005}
+  m_LocalScale: {x: 1.0000001, y: 0.9999999, z: 0.99999976}
+  m_Children:
+  - {fileID: 236780705}
+  m_Father: {fileID: 1211426961}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1945723379
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1945723377}
+  m_Material: {fileID: 1324615029}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.039570004
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.015785001}
+--- !u!171741748 &1945723380
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1945723377}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 9.313228e-10, y: 0.00000000651926, z: 0.046220012}
+  m_ParentAnchorRotation: {x: 0.000000014901161, y: 0, z: 0.000000029802322, w: 1.0000001}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 2
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1945723381
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1945723377}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 1552987639}
+  _body: {fileID: 1945723380}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 0
+  _joint: 1
+--- !u!1 &1973713155
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1973713156}
+  - component: {fileID: 1973713157}
+  - component: {fileID: 1973713158}
+  - component: {fileID: 1973713159}
+  m_Layer: 0
+  m_Name: Left Pinky Joint 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1973713156
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1973713155}
+  m_LocalRotation: {x: -0.0000000018626449, y: -0, z: -0.000000006053596, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.032740004}
+  m_LocalScale: {x: 0.9999999, y: 1, z: 1}
+  m_Children:
+  - {fileID: 71022534}
+  m_Father: {fileID: 1660436105}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1973713157
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1973713155}
+  m_Material: {fileID: 1324615029}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.02611
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.009055001}
+--- !u!171741748 &1973713158
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1973713155}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.000000017695132, y: -0.0000000137370115, z: 0.03274001}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1973713159
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1973713155}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 1552987639}
+  _body: {fileID: 1973713158}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 4
+  _joint: 1
 --- !u!1 &1989393195
 GameObject:
   m_ObjectHideFlags: 0
@@ -12907,6 +19781,124 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1989393195}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1991305266
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1991305267}
+  - component: {fileID: 1991305268}
+  - component: {fileID: 1991305269}
+  - component: {fileID: 1991305270}
+  m_Layer: 0
+  m_Name: Left Ring Joint 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1991305267
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1991305266}
+  m_LocalRotation: {x: -0, y: -0, z: -4.656613e-10, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.04137}
+  m_LocalScale: {x: 0.99999976, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1878654704}
+  m_Father: {fileID: 1280355242}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1991305268
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1991305266}
+  m_Material: {fileID: 1690218108}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.03365
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.012825}
+--- !u!171741748 &1991305269
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1991305266}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.0000000093132275, y: -0.000000015366826, z: 0.04137001}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1991305270
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1991305266}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2057484866}
+  _body: {fileID: 1991305269}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 3
+  _joint: 1
 --- !u!1 &1993941821
 GameObject:
   m_ObjectHideFlags: 0
@@ -12969,7 +19961,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -13025,6 +20017,242 @@ MonoBehaviour:
   _currentXDriveLimit: 3.4028235e+38
   _finger: 2
   _joint: 1
+--- !u!1 &1995389691
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1995389692}
+  - component: {fileID: 1995389693}
+  - component: {fileID: 1995389694}
+  - component: {fileID: 1995389695}
+  m_Layer: 0
+  m_Name: Right Middle Joint 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1995389692
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1995389691}
+  m_LocalRotation: {x: -0, y: -0, z: 9.895301e-10, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.044630002}
+  m_LocalScale: {x: 0.99999976, y: 0.9999999, z: 0.99999976}
+  m_Children:
+  - {fileID: 1017830911}
+  m_Father: {fileID: 65960885}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1995389693
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1995389691}
+  m_Material: {fileID: 189111359}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.034330003
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.013165001}
+--- !u!171741748 &1995389694
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1995389691}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 0.0000000036088763, y: 0.0000000051222755, z: 0.04463001}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1995389695
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1995389691}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2045161950}
+  _body: {fileID: 1995389694}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 2
+  _joint: 1
+--- !u!1 &1997924414
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1997924415}
+  - component: {fileID: 1997924416}
+  - component: {fileID: 1997924417}
+  - component: {fileID: 1997924418}
+  m_Layer: 0
+  m_Name: Left Pinky Joint 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1997924415
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1997924414}
+  m_LocalRotation: {x: 0.02914566, y: -0.13843812, z: 0.17725913, w: 0.9739428}
+  m_LocalPosition: {x: -0.035337448, y: -0.000000004656613, z: 0.00972872}
+  m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999999}
+  m_Children:
+  - {fileID: 439291898}
+  m_Father: {fileID: 632214914}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1997924416
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1997924414}
+  m_Material: {fileID: 1690218108}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.040740006
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.016370002}
+--- !u!171741748 &1997924417
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1997924414}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.035337463, y: -0.000000008381903, z: 0.009728719}
+  m_ParentAnchorRotation: {x: 0.029145658, y: -0.13843812, z: 0.17725913, w: 0.97394294}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -30
+    upperLimit: 80
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -15
+    upperLimit: 15
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &1997924418
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1997924414}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2057484866}
+  _body: {fileID: 1997924417}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 4
+  _joint: 0
 --- !u!1 &1999405928
 GameObject:
   m_ObjectHideFlags: 0
@@ -13068,6 +20296,124 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 70fd9230a01842d419b8c6d3e8aed589, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &2000139857
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2000139858}
+  - component: {fileID: 2000139859}
+  - component: {fileID: 2000139860}
+  - component: {fileID: 2000139861}
+  m_Layer: 0
+  m_Name: Right Thumb Joint 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2000139858
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2000139857}
+  m_LocalRotation: {x: -0, y: -0, z: -0.0000000088475645, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.046220005}
+  m_LocalScale: {x: 1.0000001, y: 0.99999964, z: 0.9999995}
+  m_Children:
+  - {fileID: 2091518380}
+  m_Father: {fileID: 794028892}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &2000139859
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2000139857}
+  m_Material: {fileID: 1081093971}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.039570004
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.015785001}
+--- !u!171741748 &2000139860
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2000139857}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.0000000130385205, y: 0.0000000046566138, z: 0.046220012}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 2
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &2000139861
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2000139857}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2127376581}
+  _body: {fileID: 2000139860}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 0
+  _joint: 1
 --- !u!134 &2041109289
 PhysicMaterial:
   m_ObjectHideFlags: 0
@@ -13080,6 +20426,121 @@ PhysicMaterial:
   bounciness: 0
   frictionCombine: 0
   bounceCombine: 1
+--- !u!1 &2045161949
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2045161951}
+  - component: {fileID: 2045161950}
+  m_Layer: 0
+  m_Name: Right Hand
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2045161950
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2045161949}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 445639c80127bbd44b6bd9d34463b470, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _physicsHand:
+    triggerDistance: 0.004
+    oldPosition: {x: 0, y: 0, z: 0}
+    gameObject: {fileID: 1085073647}
+    rootObject: {fileID: 2045161949}
+    transform: {fileID: 1085073651}
+    palmBone: {fileID: 1085073650}
+    palmBody: {fileID: 1085073649}
+    palmCollider: {fileID: 1085073648}
+    jointBones:
+    - {fileID: 1193507576}
+    - {fileID: 1930163466}
+    - {fileID: 584145264}
+    - {fileID: 2080805430}
+    - {fileID: 334822916}
+    - {fileID: 1830967255}
+    - {fileID: 65960888}
+    - {fileID: 1995389695}
+    - {fileID: 1017830913}
+    - {fileID: 1326941329}
+    - {fileID: 676571250}
+    - {fileID: 1625487773}
+    - {fileID: 182831397}
+    - {fileID: 1509403556}
+    - {fileID: 32345359}
+    jointBodies:
+    - {fileID: 1193507575}
+    - {fileID: 1930163465}
+    - {fileID: 584145263}
+    - {fileID: 2080805429}
+    - {fileID: 334822915}
+    - {fileID: 1830967254}
+    - {fileID: 65960887}
+    - {fileID: 1995389694}
+    - {fileID: 1017830912}
+    - {fileID: 1326941328}
+    - {fileID: 676571249}
+    - {fileID: 1625487772}
+    - {fileID: 182831396}
+    - {fileID: 1509403555}
+    - {fileID: 32345358}
+    jointColliders:
+    - {fileID: 1193507574}
+    - {fileID: 1930163464}
+    - {fileID: 584145261}
+    - {fileID: 2080805428}
+    - {fileID: 334822914}
+    - {fileID: 1830967252}
+    - {fileID: 65960886}
+    - {fileID: 1995389693}
+    - {fileID: 1017830910}
+    - {fileID: 1326941327}
+    - {fileID: 676571248}
+    - {fileID: 1625487770}
+    - {fileID: 182831395}
+    - {fileID: 1509403554}
+    - {fileID: 32345356}
+    overRotationFrameCount: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+    defaultRotations:
+    - {x: -0.6644467, y: -0.34441155, z: -0.5637821, w: 0.34934357}
+    - {x: -0.19850887, y: -0.549382, z: -0.8101427, w: 0.04942213}
+    - {x: -0.095235884, y: -0.55546176, z: -0.82590574, w: 0.016494589}
+    - {x: -0.013266354, y: -0.54483914, z: -0.8380312, w: 0.026037607}
+    - {x: 0.08120667, y: -0.50801295, z: -0.85746795, w: -0.00878219}
+    - {x: -0.12940955, y: -0.4829629, z: -0.8627299, w: 0.07547912}
+    strength: 2
+    stiffness: 100
+    forceLimit: 1000
+    boneMass: 0.6
+    physicMaterial: {fileID: 189111359}
+  _handedness: 1
+--- !u!4 &2045161951
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2045161949}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1085073651}
+  m_Father: {fileID: 1874090592}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2047985974
 GameObject:
   m_ObjectHideFlags: 0
@@ -13192,6 +20653,474 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2047985974}
   m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &2057484865
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2057484867}
+  - component: {fileID: 2057484866}
+  m_Layer: 0
+  m_Name: Left Hand
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2057484866
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2057484865}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 445639c80127bbd44b6bd9d34463b470, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _physicsHand:
+    triggerDistance: 0.004
+    oldPosition: {x: 0, y: 0, z: 0}
+    gameObject: {fileID: 632214910}
+    rootObject: {fileID: 2057484865}
+    transform: {fileID: 632214914}
+    palmBone: {fileID: 632214913}
+    palmBody: {fileID: 632214912}
+    palmCollider: {fileID: 632214911}
+    jointBones:
+    - {fileID: 2058509480}
+    - {fileID: 1569510036}
+    - {fileID: 1853181001}
+    - {fileID: 374448561}
+    - {fileID: 80499005}
+    - {fileID: 1330061739}
+    - {fileID: 1422669240}
+    - {fileID: 979227612}
+    - {fileID: 14895156}
+    - {fileID: 1280355245}
+    - {fileID: 1991305270}
+    - {fileID: 1878654706}
+    - {fileID: 1997924418}
+    - {fileID: 439291901}
+    - {fileID: 864411121}
+    jointBodies:
+    - {fileID: 2058509479}
+    - {fileID: 1569510035}
+    - {fileID: 1853181000}
+    - {fileID: 374448560}
+    - {fileID: 80499004}
+    - {fileID: 1330061738}
+    - {fileID: 1422669239}
+    - {fileID: 979227611}
+    - {fileID: 14895155}
+    - {fileID: 1280355244}
+    - {fileID: 1991305269}
+    - {fileID: 1878654705}
+    - {fileID: 1997924417}
+    - {fileID: 439291900}
+    - {fileID: 864411120}
+    jointColliders:
+    - {fileID: 2058509478}
+    - {fileID: 1569510034}
+    - {fileID: 1853180998}
+    - {fileID: 374448559}
+    - {fileID: 80499003}
+    - {fileID: 1330061736}
+    - {fileID: 1422669238}
+    - {fileID: 979227610}
+    - {fileID: 14895153}
+    - {fileID: 1280355243}
+    - {fileID: 1991305268}
+    - {fileID: 1878654703}
+    - {fileID: 1997924416}
+    - {fileID: 439291899}
+    - {fileID: 864411118}
+    overRotationFrameCount: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+    defaultRotations:
+    - {x: -0.66444665, y: 0.34441158, z: 0.56378216, w: 0.34934354}
+    - {x: -0.1985088, y: 0.549382, z: 0.8101427, w: 0.04942208}
+    - {x: -0.09523581, y: 0.55546176, z: 0.82590574, w: 0.01649454}
+    - {x: -0.013266281, y: 0.54483914, z: 0.8380312, w: 0.026037559}
+    - {x: 0.081206754, y: 0.50801295, z: 0.85746795, w: -0.008782235}
+    - {x: -0.12940948, y: 0.4829629, z: 0.8627299, w: 0.07547908}
+    strength: 2
+    stiffness: 100
+    forceLimit: 1000
+    boneMass: 0.6
+    physicMaterial: {fileID: 1690218108}
+  _handedness: 0
+--- !u!4 &2057484867
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2057484865}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 632214914}
+  m_Father: {fileID: 1874090592}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2058509476
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2058509477}
+  - component: {fileID: 2058509478}
+  - component: {fileID: 2058509479}
+  - component: {fileID: 2058509480}
+  m_Layer: 0
+  m_Name: Left Thumb Joint 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2058509477
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2058509476}
+  m_LocalRotation: {x: 0.019904852, y: 0.35755512, z: -0.53516835, w: 0.7650836}
+  m_LocalPosition: {x: 0.019338273, y: -0.006000001, z: -0.053168494}
+  m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999999}
+  m_Children:
+  - {fileID: 1569510033}
+  m_Father: {fileID: 632214914}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &2058509478
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2058509476}
+  m_Material: {fileID: 1690218108}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.054220006
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.023110002}
+--- !u!171741748 &2058509479
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2058509476}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: 0.019338273, y: -0.0059999935, z: -0.053168505}
+  m_ParentAnchorRotation: {x: 0.019904822, y: 0.35755518, z: -0.5351684, w: 0.7650837}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -45
+    upperLimit: 45
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -10
+    upperLimit: 50
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &2058509480
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2058509476}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2057484866}
+  _body: {fileID: 2058509479}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 0
+  _joint: 0
+--- !u!1 &2080805426
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2080805427}
+  - component: {fileID: 2080805428}
+  - component: {fileID: 2080805429}
+  - component: {fileID: 2080805430}
+  m_Layer: 0
+  m_Name: Right Index Joint 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2080805427
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2080805426}
+  m_LocalRotation: {x: 0.07411184, y: -0.08401716, z: 0.0062662363, w: 0.99368477}
+  m_LocalPosition: {x: -0.023181278, y: 0.0020000078, z: 0.023149364}
+  m_LocalScale: {x: 0.99999964, y: 0.99999976, z: 1}
+  m_Children:
+  - {fileID: 334822913}
+  m_Father: {fileID: 1085073651}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &2080805428
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2080805426}
+  m_Material: {fileID: 189111359}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.047780003
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.019890001}
+--- !u!171741748 &2080805429
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2080805426}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.023181293, y: 0.0020000115, z: 0.023149366}
+  m_ParentAnchorRotation: {x: 0.07411185, y: -0.08401715, z: 0.0062662363, w: 0.9936849}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 3
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -30
+    upperLimit: 80
+    stiffness: 200
+    damping: 1
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -15
+    upperLimit: 15
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 100000
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &2080805430
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2080805426}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2045161950}
+  _body: {fileID: 2080805429}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 1
+  _joint: 0
+--- !u!1 &2091518378
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2091518380}
+  - component: {fileID: 2091518379}
+  - component: {fileID: 2091518381}
+  - component: {fileID: 2091518382}
+  m_Layer: 0
+  m_Name: Right Thumb Joint 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!136 &2091518379
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2091518378}
+  m_Material: {fileID: 1081093971}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.004
+  m_Height: 0.02967
+  m_Direction: 2
+  m_Center: {x: 0, y: 0, z: 0.010835}
+--- !u!4 &2091518380
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2091518378}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.031570002}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2000139858}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!171741748 &2091518381
+ArticulationBody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2091518378}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Mass: 0.6
+  m_ParentAnchorPosition: {x: -0.000000018626457, y: 0.000000031664985, z: 0.031570025}
+  m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000002}
+  m_AnchorPosition: {x: 0, y: 0, z: 0}
+  m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ComputeParentAnchor: 0
+  m_ArticulationJointType: 2
+  m_LinearX: 2
+  m_LinearY: 2
+  m_LinearZ: 2
+  m_SwingY: 1
+  m_SwingZ: 1
+  m_Twist: 1
+  m_XDrive:
+    lowerLimit: -10
+    upperLimit: 89
+    stiffness: 200
+    damping: 1
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_YDrive:
+    lowerLimit: -8
+    upperLimit: 8
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_ZDrive:
+    lowerLimit: 0
+    upperLimit: 0
+    stiffness: 200
+    damping: 2
+    forceLimit: 180001.81
+    target: 0
+    targetVelocity: 0
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_JointFriction: 0.05
+  m_Immovable: 0
+  m_UseGravity: 0
+  m_CollisionDetectionMode: 3
+--- !u!114 &2091518382
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2091518378}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f55b708478cebe429cfce6531ca4cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hand: {fileID: 2127376581}
+  _body: {fileID: 2091518381}
+  _origXDriveLimit: 0
+  _currentXDriveLimit: 3.4028235e+38
+  _finger: 0
+  _joint: 2
 --- !u!1 &2103061970
 GameObject:
   m_ObjectHideFlags: 0
@@ -13349,7 +21278,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1.0000001}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -13467,7 +21396,7 @@ ArticulationBody:
   m_ParentAnchorRotation: {x: 0.019904852, y: -0.35755515, z: 0.53516847, w: 0.7650838}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_ComputeParentAnchor: 0
+  m_ComputeParentAnchor: 1
   m_ArticulationJointType: 3
   m_LinearX: 2
   m_LinearY: 2
@@ -13523,6 +21452,121 @@ MonoBehaviour:
   _currentXDriveLimit: 3.4028235e+38
   _finger: 0
   _joint: 0
+--- !u!1 &2127376580
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2127376582}
+  - component: {fileID: 2127376581}
+  m_Layer: 0
+  m_Name: Right Hand
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2127376581
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2127376580}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 445639c80127bbd44b6bd9d34463b470, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _physicsHand:
+    triggerDistance: 0.004
+    oldPosition: {x: 0, y: 0, z: 0}
+    gameObject: {fileID: 1384551527}
+    rootObject: {fileID: 2127376580}
+    transform: {fileID: 1384551531}
+    palmBone: {fileID: 1384551530}
+    palmBody: {fileID: 1384551529}
+    palmCollider: {fileID: 1384551528}
+    jointBones:
+    - {fileID: 794028895}
+    - {fileID: 2000139861}
+    - {fileID: 2091518382}
+    - {fileID: 513332376}
+    - {fileID: 517433468}
+    - {fileID: 1305726775}
+    - {fileID: 1216944355}
+    - {fileID: 1077167465}
+    - {fileID: 302522891}
+    - {fileID: 1371222478}
+    - {fileID: 1412118572}
+    - {fileID: 1530934142}
+    - {fileID: 971476551}
+    - {fileID: 436964835}
+    - {fileID: 221313060}
+    jointBodies:
+    - {fileID: 794028894}
+    - {fileID: 2000139860}
+    - {fileID: 2091518381}
+    - {fileID: 513332375}
+    - {fileID: 517433467}
+    - {fileID: 1305726774}
+    - {fileID: 1216944354}
+    - {fileID: 1077167464}
+    - {fileID: 302522890}
+    - {fileID: 1371222477}
+    - {fileID: 1412118571}
+    - {fileID: 1530934141}
+    - {fileID: 971476550}
+    - {fileID: 436964834}
+    - {fileID: 221313059}
+    jointColliders:
+    - {fileID: 794028893}
+    - {fileID: 2000139859}
+    - {fileID: 2091518379}
+    - {fileID: 513332374}
+    - {fileID: 517433466}
+    - {fileID: 1305726772}
+    - {fileID: 1216944353}
+    - {fileID: 1077167463}
+    - {fileID: 302522888}
+    - {fileID: 1371222476}
+    - {fileID: 1412118570}
+    - {fileID: 1530934139}
+    - {fileID: 971476549}
+    - {fileID: 436964833}
+    - {fileID: 221313057}
+    overRotationFrameCount: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+    defaultRotations:
+    - {x: -0.6644467, y: -0.34441155, z: -0.5637821, w: 0.34934357}
+    - {x: -0.19850887, y: -0.549382, z: -0.8101427, w: 0.04942213}
+    - {x: -0.095235884, y: -0.55546176, z: -0.82590574, w: 0.016494589}
+    - {x: -0.013266354, y: -0.54483914, z: -0.8380312, w: 0.026037607}
+    - {x: 0.08120667, y: -0.50801295, z: -0.85746795, w: -0.00878219}
+    - {x: -0.12940955, y: -0.4829629, z: -0.8627299, w: 0.07547912}
+    strength: 2
+    stiffness: 100
+    forceLimit: 1000
+    boneMass: 0.6
+    physicMaterial: {fileID: 1081093971}
+  _handedness: 1
+--- !u!4 &2127376582
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2127376580}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1384551531}
+  m_Father: {fileID: 1874090592}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2129453843
 GameObject:
   m_ObjectHideFlags: 0
@@ -13553,6 +21597,18 @@ Transform:
   m_Father: {fileID: 85926700}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!134 &2131980833
+PhysicMaterial:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Button Material
+  dynamicFriction: 1
+  staticFriction: 1
+  bounciness: 0
+  frictionCombine: 3
+  bounceCombine: 0
 --- !u!1 &2144652010
 GameObject:
   m_ObjectHideFlags: 0
@@ -13688,8 +21744,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7096687240119738267}
-  m_LocalRotation: {x: 0.17912486, y: -0.2227961, z: 0.013585571, w: -0.95817107}
-  m_LocalPosition: {x: -0.08458896, y: -0.0004762259, z: 0.040513195}
+  m_LocalRotation: {x: 0.17912485, y: -0.2227961, z: 0.013585598, w: -0.95817107}
+  m_LocalPosition: {x: -0.08458896, y: -0.00047622164, z: 0.040513195}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 2607279790514118833}
@@ -13848,8 +21904,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 188166081502518132}
-  m_LocalRotation: {x: 0.0000000074505815, y: -0, z: 0.000000002793968, w: 1}
-  m_LocalPosition: {x: -0.042507984, y: 0.000000014901161, z: -0.000000011990778}
+  m_LocalRotation: {x: 0.0000000074505815, y: -0, z: 0.000000001396984, w: 1}
+  m_LocalPosition: {x: -0.042507984, y: 0.000000014551915, z: -0.0000000119325705}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 6269058922139641272}
@@ -13928,7 +21984,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3930117551739177457}
   m_LocalRotation: {x: -0.000000014901158, y: -0, z: -0.000000007450579, w: 1}
-  m_LocalPosition: {x: -0.031183295, y: -0.000000030267984, z: -0.00000001816079}
+  m_LocalPosition: {x: -0.031183295, y: -0.000000030733645, z: -0.000000018626451}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4601032797595744570}
@@ -13943,7 +21999,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2664714030106007252}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.030068927, y: 0.000000031664968, z: -0.00000004656613}
+  m_LocalPosition: {x: -0.03006893, y: 0.000000029802322, z: -0.00000005029142}
   m_LocalScale: {x: 1.0870018, y: 1, z: 1.0000001}
   m_Children: []
   m_Father: {fileID: 5603408544073779352}
@@ -14035,8 +22091,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6734382813138696213}
-  m_LocalRotation: {x: 0.1103902, y: -0.1544627, z: 0.05827981, w: -0.980081}
-  m_LocalPosition: {x: -0.09463005, y: -0.004286067, z: 0.024981234}
+  m_LocalRotation: {x: 0.11039019, y: -0.1544627, z: 0.05827984, w: -0.980081}
+  m_LocalPosition: {x: -0.09463005, y: -0.004286062, z: 0.024981234}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4593025366294473699}
@@ -14080,8 +22136,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 988703604646546958}
-  m_LocalRotation: {x: -0.5313971, y: 0.28951305, z: 0.06647214, w: -0.7933352}
-  m_LocalPosition: {x: -0.034635402, y: 0.0052384706, z: -0.02117432}
+  m_LocalRotation: {x: -0.5313971, y: 0.28951305, z: 0.06647218, w: -0.7933352}
+  m_LocalPosition: {x: -0.034635402, y: 0.005238473, z: -0.02117432}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 5603408544073779352}
@@ -14517,6 +22573,7 @@ MonoBehaviour:
   GlobalFingerRotationOffset: {x: 360, y: 90, z: 180}
   WristRotationOffset: {x: 360, y: 80, z: 180}
   SetPositions: 1
+  UseScaleToPositionElbow: 0
   UseMetaBones: 1
   SetModelScale: 1
   ScalingSpeedMultiplier: 1
@@ -14997,8 +23054,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5410288521453035250}
-  m_LocalRotation: {x: -0, y: -0, z: 0.0000000037252903, w: 1}
-  m_LocalPosition: {x: -0.039402936, y: 0.0000000020954758, z: -0.000000011234079}
+  m_LocalRotation: {x: -0, y: -0, z: 0.0000000018626451, w: 1}
+  m_LocalPosition: {x: -0.039402936, y: 0.0000000023283064, z: -0.00000001094304}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 8960369879348156318}
@@ -15013,7 +23070,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1596977446806172696}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.017248914, y: 0.00000001697244, z: 0.000000011292287}
+  m_LocalPosition: {x: -0.017248914, y: 0.0000000174381, z: 0.000000012572856}
   m_LocalScale: {x: 1.3974507, y: 0.9999996, z: 1.0000001}
   m_Children: []
   m_Father: {fileID: 2607279790514118833}
@@ -15042,8 +23099,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7381571892018030127}
-  m_LocalRotation: {x: 0.00021690848, y: -0.0029079616, z: 0.07437592, w: -0.997226}
-  m_LocalPosition: {x: -0.10685581, y: -0.0023811362, z: -0.012156698}
+  m_LocalRotation: {x: 0.00021689646, y: -0.0029079616, z: 0.07437596, w: -0.997226}
+  m_LocalPosition: {x: -0.10685581, y: -0.0023811292, z: -0.012156698}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 8049219266935362873}
@@ -15076,8 +23133,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7020774121252782994}
-  m_LocalRotation: {x: 0.0802743, y: -0.077458076, z: 0.06854231, w: -0.9913921}
-  m_LocalPosition: {x: -0.10357945, y: -0.004286039, z: 0.0069881305}
+  m_LocalRotation: {x: 0.080274284, y: -0.077458076, z: 0.06854234, w: -0.9913921}
+  m_LocalPosition: {x: -0.10357945, y: -0.0042860326, z: 0.0069881305}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 2069468164165402009}
@@ -15106,7 +23163,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8423419461726067197}
-  m_LocalRotation: {x: -0.000000044703484, y: 0.08715576, z: 0.000000014901161, w: -0.9961947}
+  m_LocalRotation: {x: -0.000000029802322, y: 0.08715576, z: -0.000000014901161, w: -0.9961947}
   m_LocalPosition: {x: -0.23811318, y: -0.000000044703484, z: 0.000000014901161}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -15156,7 +23213,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3649006395875482}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.04402235, y: -0.000000020489097, z: -0.000000007450581}
+  m_LocalPosition: {x: -0.044022348, y: -0.000000022351742, z: -0.000000013038516}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 2620977356345534196}
@@ -15214,8 +23271,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8231225950834553287}
-  m_LocalRotation: {x: -0, y: 1.6543614e-24, z: -0, w: 1}
-  m_LocalPosition: {x: -0.02507805, y: 0.000000012596574, z: 0.000000027939677}
+  m_LocalRotation: {x: -0, y: 8.271807e-25, z: -0, w: 1}
+  m_LocalPosition: {x: -0.02507805, y: 0.000000012992168, z: 0.0000000281143}
   m_LocalScale: {x: 1.073976, y: 0.99999994, z: 0.9999999}
   m_Children: []
   m_Father: {fileID: 2069468164165402009}
@@ -15367,7 +23424,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4362745473468292719}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.021315895, y: -0.000000013292228, z: 0.00000001140773}
+  m_LocalPosition: {x: -0.021315891, y: -0.00000001334465, z: 0.000000010414501}
   m_LocalScale: {x: 1.025914, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 8049219266935362873}
@@ -15659,6 +23716,7 @@ MonoBehaviour:
   GlobalFingerRotationOffset: {x: 360, y: 270, z: 180}
   WristRotationOffset: {x: 360, y: 280, z: 180}
   SetPositions: 1
+  UseScaleToPositionElbow: 0
   UseMetaBones: 1
   SetModelScale: 1
   ScalingSpeedMultiplier: 1
@@ -16115,8 +24173,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4142538090601387268}
-  m_LocalRotation: {x: -0, y: -0, z: -0.0000000025378313, w: 1}
-  m_LocalPosition: {x: -0.03788852, y: -0.0000000115906005, z: 0.000000009989725}
+  m_LocalRotation: {x: -0, y: -0, z: -0.00000000257279, w: 1}
+  m_LocalPosition: {x: -0.037888523, y: -0.000000012601959, z: 0.000000010857862}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 6856558370827396649}
@@ -16194,7 +24252,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 237274792168281812}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.02443048, y: 0.000000004140142, z: -0.000000023457687}
+  m_LocalPosition: {x: -0.02443048, y: 0.0000000042819623, z: -0.000000023166649}
   m_LocalScale: {x: 1.2834928, y: 0.9999997, z: 1.0000005}
   m_Children: []
   m_Father: {fileID: 4593025366294473699}

--- a/Packages/Tracking Preview/PhysicsHands/Editor/PhysicsProviderEditor.cs
+++ b/Packages/Tracking Preview/PhysicsHands/Editor/PhysicsProviderEditor.cs
@@ -12,6 +12,8 @@ namespace Leap.Unity.Interaction.PhysicsHands
         private const int RECOMMENDED_SOLVER_ITERATIONS = 15;
         private const int RECOMMENDED_SOLVER_VELOCITY_ITERATIONS = 5;
         private const float RECOMMENDED_TIMESTEP = 0.011111f;
+        private const float RECOMMENDED_GRAVITY = -4.905f;
+        private const float RECOMMENDED_SLEEP_THRESHOLD = 0.001f;
 
         private readonly int[] HAND_SOLVER_ITERATIONS = { 10, 15, 30 };
         private readonly int[] HAND_SOLVER_VELOCITY_ITERATIONS = { 4, 5, 10 };
@@ -139,6 +141,29 @@ namespace Leap.Unity.Interaction.PhysicsHands
                 if (GUILayout.Button("Fix Now", GUILayout.Width(80)))
                 {
                     Physics.defaultSolverVelocityIterations = RECOMMENDED_SOLVER_VELOCITY_ITERATIONS;
+                }
+                EditorGUILayout.EndHorizontal();
+            }
+            // Gravity
+            if(Physics.gravity.y < RECOMMENDED_GRAVITY)
+            {
+                EditorGUILayout.BeginHorizontal();
+                EditorGUILayout.HelpBox($"Project gravity forces are lower than {RECOMMENDED_GRAVITY} ({Physics.gravity.y}). " +
+                    $"It is recommended to reduce this as it will make it easier for the player to grab falling objects.", MessageType.Warning);
+                if (GUILayout.Button("Fix Now", GUILayout.Width(80)))
+                {
+                    Physics.gravity = new Vector3(0, RECOMMENDED_GRAVITY, 0);
+                }
+                EditorGUILayout.EndHorizontal();
+            }
+            if(Physics.sleepThreshold > RECOMMENDED_SLEEP_THRESHOLD)
+            {
+                EditorGUILayout.BeginHorizontal();
+                EditorGUILayout.HelpBox($"Project physics sleep threshold is larger than {RECOMMENDED_SLEEP_THRESHOLD} ({Physics.sleepThreshold}). " +
+                    $"It is recommended to reduce this to limit issues with misaligned slow moving objects.", MessageType.Warning);
+                if (GUILayout.Button("Fix Now", GUILayout.Width(80)))
+                {
+                    Physics.sleepThreshold = RECOMMENDED_SLEEP_THRESHOLD;
                 }
                 EditorGUILayout.EndHorizontal();
             }

--- a/Packages/Tracking Preview/PhysicsHands/Editor/PhysicsProviderEditor.cs
+++ b/Packages/Tracking Preview/PhysicsHands/Editor/PhysicsProviderEditor.cs
@@ -15,9 +15,9 @@ namespace Leap.Unity.Interaction.PhysicsHands
         private const float RECOMMENDED_GRAVITY = -4.905f;
         private const float RECOMMENDED_SLEEP_THRESHOLD = 0.001f;
 
-        private readonly int[] HAND_SOLVER_ITERATIONS = { 10, 15, 30 };
-        private readonly int[] HAND_SOLVER_VELOCITY_ITERATIONS = { 4, 5, 10 };
-        private readonly string[] HAND_SOLVER_NAMES = { "Low", "Medium", "High", "Custom" };
+        private readonly int[] HAND_SOLVER_ITERATIONS = { 20, 30 };
+        private readonly int[] HAND_SOLVER_VELOCITY_ITERATIONS = { 15, 20 };
+        private readonly string[] HAND_SOLVER_NAMES = { "Standard", "High", "Custom" };
         private int _currentPreset = -1;
 
         PhysicsProvider _physicsProvider;

--- a/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsGraspHelper.cs
+++ b/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsGraspHelper.cs
@@ -792,7 +792,7 @@ namespace Leap.Unity.Interaction.PhysicsHands
             {
                 foreach (var hand in _graspingCandidates)
                 {
-                    hand.IgnoreCollision(_rigid, 0f, 0.04f);
+                    hand.IgnoreCollision(_rigid, 0f, 0.005f);
                 }
                 // We only want to apply the forces if we actually want to cause movement to the object
                 // We're still disabling collisions though to allow for the physics system to fully control if necessary

--- a/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsProvider.cs
+++ b/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsProvider.cs
@@ -132,7 +132,8 @@ namespace Leap.Unity.Interaction.PhysicsHands
         private Dictionary<PhysicsHand, float[]> _fingerStrengths = new Dictionary<PhysicsHand, float[]>();
         public Dictionary<PhysicsHand, float[]> FingerStrengths => _fingerStrengths;
 
-        private LayerMask _hoverMask, _contactMask;
+        private LayerMask _hoverMask, _interactionMask;
+        public LayerMask InteractionMask => _interactionMask;
 
         // These events are place holders
         public Action<Rigidbody> OnHover, OnHoverExit;
@@ -223,11 +224,11 @@ namespace Leap.Unity.Interaction.PhysicsHands
             }
 
             _hoverMask = new LayerMask();
-            _contactMask = new LayerMask();
+            _interactionMask = new LayerMask();
             for (int i = 0; i < _interactableLayers.Count; i++)
             {
                 _hoverMask = _hoverMask | _interactableLayers[i].layerMask;
-                _contactMask = _contactMask | _interactableLayers[i].layerMask;
+                _interactionMask = _interactionMask | _interactableLayers[i].layerMask;
             }
 
             _layersGenerated = true;
@@ -432,14 +433,14 @@ namespace Leap.Unity.Interaction.PhysicsHands
 
             PhysicsHand.Hand pH = hand.GetPhysicsHand();
 
-            Vector3 radiusAmount = Vector3.Scale(pH.palmCollider.size, PhysExts.AbsVec3(pH.palmCollider.transform.lossyScale)) * 0.2f;
+            Vector3 radiusAmount = Vector3.Scale(pH.palmCollider.size, PhysExts.AbsVec3(pH.palmCollider.transform.lossyScale)) * 0.5f;
 
-            _resultCount = PhysExts.OverlapBoxNonAllocOffset(pH.palmCollider, Vector3.zero, _resultsCache, _contactMask, QueryTriggerInteraction.Ignore, extraRadius: -PhysExts.MaxVec3(radiusAmount));
+            _resultCount = PhysExts.OverlapBoxNonAllocOffset(pH.palmCollider, Vector3.zero, _resultsCache, _interactionMask, QueryTriggerInteraction.Ignore, extraRadius: -PhysExts.MaxVec3(radiusAmount));
             HandleOverlaps(hand);
 
             for (int i = 0; i < pH.jointColliders.Length; i++)
             {
-                _resultCount = PhysExts.OverlapCapsuleNonAllocOffset(pH.jointColliders[i], Vector3.zero, _resultsCache, _contactMask, QueryTriggerInteraction.Ignore, extraRadius: -pH.jointColliders[i].radius * 0.2f);
+                _resultCount = PhysExts.OverlapCapsuleNonAllocOffset(pH.jointColliders[i], Vector3.zero, _resultsCache, _interactionMask, QueryTriggerInteraction.Ignore, extraRadius: -pH.jointColliders[i].radius * 0.5f);
                 HandleOverlaps(hand);
             }
         }
@@ -609,7 +610,7 @@ namespace Leap.Unity.Interaction.PhysicsHands
 
             _tempVector.x = 0;
             _tempVector.y = -pH.triggerDistance;
-            _resultCount = PhysExts.OverlapBoxNonAllocOffset(pH.palmCollider, _tempVector, _resultsCache, _contactMask);
+            _resultCount = PhysExts.OverlapBoxNonAllocOffset(pH.palmCollider, _tempVector, _resultsCache, _interactionMask);
             for (int i = 0; i < _resultCount; i++)
             {
                 if (_resultsCache[i].attachedRigidbody != null)
@@ -637,14 +638,14 @@ namespace Leap.Unity.Interaction.PhysicsHands
                 {
                     _tempVector.x = -pH.triggerDistance / 2f;
                     _tempVector.z = pH.triggerDistance / 2f;
-                    radius *= 0.8f;
+                    radius *= 0.4f;
                 }
                 else
                 {
                     // Inflate the bones slightly
                     _tempVector.x = 0;
                     _tempVector.z = 0;
-                    radius *= 0.2f;
+                    radius *= 0.1f;
                 }
                 // Move the finger tips forward a tad
                 if (pH.jointBones[i].Joint == 2)
@@ -660,7 +661,7 @@ namespace Leap.Unity.Interaction.PhysicsHands
                 }
 #endif
 
-                _resultCount = PhysExts.OverlapCapsuleNonAllocOffset(pH.jointColliders[i], _tempVector, _resultsCache, _contactMask, extraRadius: radius);
+                _resultCount = PhysExts.OverlapCapsuleNonAllocOffset(pH.jointColliders[i], _tempVector, _resultsCache, _interactionMask, extraRadius: radius);
                 for (int j = 0; j < _resultCount; j++)
                 {
                     if (_resultsCache[j].attachedRigidbody != null)

--- a/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsProvider.cs
+++ b/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsProvider.cs
@@ -84,11 +84,11 @@ namespace Leap.Unity.Interaction.PhysicsHands
 
         public int SolverIterations => _handSolverIterations;
         [SerializeField, Tooltip("The solver iterations used when calculating the hand. This can be different to your overall project iterations. Higher numbers will be more robust, but more expensive to compute."), Min(10f)]
-        private int _handSolverIterations = 15;
+        private int _handSolverIterations = 20;
 
         public int SolverVelocityIterations => _handSolverVelocityIterations;
         [SerializeField, Tooltip("The solver iterations used when calculating the hand velocity. This can be different to your overall project iterations. Higher numbers will be more robust, but more expensive to compute."), Min(5f)]
-        private int _handSolverVelocityIterations = 5;
+        private int _handSolverVelocityIterations = 15;
 
         // Helper Settings
         [SerializeField, Tooltip("Enabling helpers is recommended as these allow the user to pick up objects they normally would not be able to. " +

--- a/Packages/Tracking Preview/PhysicsHands/Runtime/UI/Prefabs/Physics Button.prefab
+++ b/Packages/Tracking Preview/PhysicsHands/Runtime/UI/Prefabs/Physics Button.prefab
@@ -138,10 +138,10 @@ ConfigurableJoint:
   m_GameObject: {fileID: 882061857553901796}
   m_ConnectedBody: {fileID: 7298562659095329044}
   m_ConnectedArticulationBody: {fileID: 0}
-  m_Anchor: {x: 0, y: 0.5, z: 0}
+  m_Anchor: {x: 0, y: 0, z: 0}
   m_Axis: {x: 1, y: 0, z: 0}
   m_AutoConfigureConnectedAnchor: 0
-  m_ConnectedAnchor: {x: 0, y: 0.02, z: 0}
+  m_ConnectedAnchor: {x: 0, y: 0.01, z: 0}
   serializedVersion: 2
   m_SecondaryAxis: {x: 0, y: 1, z: 0}
   m_XMotion: 0

--- a/Packages/Tracking Preview/PhysicsHands/Runtime/UI/Scripts/PhysicsButton.cs
+++ b/Packages/Tracking Preview/PhysicsHands/Runtime/UI/Scripts/PhysicsButton.cs
@@ -258,7 +258,16 @@ namespace Leap.Unity.Interaction.PhysicsHands
         {
             if (_provider != null)
             {
+                ResetOnBadState();
                 ProcessPhysicsEvents();
+            }
+        }
+
+        private void ResetOnBadState()
+        {
+            if (_buttonElement.transform.localRotation.eulerAngles.magnitude > 0.25f)
+            {
+                _buttonElement.transform.localRotation = Quaternion.identity;
             }
         }
 
@@ -386,10 +395,10 @@ namespace Leap.Unity.Interaction.PhysicsHands
         private void SetupJoint(ConfigurableJoint joint)
         {
             joint.connectedBody = _rigidbody;
-            joint.anchor = Vector3.up * 0.5f;
+            joint.anchor = Vector3.zero;
             joint.axis = Vector3.right;
             joint.autoConfigureConnectedAnchor = false;
-            joint.connectedAnchor = Vector3.up * buttonHeightLimit;
+            joint.connectedAnchor = Vector3.up * (buttonHeightLimit / 2f);
 
             joint.xMotion = ConfigurableJointMotion.Locked;
             joint.yMotion = ConfigurableJointMotion.Limited;
@@ -435,7 +444,7 @@ namespace Leap.Unity.Interaction.PhysicsHands
             softLimit.limit = heightLimit / 2f;
             _buttonElement.Joint.linearLimit = softLimit;
 
-            _buttonElement.Joint.connectedAnchor = Vector3.up * heightLimit;
+            _buttonElement.Joint.connectedAnchor = Vector3.up * (heightLimit / 2f);
             _buttonElement.Joint.targetPosition = Vector3.down * heightLimit;
         }
 
@@ -492,14 +501,17 @@ namespace Leap.Unity.Interaction.PhysicsHands
                 _buttonElement = GetComponentInChildren<PhysicsButtonElement>(true);
             }
 
-            if (buttonToggleHeightLimit > buttonHeightLimit)
+            if (isToggleable)
             {
-                buttonHeightLimit = buttonToggleHeightLimit;
-            }
+                if (buttonToggleHeightLimit > buttonHeightLimit)
+                {
+                    buttonHeightLimit = buttonToggleHeightLimit;
+                }
 
-            if (buttonHeightLimit < buttonToggleHeightLimit)
-            {
-                buttonToggleHeightLimit = buttonHeightLimit;
+                if (buttonHeightLimit < buttonToggleHeightLimit)
+                {
+                    buttonToggleHeightLimit = buttonHeightLimit;
+                }
             }
 
             if (_buttonElement != null)

--- a/Packages/Tracking Preview/PhysicsHands/Runtime/Utils/PhysicsHandsUtils.cs
+++ b/Packages/Tracking Preview/PhysicsHands/Runtime/Utils/PhysicsHandsUtils.cs
@@ -137,7 +137,7 @@ namespace Leap.Unity.Interaction.PhysicsHands
                     }
                     else
                     {
-                        SetupBoneDrives(physicsHand.jointBodies[boneArrayIndex], stiffness, forceLimit, strength);
+                        SetupBoneDrives(physicsHand.jointBodies[boneArrayIndex], stiffness, forceLimit, strength, fingerIndex);
                     }
                     lastTransform = capsuleGameObject.transform;
                 }
@@ -232,7 +232,7 @@ namespace Leap.Unity.Interaction.PhysicsHands
                     }
                     else
                     {
-                        SetupBoneDrives(physicsHand.jointBodies[boneArrayIndex], physicsHand.stiffness, physicsHand.forceLimit, physicsHand.strength);
+                        SetupBoneDrives(physicsHand.jointBodies[boneArrayIndex], physicsHand.stiffness, physicsHand.forceLimit, physicsHand.strength, fingerIndex);
 
                         physicsHand.jointBodies[boneArrayIndex].parentAnchorPosition = InverseTransformPoint(prevBone.PrevJoint, prevBone.Rotation, bone.PrevJoint);
                         physicsHand.jointBodies[boneArrayIndex].parentAnchorRotation = Quaternion.identity;
@@ -358,9 +358,16 @@ namespace Leap.Unity.Interaction.PhysicsHands
             knuckle.zDrive = yDrive;
         }
 
-        public static void SetupBoneDrives(ArticulationBody bone, float stiffness, float forceLimit, float strength)
+        public static void SetupBoneDrives(ArticulationBody bone, float stiffness, float forceLimit, float strength, int fingerIndex)
         {
-            bone.jointType = ArticulationJointType.SphericalJoint;
+            if(fingerIndex == 0)
+            {
+                bone.jointType = ArticulationJointType.RevoluteJoint;
+            }
+            else
+            {
+                bone.jointType = ArticulationJointType.SphericalJoint;
+            }
             bone.twistLock = ArticulationDofLock.LimitedMotion;
             bone.swingYLock = ArticulationDofLock.LimitedMotion;
             bone.swingZLock = ArticulationDofLock.LimitedMotion;
@@ -627,7 +634,7 @@ namespace Leap.Unity.Interaction.PhysicsHands
                     b.NextJoint = posA;
                     b.Width = r;
                     b.Center = (b.PrevJoint + b.NextJoint) / 2f;
-                    b.Direction = b.PrevJoint - b.NextJoint;
+                    b.Direction = (b.NextJoint - b.PrevJoint).normalized;
                     b.Length = Vector3.Distance(posA, posB);
                     b.Rotation = physicsHand.jointColliders[boneInd].transform.rotation;
                     boneInd++;

--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -10,10 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [NEXT] - unreleased
 
 ### Added
-- 
+- (Physics Hands) Warnings for gravity and timestep settings
+- (Physics Hands) Exposed interaction mask
 ### Changed
-- 
+- (Physics Hands) Reduced hand to object collision radius when throwing and testing overlaps
+- (Physics Hands) Thumb joints reverted to revolute for non-0th thumb joints
+- (Physics Hands) Default physics hands solver iterations & presets
 ### Fixed
+- (Physics Hands) Bone directions when converting back to Leap Hands
+- (Physics Hands) Incorrect setup and positioning of physics buttons
 - 
 ### Known issues 
 - Scenes containing the infrared viewer render incorrectly on Android build targets and in scriptable render pipelines such as URP and HDRP. 


### PR DESCRIPTION
## Summary

- Adds warnings for recommended gravity and timesteps.
- Fixes direction of bones when converting back to leap hands.
- Reduces the collision radius on throwing to prevent problems with near field throwing and catching.
- Reduces radius of post update collision checks
  - This is done due to corrections made to the extra radius values in the overlap functions a few MRs ago. Previously they were calculated by using a raw set radius value, when they should have been done off of an addition to the radius.
- Exposes the interaction mask to allow for easier physics calculations.
- Physics button values and setup have been fixed. Rotations are now reset to prevent physics simulation issues.
- Thumb joints are returned to revolute as spherical (Y rotation) on non-0th thumb joints resulted in significant body horror issues.
- Updated default physics hands solver iterations & presets

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [x] Pair review with a member of the QA team.
- [x] Add any release testing considerations to the MR for the next release.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] Checked and agree with release testing considerations added to MR for the next release.

## Closes JIRA Issue

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_