### PR TITLE
Fixes for the direct and indirect UIInput modes stamping on each othe…

### DIFF
--- a/Packages/Tracking Preview/UI Input/Runtime/Scripts/PointerElement.cs
+++ b/Packages/Tracking Preview/UI Input/Runtime/Scripts/PointerElement.cs
@@ -309,7 +309,9 @@ namespace Leap.Unity.InputModule
             }
 
             if (EventData != null)
+            {
                 PrevScreenPosition = EventData.position;
+            }
 
             switch (module?.InteractionMode)
             {
@@ -330,9 +332,6 @@ namespace Leap.Unity.InputModule
 
                 case InteractionCapability.Indirect:
                     RaiseEventsForStateChanges(PointerStateProjective, PrevStateProjective);
-                    break;
-
-                default:
                     break;
             }
 
@@ -363,9 +362,6 @@ namespace Leap.Unity.InputModule
                     {
                         TimeEnteredCanvas = Time.time;
                     }
-
-                    break;
-                default:
                     break;
             }
         }
@@ -642,7 +638,9 @@ namespace Leap.Unity.InputModule
             var tipRaycast = false;
 
             if (EventData == null)
+            {
                 return false;
+            }
 
             EventData.Reset();
 
@@ -701,7 +699,9 @@ namespace Leap.Unity.InputModule
         private PointerStates ProcessState(Hand hand, bool tipRaycastUsed, PointerStates PointerState)
         {
             if (EventData == null)
+            {
                 return PointerState;
+            }
 
             if (EventData.pointerCurrentRaycast.gameObject != null)
             {
@@ -755,7 +755,9 @@ namespace Leap.Unity.InputModule
         private void UpdatePointer(PointerEventData pointData)
         {
             if (EventData == null)
+            {
                 return;
+            }
 
             var element = EventData.pointerCurrentRaycast.gameObject;
             if (element != null)

--- a/Packages/Tracking Preview/UI Input/Runtime/Scripts/PointerElement.cs
+++ b/Packages/Tracking Preview/UI Input/Runtime/Scripts/PointerElement.cs
@@ -8,7 +8,6 @@
 
 using System;
 using System.Collections.Generic;
-using UnityEditor;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;

--- a/Packages/Tracking Preview/UI Input/Runtime/Scripts/UIInputCursor.cs
+++ b/Packages/Tracking Preview/UI Input/Runtime/Scripts/UIInputCursor.cs
@@ -56,7 +56,7 @@ namespace Leap.Unity.InputModule
                 ? Vector3.Lerp(initialScale, initialScale * interactionPointerScale, hand.PinchStrength)
                 : Vector3.one;
 
-            switch (element.PointerState)
+            switch (element.AggregatePointerState)  
             {
                 case PointerStates.OnCanvas:
                     spriteRenderer.color = colorBlock.normalColor;

--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - "Pullcord" jitters when being interacted with
 - Hand Binder finger tip scale disproportionately when LeapProvider Transform is scaled
 - Creating objects from GameObject/Ultraleap/ menu makes more than just prefabs - Ghost Hands (with Arms)
+- (UIInput) several interaction events were not firing when both direct and indirect interaction is enabled for the UI Input module. All expected events should now be fired.  
 
 ### Known issues 
 - Scenes containing the infrared viewer render incorrectly on Android build targets and in scriptable render pipelines such as URP and HDRP. 


### PR DESCRIPTION
…r, preventing events being raised for the pointer element and the associated unity events


## Summary

Fixes two issues:
1. When both direct and indirect interaction are enabled (InteractionMode==both), the events in the StateChangeActionMap are now raised (i.e. you will hear the sounds when interacting directly and indirectly with the UI elements in the test scene). This should be for both direct and indirect interaction.
2. When both direct and indirect interaction are enabled (InteractionMode==both), the UI elements respond correctly - colour changes, pressed state. These are driven from the Unity events being raised. This should be for both direct and indirect interaction.

Context: events were not being raised correctly (or at all) when the mode is set to both direct and indirect interaction. This is because the logic used to process the tactile and projective states would stamp on top of each others data - e.g.. the pointer states and the time since an interaction with the canvas happened. I've had to make the code aware that the hybrid mode needs special handling of the states and how they are combined.

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [ ] Pair review with a member of the QA team.
- [ ] Add any release testing considerations to the MR for the next release.
- [ ] Check any relevant CHANGELOG files have been updated.
- [ ] Ensure documentation requirements are met e.g., public API is commented.
- [ ] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [ ] Add any relevant labels such as `breaking` to this MR.
- [ ] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [ ] Checked and agree with release testing considerations added to MR for the next release.

## Closes JIRA Issue

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_