### PR TITLE
Calculate hand scale and use this instead of palm width

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 
 
 ### Changed
-- 
+- Changed OpenXRLeapProvider to calculate a LeapC-style palm width and pinch strength
 
 ### Fixed
 - Preview package version dependency mismatch for XRI when using InputSystem 1.4.4

--- a/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
+++ b/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
@@ -255,7 +255,8 @@ namespace Ultraleap.Tracking.OpenXR
                     (Finger.FingerType)fingerIndex);
             }
 
-            var palmWidth = _joints[(int)HandJoint.Palm].Radius * 2.0f;
+            var handScale = CalculateHandScale(ref hand);
+            var palmWidth = handScale * 0.08425f;
 
             // Populate the whole hand information.
             hand.Fill(
@@ -263,7 +264,7 @@ namespace Ultraleap.Tracking.OpenXR
                 handTracker == HandTracker.Left ? _leftHandId : _rightHandId,
                 1f,
                 CalculateGrabStrength(hand),
-                CalculatePinchStrength(ref hand, palmWidth),
+                CalculatePinchStrength(ref hand, handScale),
                 CalculatePinchDistance(ref hand),
                 palmWidth,
                 handTracker == HandTracker.Left,
@@ -320,13 +321,21 @@ namespace Ultraleap.Tracking.OpenXR
             return true;
         }
 
-        private float CalculatePinchStrength(ref Hand hand, float palmWidth)
+        private static readonly float[] DefaultMetacarpalLengths = { 0.6812f, 0.6460f, 0.5800f, 0.5369f };
+        
+        private float CalculateHandScale(ref Hand hand)
         {
-            // Magic values taken from existing LeapC implementation (scaled to metres)
-            float handScale = palmWidth / 0.08425f;
-            float distanceZero = 0.0600f * handScale;
-            float distanceOne = 0.0220f * handScale;
+            // Iterate through the fingers, skipping the thumb and accumulate the scale.
+            float scale = 0.0f;
+            for (var i = 1; i < hand.Fingers.Count; ++i)
+            {
+                scale += hand.Fingers[i].Bone(Bone.BoneType.TYPE_METACARPAL).Length / DefaultMetacarpalLengths[i] / 4.0f;
+            }
+            return scale;
+        }
 
+        private float CalculatePinchStrength(ref Hand hand, float handScale)
+        {
             // Get the thumb position.
             var thumbTipPosition = hand.GetThumb().TipPosition;
 
@@ -340,7 +349,9 @@ namespace Ultraleap.Tracking.OpenXR
                 minDistanceSquared = Mathf.Min(distanceSquared, minDistanceSquared);
             }
 
-            // Compute the pinch strength.
+            // Compute the pinch strength. Magic values taken from existing LeapC implementation (scaled to metres)
+            float distanceZero = 0.0600f * handScale;
+            float distanceOne = 0.0220f * handScale;
             return Mathf.Clamp01((Mathf.Sqrt(minDistanceSquared) - distanceZero) / (distanceOne - distanceZero));
         }
 

--- a/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
+++ b/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
@@ -321,7 +321,7 @@ namespace Ultraleap.Tracking.OpenXR
             return true;
         }
 
-        private static readonly float[] DefaultMetacarpalLengths = { 0.6812f, 0.6460f, 0.5800f, 0.5369f };
+        private static readonly float[] DefaultMetacarpalLengths = { 0, 0.6812f, 0.6460f, 0.5800f, 0.5369f };
         
         private float CalculateHandScale(ref Hand hand)
         {

--- a/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
+++ b/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
@@ -31,6 +31,10 @@ namespace Ultraleap.Tracking.OpenXR
         // Magic 0th thumb bone rotation offsets from LeapC
         public const float HAND_ROTATION_OFFSET_Y = 25.9f, HAND_ROTATION_OFFSET_Z = -63.45f;
 
+        // Magic numbers for palm width and PinchStrength calculation
+        private static readonly float[] DefaultMetacarpalLengths = { 0, 0.06812f, 0.06460f, 0.05800f, 0.05369f };
+        private const float DEFAULT_HAND_SCALE = 0.08425f;
+
         private long _frameId = 0;
 
         [Tooltip("Specifies the main camera. Falls back to Camera.main if not set")]
@@ -255,8 +259,8 @@ namespace Ultraleap.Tracking.OpenXR
                     (Finger.FingerType)fingerIndex);
             }
 
-            var handScale = CalculateHandScale(ref hand);
-            var palmWidth = handScale * 0.08425f;
+            float handScale = CalculateHandScale(ref hand);
+            float palmWidth = handScale * DEFAULT_HAND_SCALE;
 
             // Populate the whole hand information.
             hand.Fill(
@@ -321,16 +325,15 @@ namespace Ultraleap.Tracking.OpenXR
             return true;
         }
 
-        private static readonly float[] DefaultMetacarpalLengths = { 0, 0.6812f, 0.6460f, 0.5800f, 0.5369f };
-        
         private float CalculateHandScale(ref Hand hand)
         {
             // Iterate through the fingers, skipping the thumb and accumulate the scale.
             float scale = 0.0f;
             for (var i = 1; i < hand.Fingers.Count; ++i)
             {
-                scale += hand.Fingers[i].Bone(Bone.BoneType.TYPE_METACARPAL).Length / DefaultMetacarpalLengths[i] / 4.0f;
+                scale += (hand.Fingers[i].Bone(Bone.BoneType.TYPE_METACARPAL).Length / DefaultMetacarpalLengths[i]) / 4.0f;
             }
+
             return scale;
         }
 


### PR DESCRIPTION
## Summary

This changes the pinch calculation for OpenXR to no longer be dependent on the palm width being the same as it was in LeapC. This also has the advantage of working better on non-Ultraleap OpenXR hand-tracking.

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [ ] Pair review with a member of the QA team.
- [x] Add any release testing considerations to the MR for the next release.
- [x] Check any relevant CHANGELOG files have been updated.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.
- [ ] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [ ] Checked and agree with release testing considerations added to MR for the next release.

## Closes JIRA Issue

- Closes https://ultrahaptics.atlassian.net/browse/UNITY-1142
- Closes https://ultrahaptics.atlassian.net/browse/OXR-308