### PR TITLE
Added ability to clear all attachments in AttachmentHands inspector

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (Physics Hands) Dynamically adjusting fingers when grabbing objects
 - (Physics Hands) Distance calculations and values for each bone
 - Per finger pinch distances in HandUtils
-- Added advanced option to LeapXRServiceProvider to avoid adding TrackedPoseDrivers to MainCamera 
+- Added advanced option to LeapXRServiceProvider to avoid adding TrackedPoseDrivers to MainCamera
+- Ability to clear all attachments on AttachmentHands component
 
 ### Changed
 - (Physics Hands) Reduced hand to object collision radius when throwing and testing overlaps

--- a/Packages/Tracking/Core/Editor/Scripts/AttachmentHandsEditor.cs
+++ b/Packages/Tracking/Core/Editor/Scripts/AttachmentHandsEditor.cs
@@ -100,6 +100,19 @@ namespace Leap.Unity.Attachments
             EditorGUI.EndDisabledGroup();
 
             EditorGUILayout.EndVertical();
+
+            EditorGUILayout.Space();
+
+            if (GUILayout.Button("Clear all attachments"))
+            {
+                if (EditorUtility.DisplayDialog("Delete all attachments?",
+                                                   "Doing so will destroy all child GameObjects of " + target.gameObject.name + ".",
+                                                   "Delete", "Cancel"))
+                {
+                    target.attachmentPoints = AttachmentPointFlags.None;
+                    GUIUtility.ExitGUI();
+                }
+            }
         }
 
         private void makeAttachmentPointsToggle(string attachmentFlagName, Vector2 offCenterPosImgSpace)

--- a/Packages/Tracking/Core/Editor/Scripts/PrefabCreateMenu.cs
+++ b/Packages/Tracking/Core/Editor/Scripts/PrefabCreateMenu.cs
@@ -80,6 +80,12 @@ namespace Leap
             CreatePrefab("SkeletonHands");
         }
 
+        [MenuItem("GameObject/Ultraleap/Hands/Attachment Hands", false, 26)]
+        public static void CreateAttachmentHands()
+        {
+            CreatePrefab("Attachment Hands");
+        }
+
         public static void CreatePrefab(string prefabName)
         {
             var guids = AssetDatabase.FindAssets(prefabName);


### PR DESCRIPTION
## Summary

Added ability to clear all attachments in AttachmentHands inspector. This makes the AttachmentHands prefab more usable as it can be added to a scene and immediately cleared of content for use with new attachments

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [ ] Pair review with a member of the QA team.
- [x] Add any release testing considerations to the MR for the next release.
- [x] Check any relevant CHANGELOG files have been updated.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.
- [ ] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [ ] Checked and agree with release testing considerations added to MR for the next release.

## Closes JIRA Issue

Closes UNITY-587