### PR TITLE
Feature/unity 1218 xr hands use existing provider

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -  
 
 ### Changed
-- 
+- (XRHands) XRHands subsystem will now use existing LeapXRServiceProviders found in the scene before considering generating new ones
 
 ### Fixed
 - 

--- a/Packages/Tracking/Core/Runtime/Scripts/XRHandsSubsystem/SubsystemStarter.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/XRHandsSubsystem/SubsystemStarter.cs
@@ -90,23 +90,21 @@ namespace Leap.Unity
                 return;
             }
 
-            LeapProvider leapProvider = Hands.Provider;
+            LeapXRServiceProvider leapProvider = GameObject.FindAnyObjectByType<LeapXRServiceProvider>();
 
             // If there is no leap provider in the scene
             if (leapProvider == null)
             {
-                Debug.Log("There are no Leap Providers in the scene, automatically assigning one for use with Leap XRHands");
+                Debug.Log("There are no LeapXRServiceProviders in the scene, automatically assigning one for use with Ultraleap Subsystem for XRHands");
+
+                GameObject leapProviderGO = new GameObject("LeapXRServiceProvider");
+                leapProvider = leapProviderGO.AddComponent<LeapXRServiceProvider>();
+                GameObject.DontDestroyOnLoad(leapProviderGO);
             }
             else
             {
-                Debug.LogWarning("We recommend that you do not add a Leap Provider to scenes using the Leap Subsystem for XR Hands. This can cause unwanted behaviour. \n A new leap provider has been created which the subsystem will use.");
+                Debug.Log("Ultraleap Subsystem for XRHands is using the existing LeapXRServiceProvider found in the current scene");
             }
-
-            leapProviderGO = new GameObject("LeapXRServiceProvider");
-            LeapXRServiceProvider leapXRServiceProvider = leapProviderGO.AddComponent<LeapXRServiceProvider>();
-            leapXRServiceProvider.PositionDeviceRelativeToMainCamera = true;
-            leapProvider = (LeapProvider)leapXRServiceProvider;
-            GameObject.DontDestroyOnLoad(leapProviderGO);
 
             if (subsystemProvider != null)
             {

--- a/Packages/Tracking/Core/Runtime/Scripts/XRHandsSubsystem/SubsystemStarter.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/XRHandsSubsystem/SubsystemStarter.cs
@@ -90,7 +90,7 @@ namespace Leap.Unity
                 return;
             }
 
-            LeapXRServiceProvider leapProvider = GameObject.FindAnyObjectByType<LeapXRServiceProvider>();
+            LeapProvider leapProvider = GameObject.FindAnyObjectByType<LeapXRServiceProvider>();
 
             // If there is no leap provider in the scene
             if (leapProvider == null)
@@ -98,7 +98,9 @@ namespace Leap.Unity
                 Debug.Log("There are no LeapXRServiceProviders in the scene, automatically assigning one for use with Ultraleap Subsystem for XRHands");
 
                 GameObject leapProviderGO = new GameObject("LeapXRServiceProvider");
-                leapProvider = leapProviderGO.AddComponent<LeapXRServiceProvider>();
+                LeapXRServiceProvider leapXRServiceProvider = leapProviderGO.AddComponent<LeapXRServiceProvider>();
+                leapXRServiceProvider.PositionDeviceRelativeToMainCamera = true;
+                leapProvider = (LeapProvider)leapXRServiceProvider;
                 GameObject.DontDestroyOnLoad(leapProviderGO);
             }
             else


### PR DESCRIPTION
## Summary

Change XRHands subsystem to make use of any existing LeapXRServiceProvider in the scene before generating one for the user. This is to align with the same approach for MRTK.

## Contributor Tasks

- [x] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [x] Add a CHANGELOG entry for this change.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Run all tests associated with the ticket.
- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Closes JIRA Issue

Closes UNITY-1218
