### PR TITLE
Feature/unity 1389 phys hands kinematic movement

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -14,9 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Android 	v5.17.1
 
 ### Added
-- LeapServiceProvider accessor for world space psoition of the Tracking Camera
-- LeapXRServiceProvider accessor for world space psoition of the Tracking Camera
-- (Physical hands) Ability to ignore collisions on single object or all children
+- LeapServiceProvider accessor for world space position of the Tracking Camera
+- LeapXRServiceProvider accessor for world space position of the Tracking Camera
+- (Physical Hands) Ability to ignore collisions on single object or all children
+- (Physical Hands) Added toggle to GrabHelper to allow kinematic object movement
 
 ### Changed
 - (Config) Additional uses of Config marked as Obsolete

--- a/Packages/Tracking/Physical Hands/Runtime/Scripts/Hard Contact/HardContactHand.cs
+++ b/Packages/Tracking/Physical Hands/Runtime/Scripts/Hard Contact/HardContactHand.cs
@@ -204,9 +204,9 @@ namespace Leap.Unity.PhysicalHands
                     contactingFingers++;
                 }
 
-                if (!hasFingerGrasped)
+                if (!contacting || hasFingerGrasped)
                 {
-                    fingerStiffness[fingerIndex] = hardContactParent.boneStiffness;
+                    fingerStiffness[fingerIndex] = Mathf.Lerp(fingerStiffness[fingerIndex], hardContactParent.boneStiffness, Time.fixedDeltaTime * 5);
                 }
             }
 
@@ -219,7 +219,7 @@ namespace Leap.Unity.PhysicalHands
             {
                 _contactFingerDisplacement = _overallFingerDisplacement * contactingFingers;
 
-                if (_displacementGrabCooldown > 0)
+                if (_displacementGrabCooldownCurrent > 0)
                 {
                     _displacementGrabCooldownCurrent -= Time.fixedDeltaTime;
 

--- a/Packages/Tracking/Physical Hands/Runtime/Scripts/Hard Contact/HardContactParent.cs
+++ b/Packages/Tracking/Physical Hands/Runtime/Scripts/Hard Contact/HardContactParent.cs
@@ -24,7 +24,7 @@ namespace Leap.Unity.PhysicalHands
         [SerializeField, HideInInspector, Range(0.01f, 0.5f), Tooltip("The maximum distance at which the hand will then jump back to the data hand.")]
         internal float teleportDistance = 0.1f;
         [SerializeField, HideInInspector]
-        internal float boneMass = 0.1f, boneStiffness = 100f, boneDamping = 1f;
+        internal float boneMass = 0.1f, boneStiffness = 100f, grabbedBoneStiffness = 10f, boneDamping = 1f;
 
         [SerializeField, HideInInspector]
         internal bool useProjectPhysicsIterations = false;

--- a/Packages/Tracking/Physical Hands/Runtime/Scripts/Helpers/GrabHelper.cs
+++ b/Packages/Tracking/Physical Hands/Runtime/Scripts/Helpers/GrabHelper.cs
@@ -17,6 +17,12 @@ namespace Leap.Unity.PhysicalHands
         [SerializeField]
         private PhysicalHandsManager physicalHandsManager;
 
+        [Tooltip("Should kinematic objects be changed to non-kinematic for movement?" +
+                "\n\nIf true, rigidbodies will be changed to non-kinematic when grabbed, and returned to kinematic when released" +
+                "\n\nIf false, kinematic objects will be positioned through kinematic methods" +
+                "\n\nWarning: Hard Contact hands can jitter when moving a kinematic object")]
+        public bool useNonKinematicMovementOnly = true;
+
         private ContactHand _leftContactHand { get { return physicalHandsManager.ContactParent.LeftHand; } }
         private ContactHand _rightContactHand { get { return physicalHandsManager.ContactParent.RightHand; } }
 

--- a/Packages/Tracking/Physical Hands/Runtime/Scripts/Helpers/GrabHelper.cs
+++ b/Packages/Tracking/Physical Hands/Runtime/Scripts/Helpers/GrabHelper.cs
@@ -326,9 +326,9 @@ namespace Leap.Unity.PhysicalHands
             hand = null;
             if (_grabHelperObjects.TryGetValue(rigid, out GrabHelperObject helper))
             {
-                if (helper.GrabState == GrabHelperObject.State.Grab && helper.GrabbingHands.Count > 0)
+                if(helper.currentlyGrabbingHand != null)
                 {
-                    hand = helper.GrabbingHands[helper.GrabbingHands.Count - 1];
+                    hand = helper.currentlyGrabbingHand;
                     return true;
                 }
             }


### PR DESCRIPTION
## Summary

Add toggle to GrabHelper to allow kinematic movement of grabbed objects. This has known instability when using Hard Contact hands, so is warned and non-kinematic movement is used by default

## Contributor Tasks

- [x] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [x] Add a CHANGELOG entry for this change.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Test Cycle

[_Link to the test cycle here._](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testPlayer/UNITY-R112)

## Reviewer Tasks

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [x] Documentation has been reviewed.
- [x] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

Closes [UNITY-1389](https://ultrahaptics.atlassian.net/browse/UNITY-1389)

[UNITY-1389]: https://ultrahaptics.atlassian.net/browse/UNITY-1389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ