### PR TITLE
Head pose transform history now returns that latest head pose if inte…

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (Locomotion) Jump Gems look for audio sources in their children, even if the audio source was set
 - (Locomotion) If pinched gem was null, jump gem teleport could still be in a selected state
 - (Locomotion) Teleport ray did not change to an invalid colour when no colliders were hit
+- (Core) Fixed hands juddering in XR when interpolation is turned off on the LeapXRServiceProvider. Turning off interpolation now turns off head pose interpolation
 
 ### Known issues 
 - Use of the LeapCSharp Config class is unavailable with v5.X tracking service

--- a/Packages/Tracking/Core/Runtime/Scripts/LeapXRServiceProvider.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/LeapXRServiceProvider.cs
@@ -417,6 +417,7 @@ namespace Leap.Unity
             Vector3 pastPosition; Quaternion pastRotation;
             transformHistory.SampleTransform(imageTimeStamp
                                                - (long)(warpingAdjustment * 1000f),
+                                               _useInterpolation,
                                              out pastPosition, out pastRotation);
 
             // Use _tweenImageWarping
@@ -589,7 +590,7 @@ namespace Leap.Unity
                 }
                 else
                 {
-                    transformHistory.SampleTransform(timestamp, out currentPose.position, out currentPose.rotation);
+                    transformHistory.SampleTransform(timestamp, _useInterpolation, out currentPose.position, out currentPose.rotation);
                 }
 
                 warpedPosition = currentPose.position;
@@ -600,7 +601,7 @@ namespace Leap.Unity
             {
                 var imageAdjustment = _temporalWarpingMode == TemporalWarpingMode.Images ? -20000 : 0;
                 var sampleTimestamp = timestamp - (long)(warpingAdjustment * 1000f) - imageAdjustment;
-                transformHistory.SampleTransform(sampleTimestamp, out warpedPosition, out warpedRotation);
+                transformHistory.SampleTransform(sampleTimestamp, _useInterpolation, out warpedPosition, out warpedRotation);
             }
 
             // Normalize the rotation Quaternion.

--- a/Packages/Tracking/Core/Runtime/Scripts/Utils/TransformHistory.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Utils/TransformHistory.cs
@@ -39,9 +39,17 @@ namespace Leap.Unity
         public void SampleTransform(long timestamp, out Vector3 delayedPos, out Quaternion delayedRot)
         {
             TransformData desiredTransform = TransformData.GetTransformAtTime(history, timestamp);
+            SampleTransform(timestamp, true, out delayedPos, out delayedRot);
+        }
+
+        //Calculate delayed Transform
+        internal void SampleTransform(long timestamp, bool useInterpolation, out Vector3 delayedPos, out Quaternion delayedRot)
+        {
+            TransformData desiredTransform = TransformData.GetTransformAtTime(history, timestamp, useInterpolation);
             delayedPos = desiredTransform.position;
             delayedRot = desiredTransform.rotation;
         }
+
 
         public struct TransformData
         {
@@ -64,13 +72,31 @@ namespace Leap.Unity
                 };
             }
 
-            public static TransformData GetTransformAtTime(RingBuffer<TransformData> history, long desiredTime)
+            /// <summary>
+            /// Returns a head pose transform for a given time. If interpolation is off returns the latest head pose, otherwise
+            /// interpolates transform data from the adjacent samples in the history buffer
+            /// </summary>
+            /// <param name="history">Buffer containing a set of timestamped samples of the head pose transform data</param>
+            /// <param name="desiredTime">Target time for the transform data</param>
+            /// <param name="useInterplation">Should interpolation be used to interpolate the transform data. If <see langword="false"/> will 
+            /// return the latest head pose</param>
+            /// <returns>The transform data for the target time, intepolated from the history buffer for the target time if 
+            /// interpolation is on, otherwise just returns the latest transform data</returns>
+            public static TransformData GetTransformAtTime(RingBuffer<TransformData> history, long desiredTime, bool useInterplation = true)
             {
                 for (int i = history.Count - 1; i > 0; i--)
                 {
                     if (history.Get(i).time >= desiredTime && history.Get(i - 1).time < desiredTime)
                     {
-                        return Lerp(history.Get(i - 1), history.Get(i), desiredTime);
+                        if (useInterplation)
+                        {
+                            return Lerp(history.Get(i - 1), history.Get(i), desiredTime);
+                        }
+                        else
+                        {
+                            // Return the latest pose, do not return the closest tranform data to the desired time
+                            return history.GetLatest();
+                        }
                     }
                 }
 


### PR DESCRIPTION
…rpolation is off. This prevents stuttering in XR when interpolation is off

## Summary

From a thread reported by @fmaurer https://ultrahaptics.slack.com/archives/C01EE27V1FF/p1676508911401729.

Fixes these issues:

"Seems to be tied to OpenXR, I can toggle the subpar performance on/off by switching between OPEN_XR and LEAP_DIRECT
EDIT: I can toggle it there, and also if I select LEAP_DIRECT and uncheck/check "use interpolation" in service provider. The symptom is massive stuttering on my setup. I suspect there must be a lower level problem that is being smoothed/interpolated away because both providers (leap and xr) are showing the symptom. Default hands should never be smoothed/averaged; completely removes immersion of our high fps tracking
EDIT 2: pinpointed to public TransformHistory(int capacity = 32) is causing issues. When changing default capacity to 1, it completely fixes stuttering (checked back and forth twice). Something with it is wrong. This doesn't impact the OPEN_XR mode however, only for LEAP_DIRECT. (edited)"

If you turn interpolation off on the XR Service Provider you see the hand judder. This will stop if you set the transform history to 1. The reason this happens is that interpolation is off for the hands, but on for the head pose which is used to transform the hand data to world space. These are now effectively out of sync and the judder is the delta shifting. 

The fix is to turn interpolation off for the head pose if interpolation is off for the hands. You can't sample the closest point in the head pose buffer as this shifts - causing a binary judder of the hands. You have to return the most recent head pose.

## Contributor Tasks

- [x] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [x] Add a CHANGELOG entry for this change.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [ ] Run all tests associated with the ticket.
- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Closes JIRA Issue

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_

## Pull Request Templates

Switch template by going to preview and clicking the link - note it will not work if you've made any changes to the description.

- [default.md](?expand=1) - for contributions to stable packages.
- [release.md](?expand=1&template=release.md) - for release merge requests.

**You are currently using: default.md**

Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.
