### PR TITLE
Physics Hands Improved Grasping 

### DIFF
--- a/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsBone.cs
+++ b/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsBone.cs
@@ -22,7 +22,7 @@ namespace Leap.Unity.Interaction.PhysicsHands
             }
         }
 
-        public class ClosestHoverDirection
+        public class ClosestObjectDirection
         {
             /// <summary>
             /// The closest position on the hovering bone
@@ -66,14 +66,14 @@ namespace Leap.Unity.Interaction.PhysicsHands
         ///<summary>
         /// Dictionary of dictionaries of the directions from this bone to a hovered object's colliders
         ///</summary>
-        public Dictionary<Rigidbody, Dictionary<Collider, ClosestHoverDirection>> HoverDirections => _hoverDirections;
-        private Dictionary<Rigidbody, Dictionary<Collider, ClosestHoverDirection>> _hoverDirections = new Dictionary<Rigidbody, Dictionary<Collider, ClosestHoverDirection>>();
+        public Dictionary<Rigidbody, Dictionary<Collider, ClosestObjectDirection>> HoverDirections => _hoverDirections;
+        private Dictionary<Rigidbody, Dictionary<Collider, ClosestObjectDirection>> _hoverDirections = new Dictionary<Rigidbody, Dictionary<Collider, ClosestObjectDirection>>();
 
         ///<summary>
         /// Dictionary of dictionaries of the directions from this bone to a grabbable object's colliders
         ///</summary>
-        public Dictionary<Rigidbody, Dictionary<Collider, ClosestHoverDirection>> GrabbableDirections => _grabbableDirections;
-        private Dictionary<Rigidbody, Dictionary<Collider, ClosestHoverDirection>> _grabbableDirections = new Dictionary<Rigidbody, Dictionary<Collider, ClosestHoverDirection>>();
+        public Dictionary<Rigidbody, Dictionary<Collider, ClosestObjectDirection>> GrabbableDirections => _grabbableDirections;
+        private Dictionary<Rigidbody, Dictionary<Collider, ClosestObjectDirection>> _grabbableDirections = new Dictionary<Rigidbody, Dictionary<Collider, ClosestObjectDirection>>();
 
         /// <summary>
         /// Objects that *can* be grabbed, not ones that are
@@ -306,13 +306,13 @@ namespace Leap.Unity.Interaction.PhysicsHands
                 {
                     if (!_hoverDirections[rb].ContainsKey(_hoverQueue[i]))
                     {
-                        _hoverDirections[rb].Add(_hoverQueue[i], new ClosestHoverDirection());
+                        _hoverDirections[rb].Add(_hoverQueue[i], new ClosestObjectDirection());
                     }
                 }
                 else
                 {
-                    _hoverDirections.Add(rb, new Dictionary<Collider, ClosestHoverDirection>());
-                    _hoverDirections[rb].Add(_hoverQueue[i], new ClosestHoverDirection());
+                    _hoverDirections.Add(rb, new Dictionary<Collider, ClosestObjectDirection>());
+                    _hoverDirections[rb].Add(_hoverQueue[i], new ClosestObjectDirection());
                 }
 
             }
@@ -386,7 +386,6 @@ namespace Leap.Unity.Interaction.PhysicsHands
 
             foreach (var key in _contactObjects.Keys)
             {
-                //if (IsObjectGrabbable(_contactObjects[key]))
                 if (IsObjectGrabbable(key))
                 {
                     // add to grabbable rb dicts
@@ -454,8 +453,8 @@ namespace Leap.Unity.Interaction.PhysicsHands
         {
             _objectDistance = float.MaxValue;
 
-            float tempDist;
-            Vector3 colliderPos, bonePos, tempMid, direction;
+            float distance;
+            Vector3 colliderPos, bonePos, midPoint, direction;
             foreach (var hoverPairs in _hoverObjects)
             {
                 foreach (var hoveredCollider in hoverPairs.Value)
@@ -463,13 +462,13 @@ namespace Leap.Unity.Interaction.PhysicsHands
                     colliderPos = hoveredCollider.ClosestPoint(_collider.transform.position);
                     bonePos = _collider.ClosestPoint(hoveredCollider.transform.position);
 
-                    tempMid = colliderPos + (bonePos - colliderPos) / 2f;
+                    midPoint = colliderPos + (bonePos - colliderPos) / 2f;
 
-                    colliderPos = hoveredCollider.ClosestPoint(tempMid);
-                    bonePos = _collider.ClosestPoint(tempMid);
+                    colliderPos = hoveredCollider.ClosestPoint(midPoint);
+                    bonePos = _collider.ClosestPoint(midPoint);
 
 
-                    tempDist = Vector3.Distance(colliderPos, bonePos);
+                    distance = Vector3.Distance(colliderPos, bonePos);
                     direction = (colliderPos - bonePos).normalized;
 
                     if (_hoverDirections[hoverPairs.Key].ContainsKey(hoveredCollider))
@@ -482,7 +481,7 @@ namespace Leap.Unity.Interaction.PhysicsHands
                     {
                         _hoverDirections[hoverPairs.Key].Add(
                             hoveredCollider,
-                            new ClosestHoverDirection()
+                            new ClosestObjectDirection()
                             {
                                 bonePos = bonePos,
                                 colliderPos = colliderPos,
@@ -491,9 +490,9 @@ namespace Leap.Unity.Interaction.PhysicsHands
                         );
                     }
 
-                    if (tempDist < _objectDistance)
+                    if (distance < _objectDistance)
                     {
-                        _objectDistance = tempDist;
+                        _objectDistance = distance;
                         _debugDistanceA = colliderPos;
                         _debugDistanceB = bonePos;
                     }

--- a/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsBone.cs
+++ b/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsBone.cs
@@ -413,8 +413,6 @@ namespace Leap.Unity.Interaction.PhysicsHands
             IsBoneHovering = _hoverObjects.Count > 0;
             IsBoneContacting = _contactObjects.Count > 0;
             IsBoneReadyToGrab = _grabObjects.Count > 0;
-
-
         }
 
         private bool RemoveHoverQueue(Collider collider)

--- a/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsBone.cs
+++ b/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsBone.cs
@@ -516,7 +516,7 @@ namespace Leap.Unity.Interaction.PhysicsHands
                     if (Joint == 2)
                     {
                         // Rotate the direction forward if the contact is closer to the tip
-                        jointDirection = Quaternion.Euler(0, 0, Mathf.InverseLerp(JointDistance, 0, Vector3.Distance(bonePosCenter, JointTip)) * 60f) * -transform.up;
+                        jointDirection = Quaternion.AngleAxis(Mathf.InverseLerp(JointDistance, 0, Vector3.Distance(bonePosCenter, JointTip)) * 45f, -transform.right) * -transform.up;
                     }
                     else
                     {
@@ -527,15 +527,15 @@ namespace Leap.Unity.Interaction.PhysicsHands
                     {
                         case 0:
                             // Point the thumb closer to the index
-                            jointDirection = Quaternion.Euler(0, Hand.Handedness == Chirality.Left ? 35f : -35f, 0) * jointDirection;
+                            jointDirection = Quaternion.AngleAxis(Hand.Handedness == Chirality.Left ? -45f : 45f, transform.forward) * jointDirection;
                             break;
                         case 1:
                             // Point the index closer to the thumb
-                            jointDirection = Quaternion.Euler(0, Hand.Handedness == Chirality.Left ? -20f : 20f, 0) * jointDirection;
+                            jointDirection = Quaternion.AngleAxis(Hand.Handedness == Chirality.Left ? 25f : -25f, transform.forward) * jointDirection;
                             break;
                     }
 
-                    if (Vector3.Dot(boneCenterToColliderDirection, jointDirection) > 0.18f)
+                    if (Vector3.Dot(boneCenterToColliderDirection, jointDirection) > (Finger == 0 ? 0.04f : 0.18f))
                     {
                         return true;
                     }

--- a/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsBone.cs
+++ b/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsBone.cs
@@ -29,10 +29,6 @@ namespace Leap.Unity.Interaction.PhysicsHands
             /// </summary>
             public Vector3 bonePos = Vector3.zero;
             /// <summary>
-            /// The closest position on the hovered collider
-            /// </summary>
-            public Vector3 colliderPos = Vector3.zero;
-            /// <summary>
             /// The direction from the closest pos on the bone to the closest pos on the collider
             /// </summary>
             public Vector3 direction = Vector3.zero;
@@ -484,7 +480,6 @@ namespace Leap.Unity.Interaction.PhysicsHands
                             new ClosestObjectDirection()
                             {
                                 bonePos = bonePos,
-                                colliderPos = colliderPos,
                                 direction = direction
                             }
                         );

--- a/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsBone.cs
+++ b/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsBone.cs
@@ -471,7 +471,6 @@ namespace Leap.Unity.Interaction.PhysicsHands
                     {
                         _hoverDirections[hoverPairs.Key][hoveredCollider].direction = direction;
                         _hoverDirections[hoverPairs.Key][hoveredCollider].bonePos = bonePos;
-                        _hoverDirections[hoverPairs.Key][hoveredCollider].colliderPos = colliderPos;
                     }
                     else
                     {

--- a/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsGraspHelper.cs
+++ b/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsGraspHelper.cs
@@ -500,7 +500,7 @@ namespace Leap.Unity.Interaction.PhysicsHands
 
             foreach (PhysicsBone b1 in BoneHash)
             {
-                if (b1.GrabbableDirections.TryGetValue(_rigid, out Dictionary<Collider, Vector3> grabbableDirectionsA))
+                if (b1.GrabbableDirections.TryGetValue(_rigid, out var grabbableDirectionsA))
                 {
                     int idB1 = b1.GetInstanceID();
                     foreach (PhysicsBone b2 in BoneHash)
@@ -519,13 +519,13 @@ namespace Leap.Unity.Interaction.PhysicsHands
                         // Register this pair of bones as checked, so that we don't check against it again
                         checkedPairs.Add(idPair1);
 
-                        if (b2.GrabbableDirections.TryGetValue(_rigid, out Dictionary<Collider, Vector3> grabbableDirectionsB))
+                        if (b2.GrabbableDirections.TryGetValue(_rigid, out var grabbableDirectionsB))
                         {
-                            foreach(var directionPairA in grabbableDirectionsA)
+                            foreach (var directionPairA in grabbableDirectionsA)
                             {
-                                foreach(var directionPairB in grabbableDirectionsB)
+                                foreach (var directionPairB in grabbableDirectionsB)
                                 {
-                                    float dot = Vector3.Dot(directionPairA.Value, directionPairB.Value);
+                                    float dot = Vector3.Dot(directionPairA.Value.direction, directionPairB.Value.direction);
                                     if (dot < GRABBABLE_DIRECTIONS_DOT)
                                     {
                                         return true;

--- a/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsGraspHelper.cs
+++ b/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsGraspHelper.cs
@@ -616,6 +616,7 @@ namespace Leap.Unity.Interaction.PhysicsHands
                 if (_graspingHands.Count > 1
                     && !graspedHand.Value.handGrabbing
                     && !graspedHand.Value.facingOppositeHand
+                    // Hand has moved significantly far away from the object
                     && (_rigid.position - graspedHand.Key.GetPhysicsHand().palmBone.transform.position).sqrMagnitude > graspedHand.Value.offset.sqrMagnitude * 1.5f)
                 {
                     SetBoneGrasping(graspedHand, false);
@@ -630,15 +631,18 @@ namespace Leap.Unity.Interaction.PhysicsHands
                 int c = 0;
                 for (int i = 0; i < 5; i++)
                 {
+                    // Was the finger not contacting before?
                     if (graspedHand.Value.fingerStrength[i] == -1)
                     {
                         if (Manager.FingerStrengths[graspedHand.Key][i] > (i == 0 ? MINIMUM_THUMB_STRENGTH : MINIMUM_STRENGTH) && Grasped(graspedHand.Key, i))
                         {
+                            // Store the strength value on contact
                             graspedHand.Value.fingerStrength[i] = Manager.FingerStrengths[graspedHand.Key][i];
                         }
                     }
                     else
                     {
+                        // If the finger was contacting but has uncurled by the exit percentage then it is no longer "grabbed"
                         if (Manager.FingerStrengths[graspedHand.Key][i] < (i == 0 ? MINIMUM_THUMB_STRENGTH : MINIMUM_STRENGTH) || graspedHand.Value.fingerStrength[i] * (1 - (i == 0 ? REQUIRED_THUMB_EXIT_STRENGTH : REQUIRED_EXIT_STRENGTH)) >= Manager.FingerStrengths[graspedHand.Key][i])
                         {
                             graspedHand.Value.fingerStrength[i] = -1;
@@ -651,12 +655,14 @@ namespace Leap.Unity.Interaction.PhysicsHands
                     }
                 }
 
+                // If we've got two fingers curled, the hand was grabbing in the grab contact checks, or the hand is facing the other, then we grab
                 if (c >= 2 || graspedHand.Value.handGrabbing || graspedHand.Value.facingOppositeHand)
                 {
                     SetBoneGrasping(graspedHand, true);
                     continue;
                 }
 
+                // One final check to see if the original data hand has bones inside of the object to retain grasping during physics updates
                 bool data = DataHandIntersection(graspedHand.Key);
 
                 if (!data)

--- a/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsGraspHelper.cs
+++ b/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsGraspHelper.cs
@@ -578,7 +578,6 @@ namespace Leap.Unity.Interaction.PhysicsHands
 
             if (_graspingHands.Count > 0)
             {
-                //_rigid.mass = 1f;
                 GraspState = State.Grasp;
             }
             _graspingValues[hand].offset = _rigid.position - hand.GetPhysicsHand().palmBone.transform.position;

--- a/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsGraspHelper.cs
+++ b/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsGraspHelper.cs
@@ -74,7 +74,7 @@ namespace Leap.Unity.Interaction.PhysicsHands
         private Vector3 _newPosition;
         private Quaternion _newRotation;
 
-        private bool _oldKinematic, _oldGravity;
+        private bool _oldKinematic;
         private float _originalMass = 1f;
         public float OriginalMass => _originalMass;
 
@@ -228,8 +228,6 @@ namespace Leap.Unity.Interaction.PhysicsHands
                 {
                     // Only ever unset the rigidbody values here otherwise outside logic will get confused
                     _rigid.isKinematic = _oldKinematic;
-                    _rigid.useGravity = _oldGravity;
-                    _rigid.mass = _originalMass;
                 }
                 if (Manager.EnhanceThrowing && !Ignored)
                 {
@@ -468,14 +466,12 @@ namespace Leap.Unity.Interaction.PhysicsHands
                         {
                             // Store the original rigidbody variables
                             _oldKinematic = _rigid.isKinematic;
-                            _oldGravity = _rigid.useGravity;
-                            _rigid.useGravity = false;
                             _rigid.isKinematic = false;
                         }
                         _graspingHands.Add(hand);
                         if (_graspingHands.Count > 0)
                         {
-                            _rigid.mass = 1f;
+                            //_rigid.mass = 1f;
                             GraspState = State.Grasp;
                         }
                         _graspingValues[hand].offset = _rigid.position - hand.GetPhysicsHand().palmBone.transform.position;
@@ -780,10 +776,6 @@ namespace Leap.Unity.Interaction.PhysicsHands
             if (_rigid.isKinematic)
             {
                 _rigid.isKinematic = false;
-            }
-            if (_rigid.useGravity)
-            {
-                _rigid.useGravity = false;
             }
             PhysicsMovement(_newPosition, _newRotation, _rigid);
         }

--- a/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsGraspHelper.cs
+++ b/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsGraspHelper.cs
@@ -500,7 +500,7 @@ namespace Leap.Unity.Interaction.PhysicsHands
 
             foreach (PhysicsBone b1 in BoneHash)
             {
-                if (b1.GrabbableDirections.TryGetValue(_rigid, out List<Vector3> grabbableDirectionsA))
+                if (b1.GrabbableDirections.TryGetValue(_rigid, out Dictionary<Collider, Vector3> grabbableDirectionsA))
                 {
                     int idB1 = b1.GetInstanceID();
                     foreach (PhysicsBone b2 in BoneHash)
@@ -519,13 +519,13 @@ namespace Leap.Unity.Interaction.PhysicsHands
                         // Register this pair of bones as checked, so that we don't check against it again
                         checkedPairs.Add(idPair1);
 
-                        if (b2.GrabbableDirections.TryGetValue(_rigid, out List<Vector3> grabbableDirectionsB))
+                        if (b2.GrabbableDirections.TryGetValue(_rigid, out Dictionary<Collider, Vector3> grabbableDirectionsB))
                         {
-                            for (int i = 0; i < grabbableDirectionsA.Count; i++)
+                            foreach(var directionPairA in grabbableDirectionsA)
                             {
-                                for (int j = 0; j < grabbableDirectionsB.Count; j++)
+                                foreach(var directionPairB in grabbableDirectionsB)
                                 {
-                                    float dot = Vector3.Dot(grabbableDirectionsA[i], grabbableDirectionsB[j]);
+                                    float dot = Vector3.Dot(directionPairA.Value, directionPairB.Value);
                                     if (dot < GRABBABLE_DIRECTIONS_DOT)
                                     {
                                         return true;

--- a/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsGraspHelper.cs
+++ b/Packages/Tracking Preview/PhysicsHands/Runtime/PhysicsGraspHelper.cs
@@ -610,8 +610,9 @@ namespace Leap.Unity.Interaction.PhysicsHands
 
         private void UpdateGraspingValues()
         {
-            foreach (var graspedHand in _graspingValues)
+            foreach (KeyValuePair<PhysicsHand, GraspValues> graspedHand in _graspingValues)
             {
+                // Check if this hand was grasping and is now not grasping
                 if (_graspingHands.Count > 1
                     && !graspedHand.Value.handGrabbing
                     && !graspedHand.Value.facingOppositeHand
@@ -794,7 +795,7 @@ namespace Leap.Unity.Interaction.PhysicsHands
                 /*
                  * Grasp priority
                  * Last hand to grab object
-                 * Otherwise, last hand to be adding to graspingHands
+                 * Otherwise, last hand to be added to graspingHands
                  */
 
                 PhysicsHand hand = null;

--- a/Packages/Tracking Preview/PhysicsHands/Runtime/UI/Scripts/PhysicsButton.cs
+++ b/Packages/Tracking Preview/PhysicsHands/Runtime/UI/Scripts/PhysicsButton.cs
@@ -287,6 +287,7 @@ namespace Leap.Unity.Interaction.PhysicsHands
                 Mathf.Abs(_buttonElement.transform.localRotation.eulerAngles.z) > 0.002f)
             {
                 _buttonElement.transform.localRotation = Quaternion.identity;
+                SetupButton();
             }
             if (_buttonElement.transform.lossyScale != _elementScale)
             {

--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -25,12 +25,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (Physics Hands) Updated example scene with new events and better visuals
 - (Physics Hands) Updated Grasp Helper algorithm to account for grasps from fingers facing opposite directions
 - (Physics Hands) Updated PhysicsBone IsObjectGrabbable calculations to use the closest point on the bone to the hovered object
+- (Physics Hands) Improved Physics Hands grasp helpers to take into account grabs where bones are facing each other
 - (Locomotion) Expose teleport anchor list & last teleported anchor
 - (Locomotion) Moved Jump Gems further away from the arm, to account for sleeves
 - (Locomotion) Added functionality to update the initial position and rotations of the TP anchor after the first Awake
 
 ### Fixed
 - (Physics Hands) Hand forces are reduced when pushing into objects with fingers
+- (Physics Hands) Stopped physics buttons from rotating incorrectly
 - (Locomotion) Jump Gems look for audio sources in their children, even if the audio source was set
 - (Locomotion) If pinched gem was null, jump gem teleport could still be in a selected state
 - (Locomotion) Teleport ray did not change to an invalid colour when no colliders were hit

--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (Physics Hands) Hand and bone states have been improved and are more consistent with expectations
 - (Physics Hands) Updated example scene with new events and better visuals
 - (Physics Hands) Updated Grasp Helper algorithm to account for grasps from fingers facing opposite directions
+- (Physics Hands) Updated PhysicsBone IsObjectGrabbable calculations to use the closest point on the bone to the hovered object
 - (Locomotion) Expose teleport anchor list & last teleported anchor
 - (Locomotion) Moved Jump Gems further away from the arm, to account for sleeves
 - (Locomotion) Added functionality to update the initial position and rotations of the TP anchor after the first Awake

--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - This is tailored to handle specific Rigidbodies and will only fire when your subscribed Rigidbody is affected
 - (Physics Hands) Hand and bone states have been improved and are more consistent with expectations
 - (Physics Hands) Updated example scene with new events and better visuals
+- (Physics Hands) Updated Grasp Helper algorithm to account for grasps from fingers facing opposite directions
 - (Locomotion) Expose teleport anchor list & last teleported anchor
 - (Locomotion) Moved Jump Gems further away from the arm, to account for sleeves
 - (Locomotion) Added functionality to update the initial position and rotations of the TP anchor after the first Awake


### PR DESCRIPTION
## Summary

https://github.com/ultraleap/UnityPlugin/assets/17143693/6ad107e1-2160-4f66-a635-db062ed2cc45

This improves the grasping of small->mid objects, and holding objects with two hands facing each other.

- Add a check into the grasp helper to see if bones are facing each other. This uses the direction from the closest point on the bone, to the object, disregarding any directions which aren't forward facing
- Fix physics buttons rotating incorrectly

## Contributor Tasks

- [x] Add a CHANGELOG entry for this change.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [ ] Run all tests associated with the ticket.
- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Closes JIRA Issue

Closes [XRIC-145](https://ultrahaptics.atlassian.net/browse/XRIC-145)


[XRIC-145]: https://ultrahaptics.atlassian.net/browse/XRIC-145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ