### PR TITLE
Added optional toggle for adding of TrackedPoseDriver

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (Physics Hands) Dynamically adjusting fingers when grabbing objects
 - (Physics Hands) Distance calculations and values for each bone
 - Per finger pinch distances in HandUtils
+- Added advanced option to LeapXRServiceProvider to avoid adding TrackedPoseDrivers to MainCamera 
 
 ### Changed
 - (Physics Hands) Reduced hand to object collision radius when throwing and testing overlaps

--- a/Packages/Tracking/Core/Editor/Scripts/LeapXRServiceProviderEditor.cs
+++ b/Packages/Tracking/Core/Editor/Scripts/LeapXRServiceProviderEditor.cs
@@ -76,6 +76,7 @@ namespace Leap.Unity
             addPropertyToFoldout("_deviceOrigin", "Advanced Options");
             addPropertyToFoldout("_updateHandInPrecull", "Advanced Options");
             addPropertyToFoldout("_preventInitializingTrackingMode", "Advanced Options");
+            addPropertyToFoldout("_autoCreateTrackedPoseDriver", "Advanced Options");
             hideField("_trackingOptimization");
 
             targetTransform = (target as LeapXRServiceProvider).transform;

--- a/Packages/Tracking/Core/Runtime/Scripts/LeapXRServiceProvider.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/LeapXRServiceProvider.cs
@@ -274,6 +274,9 @@ namespace Leap.Unity
             }
         }
 
+        [Tooltip("Automatically adds a TrackedPoseDriver to the MainCamera if there is not one already")]
+        public bool _autoCreateTrackedPoseDriver = true;
+
         #endregion
 
         #region Internal Memory
@@ -314,7 +317,7 @@ namespace Leap.Unity
             resetShaderTransforms();
 
 #if XR_MANAGEMENT_AVAILABLE
-            if (mainCamera.GetComponent<UnityEngine.SpatialTracking.TrackedPoseDriver>() == null)
+            if (mainCamera.GetComponent<UnityEngine.SpatialTracking.TrackedPoseDriver>() == null && _autoCreateTrackedPoseDriver)
             {
                 mainCamera.gameObject.AddComponent<UnityEngine.SpatialTracking.TrackedPoseDriver>().UseRelativeTransform = true;
             }


### PR DESCRIPTION
## Summary

Allow users that do not require a TrackedPoseDriver to optionally turn _off_ the automatic creation of TrackedPoseDrivers from the LeapXRServiceProvider

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [ ] Pair review with a member of the QA team.
- [x] Add any release testing considerations to the MR for the next release.
- [x] Check any relevant CHANGELOG files have been updated.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.
- [ ] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [ ] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [ ] Checked and agree with release testing considerations added to MR for the next release.

## Closes JIRA Issue

Closes UNITY-984