### PR TITLE
Fixing direction on VectorHands

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -22,6 +22,7 @@ This release was tested against Unity 2021.3 LTS and 2022.3 LTS
 ### Fixed
 - (Preview) CPU performance issues on PICO when re-connecting tracking device
 - (Locomotion) Jump gems could occasionally break and not show their ray
+- VectorHand bone directions
 
 ### Known issues 
 - Use of the LeapCSharp Config class is unavailable with v5.X tracking service

--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -22,7 +22,7 @@ This release was tested against Unity 2021.3 LTS and 2022.3 LTS
 ### Fixed
 - (Preview) CPU performance issues on PICO when re-connecting tracking device
 - (Locomotion) Jump gems could occasionally break and not show their ray
-- VectorHand bone directions
+- VectorHand bone directions and thumb rotations
 
 ### Known issues 
 - Use of the LeapCSharp Config class is unavailable with v5.X tracking service

--- a/Packages/Tracking/Core/Runtime/Scripts/Encoding/VectorHand.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Encoding/VectorHand.cs
@@ -188,7 +188,7 @@ namespace Leap.Unity.Encoding
                       prevJoint: prevJoint,
                       nextJoint: nextJoint,
                       center: ((nextJoint + prevJoint) / 2f),
-                      direction: (palmRot * Vector3.forward),
+                      direction: (nextJoint - prevJoint).normalized,
                       length: (prevJoint - nextJoint).magnitude,
                       width: 0.01f,
                       type: (Bone.BoneType)jointIdx,
@@ -200,7 +200,7 @@ namespace Leap.Unity.Encoding
                   fingerId: fingerIdx,
                   timeVisible: 10f,// Time.time, <- This is unused and main thread only
                   tipPosition: nextJoint,
-                  direction: (boneRot * Vector3.forward),
+                  direction: (nextJoint - prevJoint).normalized,
                   width: 1f,
                   length: 1f,
                   isExtended: true,

--- a/Packages/Tracking/Core/Runtime/Scripts/Encoding/VectorHand.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Encoding/VectorHand.cs
@@ -71,6 +71,13 @@ namespace Leap.Unity.Encoding
             }
         }
 
+        // Correction for the 0th thumb bone rotation offsets to match LeapC
+        private static readonly Quaternion[] ThumbMetacarpalRotationOffset =
+        {
+            Quaternion.Euler(0, +25.9f, -63.45f),
+            Quaternion.Euler(0, -25.9f, +63.45f),
+        };
+
         #endregion
 
         /// <summary>
@@ -183,6 +190,11 @@ namespace Leap.Unity.Encoding
                     nextJoint = ToWorld(nextJoint, palmPos, palmRot);
                     prevJoint = ToWorld(prevJoint, palmPos, palmRot);
                     boneRot = palmRot * boneRot;
+
+                    if(fingerIdx == 0 && boneIdx == 0)
+                    {
+                        boneRot *= ThumbMetacarpalRotationOffset[intoHand.IsLeft ? 0 : 1];
+                    }
 
                     intoHand.GetBone(boneIdx).Fill(
                       prevJoint: prevJoint,


### PR DESCRIPTION
## Summary

- Fixes incorrect direction calculations in VectorHand

## Contributor Tasks

- [ ] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [x] Add a CHANGELOG entry for this change.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [ ] Add any relevant labels such as `breaking` to this MR.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [ ] Run all tests associated with the ticket.
- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Closes JIRA Issue

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_

## Pull Request Templates

Switch template by going to preview and clicking the link - note it will not work if you've made any changes to the description.

- [default.md](?expand=1) - for contributions to stable packages.
- [release.md](?expand=1&template=release.md) - for release merge requests.

**You are currently using: default.md**

Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.
