### PR TITLE
Feature/unity 982 custom reconnection attempts

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - (Physics Hands) In-editor readme for example scene
+- (LeapServiceProvider) Ability to change the number of Service connection attempts and interval
 
 ### Changed
 - (HandUtils) Only cache static Provider and CameraRig references when they are requested

--- a/Packages/Tracking/Core/Editor/Scripts/LeapServiceProviderEditor.cs
+++ b/Packages/Tracking/Core/Editor/Scripts/LeapServiceProviderEditor.cs
@@ -66,6 +66,9 @@ namespace Leap.Unity
             deferProperty("_serverNameSpace");
             deferProperty("_useInterpolation");
 
+            deferProperty("_reconnectionAttempts");
+            deferProperty("_reconnectionInterval");
+
             if (!(LeapServiceProvider is LeapXRServiceProvider))
             {
                 addPropertyToFoldout("_trackingOptimization", "Advanced Options");
@@ -76,6 +79,9 @@ namespace Leap.Unity
             }
             addPropertyToFoldout("_useInterpolation", "Advanced Options");
             addPropertyToFoldout("_serverNameSpace", "Advanced Options");
+
+            addPropertyToFoldout("_reconnectionAttempts", "Advanced Options");
+            addPropertyToFoldout("_reconnectionInterval", "Advanced Options");
         }
 
         private void frameOptimizationWarning(SerializedProperty property)

--- a/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
@@ -282,6 +282,12 @@ namespace Leap.Unity
         [SerializeField]
         public bool _useInterpolation = true;
 
+        [SerializeField, Min(-1), Tooltip("The maximum number of attempts to connect to the service. Infinite attempts if -1.")]
+        public int _reconnectionAttempts = MAX_RECONNECTION_ATTEMPTS;
+
+        [SerializeField, Min(1), Tooltip("The interval in frames between service connection attempts.")]
+        public int _reconnectionInterval = RECONNECTION_INTERVAL;
+
         #endregion
 
         #region Internal Settings & Memory
@@ -1012,17 +1018,17 @@ namespace Leap.Unity
                 _numberOfReconnectionAttempts = 0;
                 return true;
             }
-            else if (_numberOfReconnectionAttempts < MAX_RECONNECTION_ATTEMPTS)
+            else if (_numberOfReconnectionAttempts < _reconnectionAttempts || _reconnectionAttempts == -1)
             {
                 _framesSinceServiceConnectionChecked++;
 
-                if (_framesSinceServiceConnectionChecked > RECONNECTION_INTERVAL)
+                if (_framesSinceServiceConnectionChecked > _reconnectionInterval)
                 {
                     _framesSinceServiceConnectionChecked = 0;
                     _numberOfReconnectionAttempts++;
 
                     Debug.LogWarning("Leap Service not connected; attempting to reconnect for try " +
-                                     _numberOfReconnectionAttempts + "/" + MAX_RECONNECTION_ATTEMPTS +
+                                     _numberOfReconnectionAttempts + "/" + _reconnectionAttempts +
                                      "...", this);
                     destroyController();
                     createController();


### PR DESCRIPTION
## Summary

Added ability to set custom reconnection attempts count and the frame interval on the ServiceProviders' advanced settings

Setting attempts to -1 makes it attempt forever

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [ ] Pair review with a member of the QA team.
- [x] Add any release testing considerations to the MR for the next release.
- [x] Check any relevant CHANGELOG files have been updated.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.
- [ ] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [ ] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [ ] Checked and agree with release testing considerations added to MR for the next release.

## Closes JIRA Issue

Closes UNITY-982