### PR TITLE
added clearing of hands when tracking device is lost

### DIFF
--- a/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
@@ -903,6 +903,11 @@ namespace Leap.Unity
                 if (e.Device == _currentDevice)
                 {
                     _currentDevice = null;
+
+                    _untransformedUpdateFrame.Hands.Clear();
+                    _transformedUpdateFrame.Hands.Clear();
+                    _untransformedFixedFrame.Hands.Clear();
+                    _transformedFixedFrame.Hands.Clear();
                 }
             };
 


### PR DESCRIPTION
## Summary

added clearing of hands when tracking device is lost in LeapServiceProvider so virtual hands disappear when this occurs

## Contributor Tasks

- [ ] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [ ] Add a CHANGELOG entry for this change.
- [ ] Ensure documentation requirements are met e.g., public API is commented.
- [ ] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Test Cycle

_Link to the test cycle here._

## Reviewer Tasks

- [ ] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [ ] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

Closes [UNITY-1034](https://ultrahaptics.atlassian.net/browse/UNITY-1034)

[UNITY-1034]: https://ultrahaptics.atlassian.net/browse/UNITY-1034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ