### PR TITLE
XRLeapProviderManager defaults to Direct

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -20,7 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Changed from using obsolete FindObjectOfType to using newer implementations
 - (Preview Teleportation) Lightweight Pinch Detector's finger detection can be configured
-- Ultraleap settings are now in the project settings window, under "Ultraleap" 
+- Ultraleap settings are now in the project settings window, under "Ultraleap"
+- XRLeapProviderManager defaults to Direct when using Automatic. Will use OpenXR if Direct is not available (Select OpenXR if you require OpenXR hand tracking)
 
 ### Fixed
 - 

--- a/Packages/Tracking/Core/Runtime/Scripts/XRLeapProviderManager.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/XRLeapProviderManager.cs
@@ -102,11 +102,7 @@ namespace Leap.Unity
                     yield return new WaitForEndOfFrame();
                 }
                 
-                if (openXRLeapProvider != null && openXRLeapProvider.TrackingDataSource == TrackingSource.OPENXR_LEAP)
-                {
-                    SelectTrackingSource(TrackingSourceType.OPEN_XR);
-                }
-                else if (leapXRServiceProvider != null && leapXRServiceProvider.TrackingDataSource == TrackingSource.LEAPC)
+                if (leapXRServiceProvider != null && leapXRServiceProvider.TrackingDataSource == TrackingSource.LEAPC)
                 {
                     SelectTrackingSource(TrackingSourceType.LEAP_DIRECT);
                 }

--- a/Packages/Tracking/Core/Runtime/Scripts/XRLeapProviderManager.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/XRLeapProviderManager.cs
@@ -80,7 +80,7 @@ namespace Leap.Unity
         /// <summary>
         /// The chosen source of hand tracking data
         /// </summary>
-        [Tooltip("AUTOMATIC - Windows will use LeapService, other platforms will use OpenXR if available and LeapService if OpenXR is not" +
+        [Tooltip("AUTOMATIC - Will use LeapService, if available and OpenXR if not" +
                     "OPEN_XR - Use OpenXR as the source of tracking" +
                     "LEAP_DIRECT - Directly use LeapC as the source of tracking")]
         public TrackingSourceType trackingSource;

--- a/Packages/Tracking/Core/Runtime/Scripts/XRLeapProviderManager.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/XRLeapProviderManager.cs
@@ -106,7 +106,7 @@ namespace Leap.Unity
                 {
                     SelectTrackingSource(TrackingSourceType.LEAP_DIRECT);
                 }
-                else if (openXRLeapProvider != null && openXRLeapProvider.TrackingDataSource == TrackingSource.OPENXR)
+                else if (openXRLeapProvider != null && (openXRLeapProvider.TrackingDataSource == TrackingSource.OPENXR || openXRLeapProvider.TrackingDataSource == TrackingSource.OPENXR_LEAP))
                 {
                     SelectTrackingSource(TrackingSourceType.OPEN_XR);
                 }


### PR DESCRIPTION
## Summary

Automatic XRLeapProviderManager defaults to Direct before falling back to OpenXR if not available

## Contributor Tasks

- [x] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [x] Add a CHANGELOG entry for this change.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Test Cycle

[_Link to the test cycle here._](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testPlayer/UNITY-R82)

## Reviewer Tasks

- [ ] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [ ] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

Closes [UNITY-1283](https://ultrahaptics.atlassian.net/browse/UNITY-1283)

[UNITY-1283]: https://ultrahaptics.atlassian.net/browse/UNITY-1283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ