### PR TITLE
Lightweight pinch detector's finger can be configured

### DIFF
--- a/Packages/Tracking Preview/Locomotion/Runtime/Scripts/Teleportation/Utilities/LightweightPinchDetector.cs
+++ b/Packages/Tracking Preview/Locomotion/Runtime/Scripts/Teleportation/Utilities/LightweightPinchDetector.cs
@@ -17,10 +17,21 @@ namespace Leap.Unity.Preview.Locomotion
     /// </summary>
     public class LightweightPinchDetector : MonoBehaviour
     {
+        public enum PinchableFingerType
+        {
+            INDEX = Finger.FingerType.TYPE_INDEX,
+            MIDDLE = Finger.FingerType.TYPE_MIDDLE,
+            RING = Finger.FingerType.TYPE_RING,
+            PINKY = Finger.FingerType.TYPE_PINKY,
+        }
+
         public LeapProvider leapProvider;
         public Chirality chirality;
 
-        public Leap.Finger.FingerType fingerType = Finger.FingerType.TYPE_INDEX;
+        /// <summary>
+        /// The finger to check for pinches against the thumb
+        /// </summary>
+        public PinchableFingerType fingerType = PinchableFingerType.INDEX;
 
         [Header("Pinch Activation Settings")]
         [Tooltip("The distance between fingertip and thumb at which to enter the pinching state.")]

--- a/Packages/Tracking Preview/Locomotion/Runtime/Scripts/Teleportation/Utilities/LightweightPinchDetector.cs
+++ b/Packages/Tracking Preview/Locomotion/Runtime/Scripts/Teleportation/Utilities/LightweightPinchDetector.cs
@@ -68,9 +68,7 @@ namespace Leap.Unity.Preview.Locomotion
                 return;
             }
 
-            // Convert from mm to m
-            float pinchDistance = hand.GetFingerPinchDistance((int)fingerType) * 0.001f;
-
+            float pinchDistance = hand.GetFingerPinchDistance((int)fingerType);
             if (pinchDistance < activateDistance)
             {
                 if (!IsPinching)

--- a/Packages/Tracking Preview/Locomotion/Runtime/Scripts/Teleportation/Utilities/LightweightPinchDetector.cs
+++ b/Packages/Tracking Preview/Locomotion/Runtime/Scripts/Teleportation/Utilities/LightweightPinchDetector.cs
@@ -13,17 +13,19 @@ namespace Leap.Unity.Preview.Locomotion
 {
     /// <summary>
     /// A lightweight Pinch Detector, that calculates a pinch value based on the distance between the 
-    /// index tip and the thumb tip. Utilises hysteresis in order to have different pinch and unpinch thresholds.
+    /// provided finger tip and the thumb tip. Utilises hysteresis in order to have different pinch and unpinch thresholds.
     /// </summary>
     public class LightweightPinchDetector : MonoBehaviour
     {
         public LeapProvider leapProvider;
         public Chirality chirality;
 
+        public Leap.Finger.FingerType fingerType = Finger.FingerType.TYPE_INDEX;
+
         [Header("Pinch Activation Settings")]
-        [Tooltip("The distance between index and thumb at which to enter the pinching state.")]
+        [Tooltip("The distance between fingertip and thumb at which to enter the pinching state.")]
         public float activateDistance = 0.018f;
-        [Tooltip("The distance between index and thumb at which to leave the pinching state.")]
+        [Tooltip("The distance between fingertip and thumb at which to leave the pinching state.")]
         public float deactivateDistance = 0.024f;
 
         public Action<Hand> OnPinch, OnUnpinch, OnPinching;
@@ -67,7 +69,7 @@ namespace Leap.Unity.Preview.Locomotion
             }
 
             // Convert from mm to m
-            float pinchDistance = hand.PinchDistance * 0.001f;
+            float pinchDistance = hand.GetFingerPinchDistance((int)fingerType) * 0.001f;
 
             if (pinchDistance < activateDistance)
             {

--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -  
 
 ### Changed
-- Ultraleap settings are now in the project settings window, under "Ultraleap"
 - [Teleportation] Lightweight Pinch Detector's finger detection can be configured 
 
 ### Fixed

--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Ultraleap settings are now in the project settings window, under "Ultraleap"
+- [Teleportation] Lightweight Pinch Detector's finger detection can be configured 
 
 ### Fixed
 - 

--- a/Packages/Tracking/Core/Runtime/Scripts/UltraleapSettings.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/UltraleapSettings.cs
@@ -1,5 +1,5 @@
+using System;
 using UnityEngine;
-using System.Collections.Generic;
 #if UNITY_EDITOR
 using UnityEditor;
 using System.IO;
@@ -8,34 +8,19 @@ using System.IO;
 namespace Leap.Unity
 {
 #if UNITY_EDITOR
-    static class UltraleapProjectSettings
+    [CustomEditor(typeof(UltraleapSettings))]
+    public class UltraleapSettingsDrawer : Editor
     {
-        [SettingsProvider]
-        public static SettingsProvider CreateUltraleapSettingsProvider()
+
+        public override void OnInspectorGUI()
         {
-            // First parameter is the path in the Settings window.
-            // Second parameter is the scope of this setting: it only appears in the Project Settings window.
-            var provider = new SettingsProvider("Project/Ultraleap", SettingsScope.Project)
-            {
-                // By default the last token of the path is used as display name if no label is provided.
-                label = "Ultraleap",
-                // Create the SettingsProvider and initialize its drawing (IMGUI) function in place:
-                guiHandler = (searchContext) =>
-                {
-                    LeapSubSystemSection();
-                },
+            base.OnInspectorGUI();
 
-                // Populate the search keywords to enable smart search filtering and label highlighting:
-                keywords = new HashSet<string>(new[] { "XRHands", "Leap", "Leap Input System", "Meta Aim System", "Subsystem" })
-            };
-
-            return provider;
+            LeapSubSystemSection();
         }
 
-        private static void LeapSubSystemSection()
+        private void LeapSubSystemSection()
         {
-            var settings = UltraleapSettings.GetSerializedSettings();
-
             EditorGUILayout.Space(10);
             EditorGUILayout.LabelField("Leap XRHands Subsystem", EditorStyles.boldLabel);
             
@@ -44,17 +29,17 @@ namespace Leap.Unity
 
             EditorGUILayout.Space(5);
 
-            SerializedProperty leapSubsystemEnabledProperty = settings.FindProperty("leapSubsystemEnabled");
+            SerializedProperty leapSubsystemEnabledProperty = this.serializedObject.FindProperty("leapSubsystemEnabled");
             leapSubsystemEnabledProperty.boolValue = EditorGUILayout.ToggleLeft("Enable Leap XRHands Subsystem", leapSubsystemEnabledProperty.boolValue);
 
             EditorGUILayout.Space(10);
             EditorGUILayout.LabelField("Input Actions", EditorStyles.boldLabel);
             EditorGUILayout.Space(5);
 
-            SerializedProperty updateLeapInputSystemProperty = settings.FindProperty("updateLeapInputSystem");
+            SerializedProperty updateLeapInputSystemProperty = this.serializedObject.FindProperty("updateLeapInputSystem");
             updateLeapInputSystemProperty.boolValue = EditorGUILayout.ToggleLeft("Update Leap Input System", updateLeapInputSystemProperty.boolValue);
 
-            SerializedProperty updateMetaInputSystemProperty = settings.FindProperty("updateMetaInputSystem");
+            SerializedProperty updateMetaInputSystemProperty = this.serializedObject.FindProperty("updateMetaInputSystem");
             updateMetaInputSystemProperty.boolValue = EditorGUILayout.ToggleLeft("Update Meta Aim Input System", updateMetaInputSystemProperty.boolValue);
 
             EditorGUILayout.Space(30);
@@ -63,12 +48,12 @@ namespace Leap.Unity
             {
                 if(EditorUtility.DisplayDialog("Reset all settings", "This will reset all settings in this Ultraleap settings file", "Yes", "No"))
                 {
-                    UltraleapSettings.Instance.ResetToDefaults();
+                    var settingsTarget = target as UltraleapSettings;
+                    settingsTarget.ResetToDefaults();
                 }
             }
 
-            settings.ApplyModifiedPropertiesWithoutUndo();
-
+            this.serializedObject.ApplyModifiedProperties();
         }
     }
 #endif
@@ -108,7 +93,20 @@ namespace Leap.Unity
         [MenuItem("Ultraleap/Open Ultraleap Settings")]
         private static void SelectULSettingsDropdown()
         {
-            SettingsService.OpenProjectSettings("Project/Ultraleap");
+            SelectUlSettings();
+        }
+
+        private static void SelectUlSettings(bool silent = false)
+        {
+            UltraleapSettings ulSettings = Instance;
+            if (ulSettings != null)
+            {
+                Selection.activeObject = ulSettings;
+            }
+            else
+            {
+                EditorUtility.DisplayDialog("No ultraleap settings file", "There is no settings file available, please try re-importing the plugin.", "Ok");
+            }
         }
 #endif
 
@@ -149,11 +147,6 @@ namespace Leap.Unity
 
 #endif
             return newSO;
-        }
-
-        internal static SerializedObject GetSerializedSettings()
-        {
-            return new SerializedObject(FindSettingsSO());
         }
     }
 }


### PR DESCRIPTION
## Summary

Lightweight pinch detector's finger can be configured

## Contributor Tasks

- [ ] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [x] Add a CHANGELOG entry for this change.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [ ] Run all tests associated with the ticket.
- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Closes JIRA Issue

Closes https://ultrahaptics.atlassian.net/browse/UNITY-1220

## Pull Request Templates

Switch template by going to preview and clicking the link - note it will not work if you've made any changes to the description.

- [default.md](?expand=1) - for contributions to stable packages.
- [release.md](?expand=1&template=release.md) - for release merge requests.

**You are currently using: default.md**

Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.
