### PR TITLE
added ability for anchorables to attach on demand

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (Physics Hands) Dynamically adjusting fingers when grabbing objects
 - (Physics Hands) Distance calculations and values for each bone
 - Per finger pinch distances in HandUtils
+- Ability for AnchorableBehaviours to attach on demand
 
 ### Changed
 - (Physics Hands) Reduced hand to object collision radius when throwing and testing overlaps

--- a/Packages/Tracking/Interaction Engine/Runtime/Scripts/UI/Anchors/AnchorableBehaviour.cs
+++ b/Packages/Tracking/Interaction Engine/Runtime/Scripts/UI/Anchors/AnchorableBehaviour.cs
@@ -655,13 +655,31 @@ namespace Leap.Unity.Interaction
 
             if (preferredAnchor != null)
             {
-                _preferredAnchor = preferredAnchor;
-                anchor = preferredAnchor;
-                isAttached = true;
+                AttachToNearestAnchor(preferredAnchor);
                 return true;
             }
 
             return false;
+        }
+
+        public void AttachToNearestAnchor()
+        {
+            AttachToNearestAnchor(null);
+        }
+
+        private void AttachToNearestAnchor(Anchor preferredAnchor)
+        {
+            if (preferredAnchor == null)
+            {
+                preferredAnchor = FindPreferredAnchor();
+            }
+
+            if (preferredAnchor != null)
+            {
+                _preferredAnchor = preferredAnchor;
+                anchor = preferredAnchor;
+                isAttached = true;
+            }
         }
 
         /// <summary> Score an anchor based on its proximity and this object's trajectory relative to it. </summary>


### PR DESCRIPTION
## Summary

Adds a public method for attaching AnchorableBehaviours to nearby Anchors

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [ ] Pair review with a member of the QA team.
- [x] Add any release testing considerations to the MR for the next release.
- [x] Check any relevant CHANGELOG files have been updated.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.
- [ ] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [ ] Checked and agree with release testing considerations added to MR for the next release.

## Closes JIRA Issue

Closes UNITY-994