### PR TITLE
Feature/unity 1161 1162 hand utils provider usage

### DIFF
--- a/Packages/Tracking Preview/XRControllerSupport/Runtime/Scripts/HandControllerSwapper/Checks/DistanceBetweenInputs.cs
+++ b/Packages/Tracking Preview/XRControllerSupport/Runtime/Scripts/HandControllerSwapper/Checks/DistanceBetweenInputs.cs
@@ -21,7 +21,7 @@ namespace Leap.Unity.Controllers
 
         protected override bool IsTrueLogic()
         {
-            if (GetController() && _provider.Get(hand) != null)
+            if (GetController() && _provider.GetHand(hand) != null)
             {
                 if (InputDistanceCheck())
                 {
@@ -42,14 +42,14 @@ namespace Leap.Unity.Controllers
 
             if (inputMethodType == InputMethodType.LeapHand)
             {
-                if (Vector3.Distance(_provider.Get(hand).PalmPosition, xrControllerPosition) <= actionThreshold)
+                if (Vector3.Distance(_provider.GetHand(hand).PalmPosition, xrControllerPosition) <= actionThreshold)
                 {
                     return true;
                 }
             }
             else
             {
-                if (Vector3.Distance(_provider.Get(hand).PalmPosition, xrControllerPosition) >= actionThreshold)
+                if (Vector3.Distance(_provider.GetHand(hand).PalmPosition, xrControllerPosition) >= actionThreshold)
                 {
                     return true;
                 }

--- a/Packages/Tracking Preview/XRControllerSupport/Runtime/Scripts/HandControllerSwapper/Checks/DistanceFromHead.cs
+++ b/Packages/Tracking Preview/XRControllerSupport/Runtime/Scripts/HandControllerSwapper/Checks/DistanceFromHead.cs
@@ -45,9 +45,9 @@ namespace Leap.Unity.Controllers
             switch (inputMethodType)
             {
                 case InputMethodType.LeapHand:
-                    if (_provider.Get(hand) != null)
+                    if (_provider.GetHand(hand) != null)
                     {
-                        inputPosition = _provider.Get(hand).PalmPosition;
+                        inputPosition = _provider.GetHand(hand).PalmPosition;
                         return true;
                     }
                     break;

--- a/Packages/Tracking Preview/XRControllerSupport/Runtime/Scripts/HandControllerSwapper/Checks/InputIsInactive.cs
+++ b/Packages/Tracking Preview/XRControllerSupport/Runtime/Scripts/HandControllerSwapper/Checks/InputIsInactive.cs
@@ -18,7 +18,7 @@ namespace Leap.Unity.Controllers
             switch (inputMethodType)
             {
                 case InputMethodType.LeapHand:
-                    return _provider.Get(hand) == null;
+                    return _provider.GetHand(hand) == null;
                 case InputMethodType.XRController:
                     return !GetController();
             }

--- a/Packages/Tracking Preview/XRControllerSupport/Runtime/Scripts/HandControllerSwapper/Checks/InputVelocity.cs
+++ b/Packages/Tracking Preview/XRControllerSupport/Runtime/Scripts/HandControllerSwapper/Checks/InputVelocity.cs
@@ -46,9 +46,9 @@ namespace Leap.Unity.Controllers
             switch (inputMethodType)
             {
                 case InputMethodType.LeapHand:
-                    if (_provider.Get(hand) != null)
+                    if (_provider.GetHand(hand) != null)
                     {
-                        vel = _provider.Get(hand).PalmPosition;
+                        vel = _provider.GetHand(hand).PalmPosition;
                         return true;
                     }
                     break;

--- a/Packages/Tracking Preview/XRControllerSupport/Runtime/Scripts/HandControllerSwapper/Checks/IsFacingDown.cs
+++ b/Packages/Tracking Preview/XRControllerSupport/Runtime/Scripts/HandControllerSwapper/Checks/IsFacingDown.cs
@@ -37,9 +37,9 @@ namespace Leap.Unity.Controllers
             switch (inputMethodType)
             {
                 case InputMethodType.LeapHand:
-                    if (_provider.Get(hand) != null)
+                    if (_provider.GetHand(hand) != null)
                     {
-                        angle = Vector3.Angle(_provider.Get(hand).Direction, Vector3.down);
+                        angle = Vector3.Angle(_provider.GetHand(hand).Direction, Vector3.down);
                         return true;
                     }
                     break;

--- a/Packages/Tracking Preview/XRControllerSupport/Runtime/Scripts/HandControllerSwapper/Checks/PinchGrasp.cs
+++ b/Packages/Tracking Preview/XRControllerSupport/Runtime/Scripts/HandControllerSwapper/Checks/PinchGrasp.cs
@@ -15,7 +15,7 @@ namespace Leap.Unity.Controllers
     {
         protected override bool IsTrueLogic()
         {
-            Hand hand = _provider.Get(this.hand);
+            Hand hand = _provider.GetHand(this.hand);
             if (hand != null)
             {
                 if (hand.PinchStrength > actionThreshold || hand.GrabStrength > actionThreshold)

--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - (HandUtils) Only cache static Provider and CameraRig references when they are requested
 - (HandUtils) Mark Provider-dependant methods as obsolete and point to suitable replacements
-- (HandModelBase) Avoid Auto-referencing Providers to ensure correct Providers are referenced
 
 ### Fixed
 - 

--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -12,7 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (Physics Hands) In-editor readme for example scene
 
 ### Changed
-- 
+- (HandUtils) Only cache static Provider and CameraRig references when they are requested
+- (HandUtils) Mark Provider-dependant methods as obsolete and point to suitable replacements
+- (HandModelBase) Avoid Auto-referencing Providers to ensure correct Providers are referenced
 
 ### Fixed
 - 

--- a/Packages/Tracking/Core/Runtime/Scripts/Hands/HandModelBase.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Hands/HandModelBase.cs
@@ -189,16 +189,10 @@ namespace Leap.Unity
 
             if (leapProvider == null)
             {
-                //Try to set the provider for the user
-                leapProvider = FindObjectOfType<LeapProvider>();
-
-                if (leapProvider == null)
-                {
-                    Debug.LogError("No leap provider found in the scene, hand model has been disabled", this.gameObject);
-                    this.enabled = false;
-                    this.gameObject.SetActive(false);
-                    return;
-                }
+                Debug.LogError($"No Leap Provider referenced for {gameObject.name}, hand model has been disabled", this.gameObject);
+                this.enabled = false;
+                this.gameObject.SetActive(false);
+                return;
             }
 
             if (HandModelType == ModelType.Graphics)
@@ -287,20 +281,7 @@ namespace Leap.Unity
 
                 if (leapProvider == null)
                 {
-                    //Try to set the provider for the user
-                    leapProvider = FindObjectOfType<LeapProvider>();
-                    if (leapProvider == null)
-                    {
-                        //If we still have a null hand, construct one manually
-                        if (hand == null)
-                        {
-                            hand = TestHandFactory.MakeTestHand(Handedness == Chirality.Left);
-                        }
-                    }
-                    else
-                    {
-                        hand = leapProvider.CurrentFrame.GetHand(Handedness);
-                    }
+                    hand = TestHandFactory.MakeTestHand(Handedness == Chirality.Left);
                 }
                 else
                 {

--- a/Packages/Tracking/Core/Runtime/Scripts/Hands/HandModelBase.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Hands/HandModelBase.cs
@@ -189,10 +189,16 @@ namespace Leap.Unity
 
             if (leapProvider == null)
             {
-                Debug.LogError($"No Leap Provider referenced for {gameObject.name}, hand model has been disabled", this.gameObject);
-                this.enabled = false;
-                this.gameObject.SetActive(false);
-                return;
+                //Try to set the provider for the user
+                leapProvider = FindObjectOfType<LeapProvider>();
+
+                if (leapProvider == null)
+                {
+                    Debug.LogError("No leap provider found in the scene, hand model has been disabled", this.gameObject);
+                    this.enabled = false;
+                    this.gameObject.SetActive(false);
+                    return;
+                }
             }
 
             if (HandModelType == ModelType.Graphics)
@@ -281,7 +287,20 @@ namespace Leap.Unity
 
                 if (leapProvider == null)
                 {
-                    hand = TestHandFactory.MakeTestHand(Handedness == Chirality.Left);
+                    //Try to set the provider for the user
+                    leapProvider = FindObjectOfType<LeapProvider>();
+                    if (leapProvider == null)
+                    {
+                        //If we still have a null hand, construct one manually
+                        if (hand == null)
+                        {
+                            hand = TestHandFactory.MakeTestHand(Handedness == Chirality.Left);
+                        }
+                    }
+                    else
+                    {
+                        hand = leapProvider.CurrentFrame.GetHand(Handedness);
+                    }
                 }
                 else
                 {

--- a/Packages/Tracking/Core/Runtime/Scripts/Hands/HandModelBase.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Hands/HandModelBase.cs
@@ -190,7 +190,7 @@ namespace Leap.Unity
             if (leapProvider == null)
             {
                 //Try to set the provider for the user
-                leapProvider = FindObjectOfType<LeapProvider>();
+                leapProvider = Hands.Provider;
 
                 if (leapProvider == null)
                 {
@@ -288,14 +288,12 @@ namespace Leap.Unity
                 if (leapProvider == null)
                 {
                     //Try to set the provider for the user
-                    leapProvider = FindObjectOfType<LeapProvider>();
+                    leapProvider = Hands.Provider;
+
                     if (leapProvider == null)
                     {
-                        //If we still have a null hand, construct one manually
-                        if (hand == null)
-                        {
-                            hand = TestHandFactory.MakeTestHand(Handedness == Chirality.Left);
-                        }
+                        //Construct a hand manually
+                        hand = TestHandFactory.MakeTestHand(Handedness == Chirality.Left);
                     }
                     else
                     {

--- a/Packages/Tracking/Core/Runtime/Scripts/Utils/HandUtils.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Utils/HandUtils.cs
@@ -6,10 +6,9 @@
  * between Ultraleap and you, your company or other organization.             *
  ******************************************************************************/
 
+using System;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 
 namespace Leap.Unity
 {
@@ -18,33 +17,29 @@ namespace Leap.Unity
     /// </summary>
     public static class Hands
     {
-
         private static LeapProvider s_provider;
         private static GameObject s_leapRig;
 
-        static Hands()
-        {
-            InitStatic();
-            SceneManager.activeSceneChanged += InitStaticOnNewScene;
-        }
-
-        private static void InitStaticOnNewScene(Scene unused, Scene unused2)
-        {
-            InitStatic();
-        }
-
-        private static void InitStatic()
+        /// <summary>
+        /// Assign a static reference to the most suitable provider in the scene.
+        /// 
+        /// Order:
+        /// - First PostProcessProvider found
+        /// - First XRLeapProviderManager found
+        /// - First LeapProvider found
+        /// </summary>
+        private static void AssignBestLeapProvider()
         {
             // Fall through to the best available Leap Provider if none is assigned
             if (s_provider == null)
             {
-                s_provider = Object.FindObjectOfType<PostProcessProvider>();
+                s_provider = UnityEngine.Object.FindObjectOfType<PostProcessProvider>();
                 if (s_provider == null)
                 {
-                    s_provider = Object.FindObjectOfType<XRLeapProviderManager>();
+                    s_provider = UnityEngine.Object.FindObjectOfType<XRLeapProviderManager>();
                     if (s_provider == null)
                     {
-                        s_provider = Object.FindObjectOfType<LeapProvider>();
+                        s_provider = UnityEngine.Object.FindObjectOfType<LeapProvider>();
                         if (s_provider == null)
                         {
                             Debug.Log("There are no Leap Providers in the scene, please assign one manually");
@@ -53,11 +48,22 @@ namespace Leap.Unity
                     }
                 }
             }
-            Debug.Log("LeapProvider was not assigned. Auto assigning: " + s_provider);
 
-            Camera providerCamera = s_provider.GetComponentInParent<Camera>();
-            if (providerCamera == null) return;
-            if (providerCamera.transform.parent == null) return;
+            Debug.Log("LeapProvider was not assigned. Auto assigning: " + s_provider);
+        }
+
+        /// <summary>
+        /// Finds the Camera Rig; Assuming a Camera is a child of the Camera Rig and the static Provider is a child of the Camera.
+        /// </summary>
+        private static void AssignCameraRig()
+        {
+            Camera providerCamera = Provider?.GetComponentInParent<Camera>();
+
+            if (providerCamera == null || providerCamera.transform.parent == null)
+            {
+                return;
+            }
+
             s_leapRig = providerCamera.transform.parent.gameObject;
         }
 
@@ -72,10 +78,11 @@ namespace Leap.Unity
             {
                 if (s_leapRig == null)
                 {
-                    InitStatic();
+                    AssignCameraRig();
                 }
                 return s_leapRig;
             }
+            set { s_leapRig = value; }
         }
 
         /// <summary>
@@ -96,7 +103,7 @@ namespace Leap.Unity
             {
                 if (s_provider == null)
                 {
-                    InitStatic();
+                    AssignBestLeapProvider();
                 }
                 return s_provider;
             }
@@ -107,6 +114,7 @@ namespace Leap.Unity
         /// Returns the first hand of the argument Chirality in the current frame,
         /// otherwise returns null if no such hand is found.
         /// </summary>
+        [Obsolete("Specifying Providers is highly recommended. Use LeapProvider.GetHand() instead")]
         public static Hand Get(Chirality chirality)
         {
             if (chirality == Chirality.Left) return Left;
@@ -116,6 +124,7 @@ namespace Leap.Unity
         /// <summary>
         /// As Get, but returns the FixedUpdate (physics timestep) hand as opposed to the Update hand.
         /// </summary>
+        [Obsolete("Specifying Providers is highly recommended. Use LeapProvider.GetHand() instead")]
         public static Hand GetFixed(Chirality chirality)
         {
             if (chirality == Chirality.Left) return FixedLeft;
@@ -126,6 +135,7 @@ namespace Leap.Unity
         /// Returns the first left hand found by Leap in the current frame, otherwise
         /// returns null if no such hand is found.
         /// </summary>
+        [Obsolete("Specifying Providers is highly recommended. Use LeapProvider.GetHand(Chirality.Left) instead")]
         public static Hand Left
         {
             get
@@ -140,6 +150,7 @@ namespace Leap.Unity
         /// Returns the first right hand found by Leap in the current frame, otherwise
         /// returns null if no such hand is found.
         /// </summary>
+        [Obsolete("Specifying Providers is highly recommended. Use LeapProvider.GetHand(Chirality.Right) instead")]
         public static Hand Right
         {
             get
@@ -154,6 +165,7 @@ namespace Leap.Unity
         /// Returns the first left hand found by Leap in the current fixed frame, otherwise
         /// returns null if no such hand is found. The fixed frame is aligned with the physics timestep.
         /// </summary>
+        [Obsolete("Specifying Providers is highly recommended. Use LeapProvider.GetHand(Chirality.Left) instead")]
         public static Hand FixedLeft
         {
             get
@@ -168,6 +180,7 @@ namespace Leap.Unity
         /// Returns the first right hand found by Leap in the current fixed frame, otherwise
         /// returns null if no such hand is found. The fixed frame is aligned with the physics timestep.
         /// </summary>
+        [Obsolete("Specifying Providers is highly recommended. Use LeapProvider.GetHand(Chirality.Right) instead")]
         public static Hand FixedRight
         {
             get
@@ -661,6 +674,7 @@ namespace Leap.Unity
         /// </summary>
         /// <returns>The first hand of the argument whichHand found in the current frame of 
         /// the argument provider.</returns>
+        [Obsolete("Naming updated. Use LeapProvider.GetHand() instead")]
         public static Hand Get(this LeapProvider provider, Chirality whichHand)
         {
             Frame frame;
@@ -674,6 +688,23 @@ namespace Leap.Unity
             }
 
             return frame.GetHand(whichHand);
+        }
+
+        /// <summary>
+        /// Finds a hand in the current frame.
+        /// </summary>
+        /// <returns>The first hand of the argument whichHand found in the current frame of 
+        /// the argument provider.</returns>
+        public static Hand GetHand(this LeapProvider provider, Chirality whichHand)
+        {
+            if (Time.inFixedTimeStep)
+            {
+                return provider.CurrentFixedFrame.GetHand(whichHand);
+            }
+            else
+            {
+                return provider.CurrentFrame.GetHand(whichHand);
+            }
         }
 
         #endregion


### PR DESCRIPTION
## Summary

Makes HandUtils more suitable to a Provider-based Plugin:
- Static references are only produced when requested
- Adds obsolete tags to utilities that require providers and points to the more suitable methods

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [ ] Pair review with a member of the QA team.
- [x] Add any release testing considerations to the MR for the next release.
- [x] Check any relevant CHANGELOG files have been updated.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.
- [ ] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [ ] Checked and agree with release testing considerations added to MR for the next release.

## Closes JIRA Issue

Closes UNITY-1161 & UNITY-1162