### PR TITLE
Fixing 0th rotation on the thumb bone when populating.

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - 
 ### Fixed
-- 
+- 0th thumb bone rotation values when using OpenXR
 ### Known issues 
 - Scenes containing the infrared viewer render incorrectly on Android build targets and in scriptable render pipelines such as URP and HDRP. 
 - Use of the LeapCSharp Config class is unavailable with v5.X tracking service

--- a/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
+++ b/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
@@ -216,7 +216,7 @@ namespace Ultraleap.Tracking.OpenXR
                             0f,
                             _joints[(int)HandJoint.ThumbMetacarpal].Radius * 2f,
                             (Bone.BoneType)boneIndex,
-                            hand.Rotation * Quaternion.Euler(0, hand.IsLeft ? HAND_ROTATION_OFFSET_Y : -HAND_ROTATION_OFFSET_Y, hand.IsLeft ? HAND_ROTATION_OFFSET_Z : -HAND_ROTATION_OFFSET_Z));
+                            _joints[(int)HandJoint.Palm].Pose.rotation * Quaternion.Euler(0, hand.IsLeft ? HAND_ROTATION_OFFSET_Y : -HAND_ROTATION_OFFSET_Y, hand.IsLeft ? HAND_ROTATION_OFFSET_Z : -HAND_ROTATION_OFFSET_Z));
                         continue;
                     }
 


### PR DESCRIPTION
## Summary

- Fixes the updating of the 0th thumb bone within the OXR provider.
  - It would be taking old hand data to calculate it which would be incorrect. By product of performance changes.

Before/After (red is Leap direct, blue is OXR)

https://user-images.githubusercontent.com/6281246/220096809-3f9fb7a9-adca-4911-9e07-77ce503feb72.mp4

https://user-images.githubusercontent.com/6281246/220097098-eab89f00-8bd2-419a-8119-282906f0a9f9.mp4

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [x] Pair review with a member of the QA team.
- [x] Add any release testing considerations to the MR for the next release.
- [x] Check any relevant CHANGELOG files have been updated.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.
- [ ] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [x] Checked and agree with release testing considerations added to MR for the next release.

## Closes JIRA Issue

Closes UNITY-1062