### PR TITLE
Expose service IP and port as variables in service providers

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated all custom shaders to support the Universal Render Pipeline concurrently with the Built-in Render Pipeline
 - Updated Copyright year to 2025
 - Split tracking preview examples into different groups - common assets, main examples and examples that need the old input manager to work (e.g. UI input)
+- (Service Provider) Expose service IP and port as user settable variables
 
 ### Fixed
 - Fixed some warnings around runtime variables that were only used in editor mode
@@ -131,9 +132,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Shaders all come under the Ultraleap folder
 - Deleted Interaction Engine
 - Leap and Leap.Unity namespaces are now Leap
-
-### Fixed
-
 
 
 ## [6.15.1] - 26/06/2024

--- a/Packages/Tracking/Core/Editor/Scripts/LeapServiceProviderEditor.cs
+++ b/Packages/Tracking/Core/Editor/Scripts/LeapServiceProviderEditor.cs
@@ -67,6 +67,7 @@ namespace Leap
 
             specifyCustomDrawer("_specificSerialNumber", drawSerialNumberToggle);
 
+            deferProperty("_serverConnectionInput");
             deferProperty("_serverNameSpace");
             deferProperty("_servicePort");
             deferProperty("_serviceIP");
@@ -85,6 +86,21 @@ namespace Leap
             }
 
             addPropertyToFoldout("_useInterpolation", "Advanced Options");
+
+            addPropertyToFoldout("_serviceConnectionInput", "Advanced Options");
+
+            specifyConditionalDrawing("_serviceConnectionInput",
+                (int)LeapServiceProvider.ServiceConnectionInput.NAME,
+                "_serverNameSpace");
+
+            specifyConditionalDrawing("_serviceConnectionInput",
+                (int)LeapServiceProvider.ServiceConnectionInput.IP_PORT,
+                "_serviceIP");
+
+            specifyConditionalDrawing("_serviceConnectionInput",
+                (int)LeapServiceProvider.ServiceConnectionInput.IP_PORT,
+                "_servicePort");
+
             addPropertyToFoldout("_serverNameSpace", "Advanced Options");
             addPropertyToFoldout("_serviceIP", "Advanced Options");
             addPropertyToFoldout("_servicePort", "Advanced Options");

--- a/Packages/Tracking/Core/Editor/Scripts/LeapServiceProviderEditor.cs
+++ b/Packages/Tracking/Core/Editor/Scripts/LeapServiceProviderEditor.cs
@@ -67,7 +67,8 @@ namespace Leap
 
             specifyCustomDrawer("_specificSerialNumber", drawSerialNumberToggle);
 
-            deferProperty("_serverNameSpace");
+            deferProperty("_servicePort");
+            deferProperty("_serviceIP");
             deferProperty("_useInterpolation");
 
             deferProperty("_reconnectionAttempts");
@@ -83,7 +84,8 @@ namespace Leap
             }
 
             addPropertyToFoldout("_useInterpolation", "Advanced Options");
-            addPropertyToFoldout("_serverNameSpace", "Advanced Options");
+            addPropertyToFoldout("_serviceIP", "Advanced Options");
+            addPropertyToFoldout("_servicePort", "Advanced Options");
 
             addPropertyToFoldout("_reconnectionAttempts", "Advanced Options");
             addPropertyToFoldout("_reconnectionInterval", "Advanced Options");

--- a/Packages/Tracking/Core/Editor/Scripts/LeapServiceProviderEditor.cs
+++ b/Packages/Tracking/Core/Editor/Scripts/LeapServiceProviderEditor.cs
@@ -67,7 +67,7 @@ namespace Leap
 
             specifyCustomDrawer("_specificSerialNumber", drawSerialNumberToggle);
 
-            deferProperty("_serverConnectionInput");
+            deferProperty("_serviceConnectionInput");
             deferProperty("_serverNameSpace");
             deferProperty("_servicePort");
             deferProperty("_serviceIP");

--- a/Packages/Tracking/Core/Editor/Scripts/LeapServiceProviderEditor.cs
+++ b/Packages/Tracking/Core/Editor/Scripts/LeapServiceProviderEditor.cs
@@ -67,6 +67,7 @@ namespace Leap
 
             specifyCustomDrawer("_specificSerialNumber", drawSerialNumberToggle);
 
+            deferProperty("_serverNameSpace");
             deferProperty("_servicePort");
             deferProperty("_serviceIP");
             deferProperty("_useInterpolation");
@@ -84,6 +85,7 @@ namespace Leap
             }
 
             addPropertyToFoldout("_useInterpolation", "Advanced Options");
+            addPropertyToFoldout("_serverNameSpace", "Advanced Options");
             addPropertyToFoldout("_serviceIP", "Advanced Options");
             addPropertyToFoldout("_servicePort", "Advanced Options");
 

--- a/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
@@ -916,7 +916,7 @@ namespace Leap
         }
 
         /// <summary>
-        /// Set the _serviceConnectionInput mode to IP_PORT, set the target IP and port of the service to the parameters and connect to the new service address
+        /// Set the connection mode to IP_PORT, the target IP, and port of the service, and connects to this address.
         /// </summary>
         public void SetTargetServiceIPPortToConnectTo(string IP, string port)
         {
@@ -924,6 +924,20 @@ namespace Leap
 
             _serviceIP = IP;
             _servicePort = port;
+
+            destroyController();
+            createController();
+        }
+
+        /// <summary>
+        /// Set the connection mode to NAME, sets the name, and connects to this server namespace.
+        /// </summary>
+        /// <param name="serverNamespace"></param>
+        public void SetTargetServerNamespaceToConnectTo(string serverNamespace)
+        {
+            _serviceConnectionInput = ServiceConnectionInput.NAME;
+
+            _serverNameSpace = serverNamespace;
 
             destroyController();
             createController();

--- a/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
@@ -918,7 +918,7 @@ namespace Leap
         /// <summary>
         /// Set the _serviceConnectionInput mode to IP_PORT, set the target IP and port of the service to the parameters and connect to the new service address
         /// </summary>
-        public void SetServiceIPPort(string IP, string port)
+        public void SetTargetServiceIPPortToConnectTo(string IP, string port)
         {
             _serviceConnectionInput = ServiceConnectionInput.IP_PORT;
 

--- a/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
@@ -271,6 +271,11 @@ namespace Leap
         [SerializeField]
         protected bool _preventInitializingTrackingMode;
 
+        [Tooltip("[DEPRECATED] Which Leap Service API Endpoint to connect to.  This is configured on the service with the 'api_namespace' argument.")]
+        [SerializeField]
+        [EditTimeOnly]
+        protected string _serverNameSpace = "Leap Service";
+
         [Tooltip("The IP address on which the Tracking service listens to. This is configured on the service with 'ip_address' in the 'leap_server_config' session of 'ServerConfig.json'")]
         [SerializeField]
         [EditTimeOnly]
@@ -938,7 +943,7 @@ namespace Leap
                 return;
             }
 
-            string serverNameSpace = $"{{\"tracking_server_ip\": \"{_serviceIP}\", \"tracking_server_port\": {_servicePort}}}";
+            _serverNameSpace = $"{{\"tracking_server_ip\": \"{_serviceIP}\", \"tracking_server_port\": {_servicePort}}}";
 
             if (_multipleDeviceMode == MultipleDeviceMode.Disabled)
             {
@@ -1126,9 +1131,9 @@ namespace Leap
                 return _trackingSource;
             }
 
-            string serverNameSpace = $"{{\"tracking_server_ip\": \"{_serviceIP}\", \"tracking_server_port\": {_servicePort}}}";
+            _serverNameSpace = $"{{\"tracking_server_ip\": \"{_serviceIP}\", \"tracking_server_port\": {_servicePort}}}";
 
-            if (LeapInternal.Connection.IsConnectionAvailable(serverNameSpace))
+            if (LeapInternal.Connection.IsConnectionAvailable(_serverNameSpace))
             {
                 _trackingSource = TrackingSource.LEAPC;
             }

--- a/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
@@ -909,7 +909,7 @@ namespace Leap
         protected virtual long CalculateInterpolationTime(bool endOfFrame = false)
         {
 #if UNITY_ANDROID && !UNITY_EDITOR
-      return _leapController.Now() - 16000;
+            return _leapController.Now() - 16000;
 #else
             if (_leapController != null)
             {
@@ -943,7 +943,10 @@ namespace Leap
                 return;
             }
 
-            _serverNameSpace = $"{{\"tracking_server_ip\": \"{_serviceIP}\", \"tracking_server_port\": {_servicePort}}}";
+            if (_serverNameSpace == "Leap Service")
+            {
+                _serverNameSpace = $"{{\"tracking_server_ip\": \"{_serviceIP}\", \"tracking_server_port\": {_servicePort}}}";
+            }
 
             if (_multipleDeviceMode == MultipleDeviceMode.Disabled)
             {
@@ -1131,7 +1134,10 @@ namespace Leap
                 return _trackingSource;
             }
 
-            _serverNameSpace = $"{{\"tracking_server_ip\": \"{_serviceIP}\", \"tracking_server_port\": {_servicePort}}}";
+            if (_serverNameSpace == "Leap Service")
+            {
+                _serverNameSpace = $"{{\"tracking_server_ip\": \"{_serviceIP}\", \"tracking_server_port\": {_servicePort}}}";
+            }
 
             if (LeapInternal.Connection.IsConnectionAvailable(_serverNameSpace))
             {

--- a/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
@@ -271,7 +271,20 @@ namespace Leap
         [SerializeField]
         protected bool _preventInitializingTrackingMode;
 
-        [Tooltip("[DEPRECATED] Which Leap Service API Endpoint to connect to.  This is configured on the service with the 'api_namespace' argument.")]
+        /// <summary>
+        /// The type of input to use for connection to the service
+        /// </summary>
+        public enum ServiceConnectionInput
+        {
+            NAME,
+            IP_PORT
+        }
+        [Tooltip("Which input to use for the service connection")]
+        [SerializeField]
+        [EditTimeOnly]
+        protected ServiceConnectionInput _serviceConnectionInput = ServiceConnectionInput.NAME;
+
+        [Tooltip("Which Leap Service API Endpoint to connect to.  This is configured on the service with the 'api_namespace' argument.")]
         [SerializeField]
         [EditTimeOnly]
         protected string _serverNameSpace = "Leap Service";
@@ -943,7 +956,7 @@ namespace Leap
                 return;
             }
 
-            if (_serverNameSpace == "Leap Service")
+            if(_serviceConnectionInput == ServiceConnectionInput.IP_PORT)
             {
                 _serverNameSpace = $"{{\"tracking_server_ip\": \"{_serviceIP}\", \"tracking_server_port\": {_servicePort}}}";
             }
@@ -1134,7 +1147,7 @@ namespace Leap
                 return _trackingSource;
             }
 
-            if (_serverNameSpace == "Leap Service")
+            if (_serviceConnectionInput == ServiceConnectionInput.IP_PORT)
             {
                 _serverNameSpace = $"{{\"tracking_server_ip\": \"{_serviceIP}\", \"tracking_server_port\": {_servicePort}}}";
             }

--- a/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
@@ -977,11 +977,11 @@ namespace Leap
 
             if (_multipleDeviceMode == MultipleDeviceMode.Disabled)
             {
-                _leapController = new Controller(0, serverNameSpace, true, _trackFiducialMarkers);
+                _leapController = new Controller(0, _serverNameSpace, true, _trackFiducialMarkers);
             }
             else
             {
-                _leapController = new Controller(SpecificSerialNumber.GetHashCode(), serverNameSpace, true, _trackFiducialMarkers);
+                _leapController = new Controller(SpecificSerialNumber.GetHashCode(), _serverNameSpace, true, _trackFiducialMarkers);
             }
 
             _leapController.Device += (s, e) =>

--- a/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
@@ -271,10 +271,15 @@ namespace Leap
         [SerializeField]
         protected bool _preventInitializingTrackingMode;
 
-        [Tooltip("Which Leap Service API Endpoint to connect to.  This is configured on the service with the 'api_namespace' argument.")]
+        [Tooltip("The IP address on which the Tracking service listens to. This is configured on the service with 'ip_address' in the 'leap_server_config' session of 'ServerConfig.json'")]
         [SerializeField]
         [EditTimeOnly]
-        protected string _serverNameSpace = "Leap Service";
+        protected string _serviceIP = "127.0.0.1";
+
+        [Tooltip("The port on which the Tracking service listens to. This is configured on the service with 'port' in the 'leap_server_config' session of 'ServerConfig.json'")]
+        [SerializeField]
+        [EditTimeOnly]
+        protected string _servicePort = "12345";
 
         public override TrackingSource TrackingDataSource { get { return CheckLeapServiceAvailable(); } }
 
@@ -933,13 +938,15 @@ namespace Leap
                 return;
             }
 
+            string serverNameSpace = $"{{\"tracking_server_ip\": \"{_serviceIP}\", \"tracking_server_port\": {_servicePort}}}";
+
             if (_multipleDeviceMode == MultipleDeviceMode.Disabled)
             {
-                _leapController = new Controller(0, _serverNameSpace, true, _trackFiducialMarkers);
+                _leapController = new Controller(0, serverNameSpace, true, _trackFiducialMarkers);
             }
             else
             {
-                _leapController = new Controller(SpecificSerialNumber.GetHashCode(), _serverNameSpace, true, _trackFiducialMarkers);
+                _leapController = new Controller(SpecificSerialNumber.GetHashCode(), serverNameSpace, true, _trackFiducialMarkers);
             }
 
             _leapController.Device += (s, e) =>
@@ -1116,6 +1123,18 @@ namespace Leap
             if (HandTrackingSourceUtility.LeapCTrackingAvailable)
             {
                 _trackingSource = TrackingSource.LEAPC;
+                return _trackingSource;
+            }
+
+            string serverNameSpace = $"{{\"tracking_server_ip\": \"{_serviceIP}\", \"tracking_server_port\": {_servicePort}}}";
+
+            if (LeapInternal.Connection.IsConnectionAvailable(serverNameSpace))
+            {
+                _trackingSource = TrackingSource.LEAPC;
+            }
+            else
+            {
+                _trackingSource = TrackingSource.NONE;
             }
 
             return _trackingSource;

--- a/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
@@ -915,6 +915,20 @@ namespace Leap
             throw new Exception("Unknown tracking optimization mode");
         }
 
+        /// <summary>
+        /// Set the _serviceConnectionInput mode to IP_PORT, set the target IP and port of the service to the parameters and connect to the new service address
+        /// </summary>
+        public void SetServiceIPPort(string IP, string port)
+        {
+            _serviceConnectionInput = ServiceConnectionInput.IP_PORT;
+
+            _serviceIP = IP;
+            _servicePort = port;
+
+            destroyController();
+            createController();
+        }
+
         #endregion
 
         #region Internal Methods


### PR DESCRIPTION
## Summary

This replaces the `_serverNameSpace` with `_serverIP` and `_serverPort`. `_serverNameSpace` was used back in Orion when it was using named pipes. It is now using TCP and although LeapC still uses a variable called `server_namespace`, it can be used to connect to a service listening on a different IP/port by passing a JSON payload containing `tracking_server_ip` and `tracking_server_port`:

## Contributor Tasks

- [ ] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [x] Add a CHANGELOG entry for this change.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [ ] Run all tests associated with the ticket.
- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Closes JIRA Issue

Closes [UNITY-1217](https://ultrahaptics.atlassian.net/browse/UNITY-1217)


[UNITY-1217]: https://ultrahaptics.atlassian.net/browse/UNITY-1217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ