### PR TITLE
Bug/unity 1447 nans ph soft contact open xr android

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (UI Input Preview) Null UIInput events cause unnecessary error logs
 - Memory increase when repeatedly opening scenes with LeapServiceProviders
 - ThreadAbort when changing scenes in editor that use multidevice or display the tracking device gizmo
-
+- (Physical Hands) Soft Contact NAN collider error when using OpenXR tracking on Android devices
 
 
 ## [6.14.0] - 24/01/24

--- a/Packages/Tracking/Physical Hands/Runtime/Scripts/ContactHand.cs
+++ b/Packages/Tracking/Physical Hands/Runtime/Scripts/ContactHand.cs
@@ -213,7 +213,7 @@ namespace Leap.Unity.PhysicalHands
 
                     boneArrayIndex = fingerIndex * FINGER_BONES + jointIndex;
 
-                    bones[boneArrayIndex] = new GameObject($"{HandUtils.FingerIndexToName(fingerIndex)} {HandUtils.JointIndexToName(jointIndex + 1)}", boneType, typeof(CapsuleCollider)).GetComponent<ContactBone>();
+                    bones[boneArrayIndex] = new GameObject($"{HandUtils.FingerIndexToName(fingerIndex)} {HandUtils.JointIndexToName(jointIndex + 1)}", boneType).GetComponent<ContactBone>();
                     bone = bones[boneArrayIndex];
                     bone.gameObject.layer = contactParent.physicalHandsManager.HandsResetLayer;
                     bone.transform.SetParent(lastTransform);
@@ -221,7 +221,7 @@ namespace Leap.Unity.PhysicalHands
                     bone.finger = fingerIndex;
                     bone.joint = jointIndex;
 
-                    bone.boneCollider = bone.GetComponent<CapsuleCollider>();
+                    bone.boneCollider = bone.gameObject.AddComponent<CapsuleCollider>();
                     ContactUtils.SetupBoneCollider(bone.boneCollider, leapHand.Fingers[fingerIndex].Bone((Bone.BoneType)(jointIndex + 1)));
                     bone.contactHand = this;
 


### PR DESCRIPTION
## Summary

Fixes an issue where NANs are produced by Unity when adjusting colliders associated with Soft Contact Hands while using OpenXR on standalone Android devices

## Contributor Tasks

- [x] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [x] Add a CHANGELOG entry for this change.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Test Cycle

[_Link to the test cycle here._](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testPlayer/UNITY-R114)

## Reviewer Tasks

- [ ] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [ ] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

Closes [UNITY-1447](https://ultrahaptics.atlassian.net/browse/UNITY-1447)


[UNITY-1447]: https://ultrahaptics.atlassian.net/browse/UNITY-1447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ