### PR TITLE
Feature/UI nty 1194 xr hands action input

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 
 
 ### Fixed
-- 
+- (XRHands) XRHands double-translates tracking data causing XRI InputActions to be wrongly positioned when the XROrigin is moved
 
 ### Known issues 
 - Use of the LeapCSharp Config class is unavailable with v5.X tracking service

--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/TransformExtensions.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/TransformExtensions.cs
@@ -42,6 +42,17 @@ namespace Leap
         }
 
         /**
+         * Returns a new frame that is a copy of a frame, with an additional rigid
+         * transformation applied to it.
+         *
+         * @param transform The transformation to be applied to the copied frame.
+         */
+        public static Frame TransformedCopy(this Frame frame, Vector3 position, Quaternion rotation)
+        {
+            return new Frame().CopyFrom(frame).Transform(new LeapTransform(position, rotation));
+        }
+
+        /**
          * Does an in-place rigid transformation of a Hand.
          *
          * @param transform A LeapTransform containing the desired translation, rotation, and scale
@@ -77,6 +88,17 @@ namespace Leap
         public static Hand TransformedCopy(this Hand hand, LeapTransform transform)
         {
             return new Hand().CopyFrom(hand).Transform(transform);
+        }
+
+        /**
+         * Returns a new hand that is a copy of a hand, with an additional rigid
+         * transformation applied to it.
+         *
+         * @param transform The transformation to be applied to the copied hand.
+         */
+        public static Hand TransformedCopy(this Hand hand, Vector3 position, Quaternion rotation)
+        {
+            return new Hand().CopyFrom(hand).Transform(new LeapTransform(position, rotation));
         }
 
         /**

--- a/Packages/Tracking/Core/Runtime/Scripts/XRHandsSubsystem/LeapHandsSubsystem.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/XRHandsSubsystem/LeapHandsSubsystem.cs
@@ -105,13 +105,13 @@ namespace Leap.Unity
 
             XRHandSubsystem.UpdateSuccessFlags updateSuccessFlags = XRHandSubsystem.UpdateSuccessFlags.None;
 
-            if (PopulateXRHandFromLeap(currentFrame.GetHand(Chirality.Left), ref leftHandRootPose, ref leftHandJoints))
+            if (PopulateXRHandFromLeap(currentFrame.GetHand(Chirality.Left), ref leftHandRootPose, ref leftHandJoints, updateType))
             {
                 updateSuccessFlags |= XRHandSubsystem.UpdateSuccessFlags.LeftHandRootPose;
                 updateSuccessFlags |= XRHandSubsystem.UpdateSuccessFlags.LeftHandJoints;
             }
 
-            if (PopulateXRHandFromLeap(currentFrame.GetHand(Chirality.Right), ref rightHandRootPose, ref rightHandJoints))
+            if (PopulateXRHandFromLeap(currentFrame.GetHand(Chirality.Right), ref rightHandRootPose, ref rightHandJoints, updateType))
             {
                 updateSuccessFlags |= XRHandSubsystem.UpdateSuccessFlags.RightHandRootPose;
                 updateSuccessFlags |= XRHandSubsystem.UpdateSuccessFlags.RightHandJoints;
@@ -122,26 +122,27 @@ namespace Leap.Unity
             return updateSuccessFlags;
         }
 
-        bool PopulateXRHandFromLeap(Hand leapHand, ref Pose rootPose, ref NativeArray<XRHandJoint> handJoints)
+        bool PopulateXRHandFromLeap(Hand leapHand, ref Pose rootPose, ref NativeArray<XRHandJoint> handJoints, XRHandSubsystem.UpdateType updateType)
         {
             if (leapHand == null)
             {
                 return false;
             }
 
-            if (Camera.main.transform != null)
+            if (updateType == XRHandSubsystem.UpdateType.BeforeRender)
             {
-                var camPos = Camera.main.transform.parent.position;
-                var camRot = Camera.main.transform.parent.rotation;
-                leapHand.Transform(-camPos, Quaternion.Inverse(camRot));
+                if (Camera.main.transform != null && Camera.main.transform.parent != null)
+                {
+                    var camPos = Camera.main.transform.parent.position;
+                    var camRot = Camera.main.transform.parent.rotation;
 
+                    leapHand.Transform(-camPos, Quaternion.identity);
+                    leapHand.Transform(Vector3.zero, Quaternion.Inverse(camRot));
+                }
             }
-
 
             Pose palmPose = CalculatePalmPose(leapHand);
             Pose wristPose = CalculateWristPose(leapHand);
-
-
 
             rootPose = wristPose;
             Handedness handedness = (Handedness)((int)leapHand.GetChirality() + 1); // +1 as unity has "invalid" handedness while we do not

--- a/Packages/Tracking/Core/Runtime/Scripts/XRHandsSubsystem/LeapHandsSubsystem.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/XRHandsSubsystem/LeapHandsSubsystem.cs
@@ -129,16 +129,13 @@ namespace Leap.Unity
                 return false;
             }
 
-            if (updateType == XRHandSubsystem.UpdateType.BeforeRender)
+            if (Camera.main.transform != null && Camera.main.transform.parent != null)
             {
-                if (Camera.main.transform != null && Camera.main.transform.parent != null)
-                {
-                    var camPos = Camera.main.transform.parent.position;
-                    var camRot = Camera.main.transform.parent.rotation;
+                var camPos = Camera.main.transform.parent.position;
+                var camRot = Camera.main.transform.parent.rotation;
 
-                    leapHand.Transform(-camPos, Quaternion.identity);
-                    leapHand.Transform(Vector3.zero, Quaternion.Inverse(camRot));
-                }
+                leapHand.Transform(-camPos, Quaternion.identity);
+                leapHand.Transform(Vector3.zero, Quaternion.Inverse(camRot));
             }
 
             Pose palmPose = CalculatePalmPose(leapHand);

--- a/Packages/Tracking/Core/Runtime/Scripts/XRHandsSubsystem/LeapHandsSubsystem.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/XRHandsSubsystem/LeapHandsSubsystem.cs
@@ -7,7 +7,9 @@
  ******************************************************************************/
 
 using System.Collections.Generic;
+
 using Unity.Collections;
+
 using UnityEngine;
 using UnityEngine.XR.Hands;
 using UnityEngine.XR.Hands.ProviderImplementation;

--- a/Packages/Tracking/Core/Runtime/Scripts/XRHandsSubsystem/XRHandsInputActionUpdater.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/XRHandsSubsystem/XRHandsInputActionUpdater.cs
@@ -115,8 +115,26 @@ namespace Leap.Unity.InputActions
             {
                 // TODO This does not copy the data, need to get all of the individual joints and copy them. Alternatively, mem copy
 
+
                 XRHand rightHand = subsystem.rightHand;
                 XRHand leftHand = subsystem.leftHand;
+
+                if (subsystem.subsystemDescriptor.id == "UL XR Hands")
+
+                {
+                    var camPos = Camera.main.transform.parent.position;
+                    var camRot = Camera.main.transform.parent.rotation;
+
+                    ConvertRootToWorldSpace(camPos, camRot, subsystem, subsystem.rightHand, out Pose rightRootPose);
+                    ConvertRootToWorldSpace(camPos, camRot, subsystem, subsystem.leftHand, out Pose leftRootPose);
+
+                    rightHand.SetRootPose(rightRootPose);
+                    leftHand.SetRootPose(leftRootPose);
+                }
+
+
+
+
 
                 rightHand.SetRootPose(rightHand.rootPose);
                 leftHand.SetRootPose(leftHand.rootPose);

--- a/Packages/Tracking/Core/Runtime/Scripts/XRHandsSubsystem/XRHandsInputActionUpdater.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/XRHandsSubsystem/XRHandsInputActionUpdater.cs
@@ -106,13 +106,10 @@ namespace Leap.Unity.InputActions
 
         private static void UpdateHands(XRHandSubsystem subsystem, XRHandSubsystem.UpdateSuccessFlags updateSuccessFlags, XRHandSubsystem.UpdateType updateType)
         {
-            if (Application.isPlaying && updateType == XRHandSubsystem.UpdateType.BeforeRender)
+            if (Application.isPlaying)
             {
-                XRHand rightHand = subsystem.rightHand;
-                XRHand leftHand = subsystem.leftHand;
-
-                UpdateStateWithLeapHand(rightDevice, rightHand, ref rightState);
-                UpdateStateWithLeapHand(leftDevice, leftHand, ref leftState);
+                UpdateStateWithLeapHand(rightDevice, subsystem.rightHand, ref rightState);
+                UpdateStateWithLeapHand(leftDevice, subsystem.leftHand, ref leftState);
             }
         }
 

--- a/Packages/Tracking/Core/Runtime/Scripts/XRHandsSubsystem/XRHandsInputActionUpdater.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/XRHandsSubsystem/XRHandsInputActionUpdater.cs
@@ -106,28 +106,14 @@ namespace Leap.Unity.InputActions
 
         private static void UpdateHands(XRHandSubsystem subsystem, XRHandSubsystem.UpdateSuccessFlags updateSuccessFlags, XRHandSubsystem.UpdateType updateType)
         {
-            if (Application.isPlaying && updateType == XRHandSubsystem.UpdateType.Dynamic)
+            if (Application.isPlaying && updateType == XRHandSubsystem.UpdateType.BeforeRender)
             {
                 XRHand rightHand = subsystem.rightHand;
                 XRHand leftHand = subsystem.leftHand;
 
-                //if (Camera.main.transform.parent != null)
-                //{
-                //    // Convert the XRHands into world space
-                //    Pose newRootPoseRight = ToWorldPose(rightHand.rootPose, Camera.main.transform.parent);
-                //    Pose newRootPoseLeft = ToWorldPose(leftHand.rootPose, Camera.main.transform.parent);
-                //    rightHand.SetRootPose(newRootPoseRight);
-                //    leftHand.SetRootPose(newRootPoseLeft);
-                //}
-
                 UpdateStateWithLeapHand(rightDevice, rightHand, ref rightState);
                 UpdateStateWithLeapHand(leftDevice, leftHand, ref leftState);
             }
-        }
-
-        private static Pose ToWorldPose(Pose pose, Transform origin)
-        {
-            return pose.GetTransformedBy(origin);
         }
 
         /// <summary>

--- a/Packages/Tracking/Core/Runtime/Scripts/XRHandsSubsystem/XRHandsInputActionUpdater.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/XRHandsSubsystem/XRHandsInputActionUpdater.cs
@@ -7,12 +7,11 @@
  ******************************************************************************/
 
 using System.Collections.Generic;
-using UnityEditor;
+
 using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Layouts;
 using UnityEngine.XR.Hands;
-using UnityEngine.XR.Hands.Processing;
 
 namespace Leap.Unity.InputActions
 {


### PR DESCRIPTION
## Summary

Fixes an issue where XRHands data was wrongly offset due to double-transformations

## Contributor Tasks

- [ ] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [x] Add a CHANGELOG entry for this change.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.
- [x] Add any relevant labels such as `breaking` to this MR.

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

[Use emojis in review threads to communicate intent and help contributors.](https://github.com/ultraleap/UnityPlugin/blob/develop/CONTRIBUTING.md#review-threads)

- [x] Run all tests associated with the ticket.
- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] Documentation has been reviewed.
- [x] Approve with a comment of any additional tests run or any observations.

## Closes JIRA Issue

Closes UNITY-1194