### PR TITLE
Bug/unity 1173 hand pose scriptable context menu

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- (Hand Pose) Removed unnecessary Hand Pose scriptable context menu option
 
 ### Fixed
 

--- a/Packages/Tracking/Core/Runtime/Scripts/HandPoses/HandPoseScriptableObject.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/HandPoses/HandPoseScriptableObject.cs
@@ -33,7 +33,7 @@ namespace Leap.Unity
     }
 #endif
 
-    [CreateAssetMenu(fileName = "HandPose", menuName = "ScriptableObjects/HandPose")]
+    //[CreateAssetMenu(fileName = "HandPose", menuName = "ScriptableObjects/HandPose")]
     public class HandPoseScriptableObject : ScriptableObject
     {
         [System.Serializable]


### PR DESCRIPTION
## Summary

Removes unnecessary and confusing HandPose option from right click menu

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [ ] Pair review with a member of the QA team.
- [ ] Add any release testing considerations to the MR for the next release.
- [ ] Check any relevant CHANGELOG files have been updated.
- [ ] Ensure documentation requirements are met e.g., public API is commented.
- [ ] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [ ] Add any relevant labels such as `breaking` to this MR.
- [ ] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [ ] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [ ] Checked and agree with release testing considerations added to MR for the next release.

## Closes JIRA Issue

Closes UNITY-1173