### PR TITLE
Bug/unity 1137 fixes for image alignment distortion issues

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Preview package version dependency mismatch for XRI when using InputSystem 1.4.4
+- Control panel IR image / hand vertical alignment across device types and individual devices, through changing the handdling of the distortion matrix
 
 ### Known issues 
 - Scenes containing the infrared viewer render incorrectly on Android build targets and in scriptable render pipelines such as URP and HDRP. 

--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Preview package version dependency mismatch for XRI when using InputSystem 1.4.4
-- Control panel IR image / hand vertical alignment across device types and individual devices, through changing the handdling of the distortion matrix
+- (Passthrough) change the handling of the distortion matrix for vertical alignment across device types
 
 ### Known issues 
 - Scenes containing the infrared viewer render incorrectly on Android build targets and in scriptable render pipelines such as URP and HDRP. 

--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Connection.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Connection.cs
@@ -858,6 +858,7 @@ namespace LeapInternal
             //since the distortion struct cannot be represented safely in c#
             distortionData.Data = new float[(int)(distortionData.Width * distortionData.Height * 2)]; //2 float values per map point
             Marshal.Copy(image.distortionMatrix, distortionData.Data, 0, distortionData.Data.Length);
+            distortionData.OnDataChanged();
 
             if (LeapDistortionChange != null)
             {

--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Connection.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Connection.cs
@@ -874,13 +874,11 @@ namespace LeapInternal
                 //Update distortion data, if changed
                 if ((_currentLeftDistortionData.Version != imageMsg.leftImage.matrix_version) || !_currentLeftDistortionData.IsValid)
                 {
-                    // WARNING: this has had the inputs for createDistortionData swapped to Right to account for issues in the reprojection shader
-                    _currentLeftDistortionData = createDistortionData(imageMsg.rightImage, Image.CameraType.RIGHT);
+                    _currentLeftDistortionData = createDistortionData(imageMsg.leftImage, Image.CameraType.LEFT);
                 }
                 if ((_currentRightDistortionData.Version != imageMsg.rightImage.matrix_version) || !_currentRightDistortionData.IsValid)
                 {
-                    // WARNING: this has had the inputs for createDistortionData swapped to Left to account for issues in the reprojection shader
-                    _currentRightDistortionData = createDistortionData(imageMsg.leftImage, Image.CameraType.LEFT);
+                    _currentRightDistortionData = createDistortionData(imageMsg.rightImage, Image.CameraType.RIGHT);
                 }
 
                 ImageData leftImage = new ImageData(Image.CameraType.LEFT, imageMsg.leftImage, _currentLeftDistortionData);

--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/DistortionData.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/DistortionData.cs
@@ -22,6 +22,9 @@ namespace Leap
     /// </summary>
     public class DistortionData
     {
+        private float[] _flippedData;
+        private float[] _originalData;
+
         /// <summary>
         /// Constructs an uninitialized distortion object.
         /// @since 3.0
@@ -67,11 +70,41 @@ namespace Leap
         /// </summary>
         public float Height { get; set; }
         /// <summary>
-        /// The distortion data.
+        /// The original distortion data, as provided by the service
         ///
         /// @since 3.0
         /// </summary>
-        public float[] Data { get; set; }
+        public float[] Data
+        {
+            get
+            {
+                return _originalData;
+            }
+
+            set
+            {
+                _originalData = value;
+
+                // Note, the contents of the array are normally copied into the buffer by a marshall operation,
+                // so the flipped data needs to be updated explicitly, not when the _orginalData member is set 
+            }
+        }
+
+        /// <summary>
+        /// Returns the distortion data, adjusted so that a location in the distortion map texture now refers to the 
+        /// same region of the texture containing the IR image - e.g. the bottom left of the distortion texture
+        /// maps to bottom left of the IR image
+        ///
+        /// @since 3.0
+        /// </summary>
+        public float[] FlippedData
+        {
+            get
+            {
+                return _flippedData;
+            }
+        }
+
         /// <summary>
         /// Reports whether the distortion data is internally consistent.
         /// @since 3.0
@@ -89,5 +122,33 @@ namespace Leap
                 return false;
             }
         }
+
+        internal void OnDataChanged()
+        { 
+            UpdateFlippedData();
+        }
+
+        private void UpdateFlippedData()
+        {
+            if (_originalData == null)
+            {
+                return;
+            }
+
+            // This is called normally once a session, so allocation is fine
+            float[] flipped = new float[LeapInternal.LeapC.DistortionSize * LeapInternal.LeapC.DistortionSize * 2];
+            for (int x = 0; x < LeapInternal.LeapC.DistortionSize; x++)
+            {
+                for (int y = 0; y < LeapInternal.LeapC.DistortionSize; y++)
+                {
+                    // We change the data so that the *mapped* Y value is inverted 
+                    flipped[((x + y * LeapInternal.LeapC.DistortionSize) * 2)] = _originalData[((x + y * LeapInternal.LeapC.DistortionSize) * 2)];
+                    flipped[((x + y * LeapInternal.LeapC.DistortionSize) * 2) + 1] = (float)1.0 - _originalData[((x + y * LeapInternal.LeapC.DistortionSize) * 2) + 1];
+                }
+            }
+
+            _flippedData = flipped;
+        }
+
     }
 }

--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Image.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Image.cs
@@ -151,6 +151,7 @@ namespace Leap
             if (camera != CameraType.LEFT && camera != CameraType.RIGHT)
                 return null;
 
+            // We return the FlippedData, not the Data member as this corrects for a Y flip in the distortion matrix coming from the service.
             return imageData(camera).DistortionData.FlippedData;
         }
 

--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Image.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Image.cs
@@ -151,7 +151,7 @@ namespace Leap
             if (camera != CameraType.LEFT && camera != CameraType.RIGHT)
                 return null;
 
-            return imageData(camera).DistortionData.Data;
+            return imageData(camera).DistortionData.FlippedData;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

This PR addresses issue UNITY-1137, where hands are misaligned with IR images in the control panel on certain devices. This is because the distortion matrix is treated differently between devices. The changes flip the Y value in the distortion matrix data, this also flips the IR image, so we invert the V value in the UV calculation in the shader code. 

This change makes things work in theory across device types (SIR170, 3Di, LMC). However, in fact this will then break LMC alignment. There is a new version of the service which changes the LMC distortion data to work with this fix.

This change backs out the left/right distortion matrix swap, which appeared to fix alignment across all devices but in fact was the wrong solution.

As this bug has taken a while to track down, I've added new comments to boost understanding of the 'rendering pipeline' for images.

Testing requirements:
Needs to be tested with a version of the control panel that uses a plugin with these changes. For IR/Hand alignment to work across all device types, requires a new version of the SDK/Service (5.12 RC4). Note, some devices will not obviously show misalignment so you need one that shows the issues before the fix. Because of the way SIR170s treat the image centre, they also don't show alignment issue.

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [ ] Pair review with a member of the QA team.
- [x] Add any release testing considerations to the MR for the next release.
- [x] Check any relevant CHANGELOG files have been updated.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.
- [ ] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [ ] Checked and agree with release testing considerations added to MR for the next release.

## Closes JIRA Issue

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_