### PR TITLE
Ensure LeapC hinting arrays are marshalled correctly

### DIFF
--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/LeapC.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/LeapC.cs
@@ -1263,8 +1263,20 @@ namespace LeapInternal
             public string serial;
             public string type;
         }
+        
+        public static eLeapRS SetDeviceHints(IntPtr hConnection, IntPtr hDevice, string[] hints)
+        {
+            // Ensure the final element of the array is null terminated.
+            if (hints.Length == 0 || hints[^1] != null)
+            {
+                Array.Resize(ref hints, hints.Length + 1);
+                hints[^1] = null;
+            }
 
+            return SetDeviceHintsInternal(hConnection, hDevice, hints);
+        }
+        
         [DllImport("LeapC", EntryPoint = "LeapSetDeviceHints")]
-        public static extern eLeapRS SetDeviceHints(IntPtr hConnection, IntPtr hDevice, string[] hints);
+        private static extern eLeapRS SetDeviceHintsInternal(IntPtr hConnection, IntPtr hDevice, string[] hints);
     }
 }


### PR DESCRIPTION
## Summary

LeapC hints are required to be marshalled as a null-terminated array. The currently implementation is not correctly ensuring there is a null terminator in the list.

## Contributor Tasks

- [ ] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [ ] Add a CHANGELOG entry for this change.
- [ ] Ensure documentation requirements are met e.g., public API is commented.
- [ ] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Test Cycle

_Link to the test cycle here._

## Reviewer Tasks

- [ ] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [ ] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_

## Pull Request Templates

Switch template by going to preview and clicking the link - note it will not work if you've made any changes to the description.

- [default.md](?expand=1) - for contributions to stable packages.
- [release.md](?expand=1&template=release.md) - for release merge requests.

**You are currently using: default.md**

Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.
