### PR TITLE
Added an event for the raw tracking frame

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Android 	v5.17.1
 
 ### Added
-- 
+- Now raise a RawFrameEvent for the raw tracking frame
 
 ### Changed
 - (Config) Additional uses of Config marked as Obsolete
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Errors in Editor when using pre-2023.3.18 LTS due to FindObjectByType issue
 - (Physical Hands) Objects are sticky when they ignore collision with hard contact hands
+- Issue with the method signature for LeapPixelToRectilinearEx
 
 ## [6.14.0] - 24/01/24
 
@@ -36,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Physical Hands. This introduces a new way of interacting with object in the virtual world using your hands and unitys physics engine.
+- Support for reading the camera matrix
 
 ### Changed
 - Removed Physics Hands from the preview package as Physical Hands has replaced it.

--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Connection.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Connection.cs
@@ -123,6 +123,7 @@ namespace LeapInternal
         public EventHandler<DeviceFailureEventArgs> LeapDeviceFailure;
         public EventHandler<PolicyEventArgs> LeapPolicyChange;
         public EventHandler<FrameEventArgs> LeapFrame;
+        public EventHandler<RawFrameEventArgs> LeapRawFrameData;
         public EventHandler<InternalFrameEventArgs> LeapInternalFrame;
         public EventHandler<LogEventArgs> LeapLogEvent;
         [Obsolete("Config is not used in Ultraleap's Tracking Service 5.X+. This will be removed in the next Major release")]
@@ -407,6 +408,11 @@ namespace LeapInternal
         private void handleTrackingMessage(ref LEAP_TRACKING_EVENT trackingMsg, UInt32 deviceID)
         {
             Frames.Put(ref trackingMsg);
+
+            if (LeapRawFrameData != null)
+            {
+                LeapRawFrameData.DispatchOnContext(this, EventContext, new RawFrameEventArgs(trackingMsg));
+            }
 
             if (LeapFrame != null)
             {

--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Controller.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Controller.cs
@@ -133,6 +133,21 @@ namespace Leap
         }
 
         /// <summary>
+        ///  Dispatched when the raw frame data is ready
+        /// </summary>
+        public event EventHandler<RawFrameEventArgs> RawFrameReady
+        {
+            add
+            {
+                _connection.LeapRawFrameData += value;
+            }
+            remove
+            {
+                _connection.LeapRawFrameData -= value;
+            }
+        }
+
+        /// <summary>
         /// Dispatched when an internal tracking frame is ready.
         /// @since 3.0
         /// </summary>

--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Events.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Events.cs
@@ -51,6 +51,43 @@ namespace Leap
     }
 
     /// <summary>
+    /// Provides access to the raw leap frame data
+    /// </summary>
+    public class RawFrameEventArgs : LeapEventArgs
+    {
+        public bool IsTrackingLeftHand { get; set; }
+        public LEAP_HAND LeftHand { get; set; }
+
+        public bool IsTrackingRightHand { get; set; }
+        public LEAP_HAND RightHand { get; set; }
+
+        public RawFrameEventArgs(LEAP_TRACKING_EVENT trackingMsg) : base(LeapEvent.EVENT_FRAME)
+        {
+            IsTrackingLeftHand = false;
+            IsTrackingRightHand = false;
+
+            for (int i = (int)trackingMsg.nHands; i-- != 0;)
+            {
+                LEAP_HAND hand;
+                StructMarshal<LEAP_HAND>.ArrayElementToStruct(trackingMsg.pHands, i, out hand);
+
+                switch (hand.type)
+                {
+                    case eLeapHandType.eLeapHandType_Left:
+                        LeftHand = hand;
+                        IsTrackingLeftHand = true;
+                        break;
+
+                    case eLeapHandType.eLeapHandType_Right:
+                        RightHand = hand;
+                        IsTrackingRightHand = true;
+                        break;
+                }
+            }
+        }
+    }
+
+    /// <summary>
     /// Dispatched when a tracking frame is ready.
     ///
     /// Provides the Frame object as an argument.


### PR DESCRIPTION
## Summary

Added an event for when the raw tracking frame is received.

## Contributor Tasks

- [ ] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [ ] Add a CHANGELOG entry for this change.
- [ ] Ensure documentation requirements are met e.g., public API is commented.
- [ ] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Test Cycle

_Link to the test cycle here._

## Reviewer Tasks

- [ ] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [ ] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_

## Pull Request Templates

Switch template by going to preview and clicking the link - note it will not work if you've made any changes to the description.

- [default.md](?expand=1) - for contributions to stable packages.
- [release.md](?expand=1&template=release.md) - for release merge requests.

**You are currently using: default.md**

Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.
