### PR TITLE
force hand scale for 1 second after hand is found

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - LeapXRServiceProvider ensures default device offset mode is set to new defaults when enabled
+- (Hand Binder) Hands begin at large/small scale and slowly scale to normal size
 
 ### Known issues 
 - Use of the LeapCSharp Config class is unavailable with v5.X tracking service

--- a/Packages/Tracking/Hands/Runtime/Scripts/HandBinder/HandBinder.cs
+++ b/Packages/Tracking/Hands/Runtime/Scripts/HandBinder/HandBinder.cs
@@ -82,6 +82,8 @@ namespace Leap.Unity.HandsModule
         public SerializedTransform[] DefaultHandPose;
 
 
+        private float lastHandFoundTime = 0;
+        private float instantScaleAfterHandFoundTime = 1f; // seconds
         #endregion
 
         #region Hand Model Base
@@ -156,6 +158,8 @@ namespace Leap.Unity.HandsModule
             {
                 SetModelScale = false;
             }
+
+            lastHandFoundTime = Time.time;
         }
 
         /// <summary>
@@ -213,7 +217,17 @@ namespace Leap.Unity.HandsModule
             else // Lerp the scale during playmode
             {
                 var targetScale = BoundHand.startScale * scaleRatio;
-                transform.localScale = Vector3.Lerp(transform.localScale, targetScale, Time.deltaTime * ScalingSpeedMultiplier);
+
+                if (Time.time - lastHandFoundTime < instantScaleAfterHandFoundTime)
+                {
+                    // Instantly scale if it's not been long since the hand started tracking
+                    transform.localScale = targetScale;
+                }
+                else
+                {
+                    // Smoothly scale
+                    transform.localScale = Vector3.Lerp(transform.localScale, targetScale, Time.deltaTime * ScalingSpeedMultiplier);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

When using the Hand Binder, this forced the scale to be immediately changed for the first 1 second after the hand begins tracking to avoid slow scaling from large or small hands

## Contributor Tasks

- [x] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [x] Add a CHANGELOG entry for this change.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Test Cycle

[_Link to the test cycle here._](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testPlayer/UNITY-R84)

## Reviewer Tasks

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [x] Documentation has been reviewed.
- [x] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

Closes [UNITY-1227](https://ultrahaptics.atlassian.net/browse/UNITY-1227)

[UNITY-1227]: https://ultrahaptics.atlassian.net/browse/UNITY-1227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ