### PR TITLE
Bug/unity 1174 poor performance on reconnect device

### DIFF
--- a/Packages/Tracking Preview/XR Interaction Toolkit Integration/Runtime/Scripts/LeapHandInput.cs
+++ b/Packages/Tracking Preview/XR Interaction Toolkit Integration/Runtime/Scripts/LeapHandInput.cs
@@ -177,8 +177,6 @@ namespace Leap.Unity.Preview.InputActions
                 .WithManufacturer("Ultraleap")
                 .WithProduct("^(Leap Hand)")
                 );
-
-            InputSystem.settings.SetInternalFeatureFlag("USE_OPTIMIZED_CONTROLS", true);
         }
     }
 }

--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (Hand Pose) Removed unnecessary Hand Pose scriptable context menu option
 
 ### Fixed
+- (Preview) CPU performance issues on PICO when re-connecting tracking device
 
 ### Known issues 
 - Use of the LeapCSharp Config class is unavailable with v5.X tracking service


### PR DESCRIPTION
## Summary

Remove use of internal flag that caused PICO performance to increase after re-connecting devices

## Contributor Tasks

_These tasks are for the merge request creator to tick off when creating a merge request._

- [ ] Pair review with a member of the QA team.
- [ ] Add any release testing considerations to the MR for the next release.
- [ ] Check any relevant CHANGELOG files have been updated.
- [ ] Ensure documentation requirements are met e.g., public API is commented.
- [ ] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [ ] Add any relevant labels such as `breaking` to this MR.
- [ ] If this MR closes a Jira issue, make sure the fix version on the JIRA issue is set to the correct one.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [ ] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] Documentation has been reviewed. Includes checking documentation requirements are met and not missing e.g., public API is commented.
- [ ] Checked and agree with release testing considerations added to MR for the next release.

## Closes JIRA Issue

Closes UNITY-1174