### PR TITLE
Added changes to low level code to support camera matrix look up and …

### DIFF
--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Controller.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Controller.cs
@@ -987,5 +987,26 @@ namespace Leap
         {
             _hasInitialized = false;
         }
+
+        public UnityEngine.Matrix4x4 LeapExtrinsicCameraMatrix(Image.CameraType camera, Device device)
+        {
+            float[] data = new float[16];
+            return _connection.LeapExtrinsicCameraMatrix(camera, device);
+        }
+
+        public UnityEngine.Vector3 RectilinearToPixel(Image.CameraType camera, UnityEngine.Vector3 ray)
+        {
+            return _connection.RectilinearToPixel(camera, ray);
+        }
+
+        public UnityEngine.Vector3 RectilinearToPixelEx(Image.CameraType camera, UnityEngine.Vector3 ray, Device device)
+        {
+            return _connection.RectilinearToPixelEx(device.Handle, camera, ray);
+        }
+
+        public UnityEngine.Vector3 PixelToRectilinearEx(Image.CameraType camera, UnityEngine.Vector3 pixel, Device device)
+        {
+            return _connection.PixelToRectilinearEx(device.Handle, camera, Image.CalibrationType.INFRARED, pixel);
+        }
     }
 }

--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/LeapC.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/LeapC.cs
@@ -1103,7 +1103,7 @@ namespace LeapInternal
 
         [DllImport("LeapC", EntryPoint = "LeapPixelToRectilinearEx")]
         public static extern LEAP_VECTOR LeapPixelToRectilinearEx(IntPtr hConnection,
-          IntPtr hDevice, eLeapPerspectiveType camera, eLeapCameraCalibrationType calibrationType, LEAP_VECTOR pixel);
+          IntPtr hDevice, eLeapPerspectiveType camera, LEAP_VECTOR pixel);
 
         [DllImport("LeapC", EntryPoint = "LeapRectilinearToPixel")]
         public static extern LEAP_VECTOR LeapRectilinearToPixel(IntPtr hConnection,
@@ -1240,5 +1240,11 @@ namespace LeapInternal
 
         [DllImport("LeapC", EntryPoint = "LeapGetVersion")]
         public static extern eLeapRS GetVersion(IntPtr hConnection, eLeapVersionPart versionPart, ref LEAP_VERSION pVersion);
+
+        [DllImport("LeapC", EntryPoint = "LeapExtrinsicCameraMatrix")]
+        public static extern eLeapRS LeapExtrinsicCameraMatrix(IntPtr hConnection, eLeapPerspectiveType camera, [MarshalAs(UnmanagedType.LPArray, SizeConst = 16)] float[] extrinsicMatrix);
+
+        [DllImport("LeapC", EntryPoint = "LeapExtrinsicCameraMatrixEx")]
+        public static extern eLeapRS LeapExtrinsicCameraMatrixEx(IntPtr hConnection, IntPtr hDevice, eLeapPerspectiveType camera, [MarshalAs(UnmanagedType.LPArray, SizeConst = 16)] float[] extrinsicMatrix);
     }
 }


### PR DESCRIPTION
…correct LeapPixelToRectilinearEx signature

## Summary

Adds low level support for reading the camera matrix, fixes issue with the LeapPixelToRectilinearEx signature in LeapC.cs so that it matches the native header implementation.

## Contributor Tasks

- [ ] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [ ] Add a CHANGELOG entry for this change.
- [ ] Ensure documentation requirements are met e.g., public API is commented.
- [ ] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Test Cycle

_Link to the test cycle here._

## Reviewer Tasks

- [ ] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [ ] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_

## Pull Request Templates

Switch template by going to preview and clicking the link - note it will not work if you've made any changes to the description.

- [default.md](?expand=1) - for contributions to stable packages.
- [release.md](?expand=1&template=release.md) - for release merge requests.

**You are currently using: default.md**

Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.
