### PR TITLE
Added accessor for ServiceBinder

### DIFF
--- a/Packages/Tracking/Core/Runtime/Scripts/Utils/AndroidServiceBinder.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Utils/AndroidServiceBinder.cs
@@ -14,6 +14,8 @@ namespace Leap.Unity
         static AndroidJavaObject context;
         static ServiceCallbacks serviceCallbacks;
 
+        public static AndroidJavaObject ServiceBinder => _serviceBinder;
+
         public static bool Bind()
         {
             bool isBound = _serviceBinder?.Call<bool>("isBound") ?? false;


### PR DESCRIPTION
## Summary

Implements an accessor for the ServiceBinder object, to support upcoming Control Panel work


## Contributor Tasks

- [ ] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [ ] Add a CHANGELOG entry for this change.
- [ ] Ensure documentation requirements are met e.g., public API is commented.
- [ ] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [ ] Add any relevant labels such as `breaking` to this MR.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [ ] Run all tests associated with the ticket.
- [ ] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Closes JIRA Issue

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_

## Pull Request Templates

Switch template by going to preview and clicking the link - note it will not work if you've made any changes to the description.

- [default.md](?expand=1) - for contributions to stable packages.
- [release.md](?expand=1&template=release.md) - for release merge requests.

**You are currently using: default.md**

Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.
