### PR TITLE
Feature/unity 1248 mark unused api as obsolete

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -20,7 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Changed from using obsolete FindObjectOfType to using newer implementations
 - (Preview Teleportation) Lightweight Pinch Detector's finger detection can be configured
-- Ultraleap settings are now in the project settings window, under "Ultraleap" 
+- Ultraleap settings are now in the project settings window, under "Ultraleap"
+- (Obsolete) Some old unused LeapC APIs have been marked as Obsolete (config, IsSmudged, IsLightingBad)
 
 ### Fixed
 - LeapXRServiceProvider ensures default device offset mode is set to new defaults when enabled

--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -25,14 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - 
 
-### Known issues 
-- Use of the LeapCSharp Config class is unavailable with v5.X tracking service
+### Known issues
 - Repeatedly opening scenes can cause memory use increase
-- Currently the Ultraleap Hand Tracking feature for OpenXR requires the New and Legacy input systems to be enabled, to simultaneously use OpenXR and the Ultraleap Unity Plugin's features.
 - The OpenXR Leap Provider does not currently support the `Confidence` hand property (and will return fixed values)
 - After using Ultraleap OpenXR in Unity Editor, the tracking mode of device 0 will be set to HMD until the Unity Editor session ends. This can stop the testing of non-XR scenes until the Unity Editor is re-opened
-- The OpenXR Leap Provider palm can be in unexpected position when using pre-1.4.3 OpenXR Layer. A workaround is to ensure you use 1.4.3 or newer - installed by the 5.12.0 or newer Tracking Service Installer
-- Running both the Ultraleap XRHands Subsystem and another XRHands Subsystem at the same time causes unstable results. Only enable one at a time.
 
 ## [6.12.1] - 28/09/23
 

--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Config.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Config.cs
@@ -18,6 +18,7 @@ namespace Leap
     /// 
     /// @since 1.0
     /// </summary>
+    [Obsolete("Config.cs is not used in Ultraleap's Tracking Service 5.X+. This will be removed in the next Major release")]
     public class Config
     {
         private Connection _connection;
@@ -29,12 +30,15 @@ namespace Leap
         /// Note that the Controller.Config provides a properly initialized Config object already.
         /// @since 3.0
         /// </summary>
+        [Obsolete("Config.cs is not used in Ultraleap's Tracking Service 5.X+. This will be removed in the next Major release")]
         public Config(Connection.Key connectionKey)
         {
             _connection = Connection.GetConnection(connectionKey);
             _connection.LeapConfigChange += handleConfigChange;
             _connection.LeapConfigResponse += handleConfigResponse;
         }
+
+        [Obsolete("Config.cs is not used in Ultraleap's Tracking Service 5.X+. This will be removed in the next Major release")]
         public Config(int connectionId) : this(new Connection.Key(connectionId)) { }
 
         private void handleConfigChange(object sender, ConfigChangeEventArgs eventArgs)
@@ -87,6 +91,7 @@ namespace Leap
         /// 
         /// @since 3.0
         /// </summary>
+        [Obsolete("Config.cs is not used in Ultraleap's Tracking Service 5.X+. This will be removed in the next Major release")]
         public bool Get<T>(string key, Action<T> onResult)
         {
             uint requestId = _connection.GetConfigValue(key);
@@ -107,6 +112,7 @@ namespace Leap
         /// 
         /// @since 3.0
         /// </summary>
+        [Obsolete("Config.cs is not used in Ultraleap's Tracking Service 5.X+. This will be removed in the next Major release")]
         public bool Set<T>(string key, T value, Action<bool> onResult) where T : IConvertible
         {
             uint requestId = _connection.SetConfigValue<T>(key, value);
@@ -123,6 +129,7 @@ namespace Leap
         /// Enumerates the possible data types for configuration values.
         /// @since 1.0
         /// </summary>
+        [Obsolete("Config.cs is not used in Ultraleap's Tracking Service 5.X+. This will be removed in the next Major release")]
         public enum ValueType
         {
             TYPE_UNKNOWN = 0,

--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Connection.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Connection.cs
@@ -359,9 +359,6 @@ namespace LeapInternal
                             StructMarshal<LEAP_CONFIG_CHANGE_EVENT>.PtrToStruct(_msg.eventStructPtr, out config_change_evt);
                             handleConfigChange(ref config_change_evt);
                             break;
-                        case eLeapEventType.eLeapEventType_ConfigResponse:
-                            handleConfigResponse(ref _msg);
-                            break;
                         case eLeapEventType.eLeapEventType_DroppedFrame:
                             LEAP_DROPPED_FRAME_EVENT dropped_frame_evt;
                             StructMarshal<LEAP_DROPPED_FRAME_EVENT>.PtrToStruct(_msg.eventStructPtr, out dropped_frame_evt);
@@ -746,55 +743,6 @@ namespace LeapInternal
             {
                 LeapConfigChange.DispatchOnContext(this, EventContext,
                   new ConfigChangeEventArgs(config_key, configEvent.status != false, configEvent.requestId));
-            }
-        }
-
-        private void handleConfigResponse(ref LEAP_CONNECTION_MESSAGE configMsg)
-        {
-            LEAP_CONFIG_RESPONSE_EVENT config_response_evt;
-            StructMarshal<LEAP_CONFIG_RESPONSE_EVENT>.PtrToStruct(configMsg.eventStructPtr, out config_response_evt);
-            string config_key = "";
-            _configRequests.TryGetValue(config_response_evt.requestId, out config_key);
-            if (config_key != null)
-                _configRequests.Remove(config_response_evt.requestId);
-
-            Config.ValueType dataType;
-            object value;
-            uint requestId = config_response_evt.requestId;
-            if (config_response_evt.value.type != eLeapValueType.eLeapValueType_String)
-            {
-                switch (config_response_evt.value.type)
-                {
-                    case eLeapValueType.eLeapValueType_Boolean:
-                        dataType = Config.ValueType.TYPE_BOOLEAN;
-                        value = config_response_evt.value.boolValue;
-                        break;
-                    case eLeapValueType.eLeapValueType_Int32:
-                        dataType = Config.ValueType.TYPE_INT32;
-                        value = config_response_evt.value.intValue;
-                        break;
-                    case eLeapValueType.eLeapValueType_Float:
-                        dataType = Config.ValueType.TYPE_FLOAT;
-                        value = config_response_evt.value.floatValue;
-                        break;
-                    default:
-                        dataType = Config.ValueType.TYPE_UNKNOWN;
-                        value = new object();
-                        break;
-                }
-            }
-            else
-            {
-                LEAP_CONFIG_RESPONSE_EVENT_WITH_REF_TYPE config_ref_value;
-                StructMarshal<LEAP_CONFIG_RESPONSE_EVENT_WITH_REF_TYPE>.PtrToStruct(configMsg.eventStructPtr, out config_ref_value);
-                dataType = Config.ValueType.TYPE_STRING;
-                value = config_ref_value.value.stringValue;
-            }
-            SetConfigResponseEventArgs args = new SetConfigResponseEventArgs(config_key, dataType, value, requestId);
-
-            if (LeapConfigResponse != null)
-            {
-                LeapConfigResponse.DispatchOnContext(this, EventContext, args);
             }
         }
 

--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Controller.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Controller.cs
@@ -43,7 +43,6 @@ namespace Leap
         bool _disposed = false;
         bool _supportsMultipleDevices = true;
         string _serverNamespace = "Leap Service";
-        Config _config;
 
         /// <summary>
         /// The SynchronizationContext used for dispatching events.
@@ -871,13 +870,12 @@ namespace Leap
         /// 
         /// @since 1.0
         /// </summary>
+        [Obsolete("Config.cs is not used in Ultraleap's Tracking Service 5.X+. This will be removed in the next Major release")]
         public Config Config
         {
             get
             {
-                if (_config == null)
-                    _config = new Config(this._connection.ConnectionKey);
-                return _config;
+                return null;
             }
         }
 

--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Device.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Device.cs
@@ -121,14 +121,6 @@ namespace Leap
                 IsStreaming = true;
             else
                 IsStreaming = false;
-            if ((status & eLeapDeviceStatus.eLeapDeviceStatus_Smudged) == eLeapDeviceStatus.eLeapDeviceStatus_Smudged)
-                IsSmudged = true;
-            else
-                IsSmudged = false;
-            if ((status & eLeapDeviceStatus.eLeapDeviceStatus_Robust) == eLeapDeviceStatus.eLeapDeviceStatus_Robust)
-                IsLightingBad = true;
-            else
-                IsLightingBad = false;
             if ((status & eLeapDeviceStatus.eLeapDeviceStatus_LowResource) == eLeapDeviceStatus.eLeapDeviceStatus_LowResource)
                 IsLowResource = true;
             else
@@ -349,6 +341,7 @@ namespace Leap
         /// over the Leap Motion cameras.
         /// @since 3.0
         /// </summary>
+        [Obsolete("IsSmudged is not used in Ultraleap's Tracking Service 5.X+. This will be removed in the next Major release")]
         public bool IsSmudged { get; internal set; }
 
         /// <summary>
@@ -363,6 +356,7 @@ namespace Leap
         /// isLightingBad() is true. 
         /// @since 3.0 
         /// </summary>
+        [Obsolete("IsLightingBad is not used in Ultraleap's Tracking Service 5.X+. This will be removed in the next Major release")]
         public bool IsLightingBad { get; internal set; }
 
         /// <summary>

--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Events.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Events.cs
@@ -179,6 +179,7 @@ namespace Leap
     /// Provides the configuration key, whether the change was successful, and the id of the original change request.
     /// @since 3.0
     /// </summary>
+    [Obsolete("Config.cs is not used in Ultraleap's Tracking Service 5.X+. This will be removed in the next Major release")]
     public class SetConfigResponseEventArgs : LeapEventArgs
     {
         public SetConfigResponseEventArgs(string config_key, Config.ValueType dataType, object value, uint requestId) : base(LeapEvent.EVENT_CONFIG_RESPONSE)

--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/IController.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/IController.cs
@@ -24,7 +24,7 @@ namespace Leap
         long Now();
 
         bool IsConnected { get; }
-        Config Config { get; }
+
         DeviceList Devices { get; }
 
         event EventHandler<ConnectionEventArgs> Connect;


### PR DESCRIPTION
## Summary

Mark unused LeapC API as obsolete in preparation to be removed at next major version

## Contributor Tasks

- [x] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [x] Add a CHANGELOG entry for this change.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Test Cycle

N/A covered in regression pass at release

## Reviewer Tasks

- [ ] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [ ] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

Closes [UNITY-1248](https://ultrahaptics.atlassian.net/browse/UNITY-1248)

[UNITY-1248]: https://ultrahaptics.atlassian.net/browse/UNITY-1248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ