### PR TITLE
Change the target colour palette values for joint confidence targets …

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -14,13 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Android 	v5.17.1
 
 ### Added
-- LeapServiceProvider accessor for world space psoition of the Tracking Camera
-- LeapXRServiceProvider accessor for world space psoition of the Tracking Camera
-- LeapServiceProvider accessor for world space position of the Tracking Camera
-- LeapXRServiceProvider accessor for world space position of the Tracking Camera
-- (Physical Hands) Ability to ignore collisions on single object or all children
-- (Physical Hands) Added toggle to GrabHelper to allow kinematic object movement
-- (Physical Hands) Ignore Physical hands component can now choose which hand(s) it should be applied to
 
 ### Changed
 - (Config) Additional uses of Config marked as Obsolete
@@ -28,26 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Example content to be split by XR, Tabletop and URP Examples
 - Combined example content to be part of the main Ultraleap Tracking .unitypackage when importing via .unitypackage
 - Added fog and gradient sky for all XR example scenes
-- (Hand Rays) Exposed dot product used to test if the hand is facing camera
-- (Hinting) Added support for startup setting of Hand Tracking Hints via the Ultraleap Settings window
-- (Hinting) Added support for runtime changing of Hand Tracking Hints via static HandTrackingHintManager
-- Access of Physical Hands extensions
-- Added public accessors to various Physical Hands utilities
 
 ### Fixed
 - Errors in Editor when using pre-2023.3.18 LTS due to FindObjectByType issue
 - (Physical Hands) Objects are sticky when they ignore collision with hard contact hands
-- (Physical Hands) Ability to toggle ignore Physical hands options from the inspector at runtime.
-- (Locomotion) IsPinching wouldn't fire when between Activate and Deactivate values in LightweightPinchDetector
-- (Physical Hands) Soft contact button difficult to press in physical hands playground scene when not using UI layer
-- (Physical Hands) Disabled Ignore Physical hands components still affecting grab and collision at runtime
-- (Physical Hands) Button Prefab uses mesh from example assets
-- (Physical Hands) Button gets stuck down if disabled after pressing
-- (UI Input Preview) Null UIInput events cause unnecessary error logs
-- Memory increase when repeatedly opening scenes with LeapServiceProviders
-- ThreadAbort when changing scenes in editor that use multidevice or display the tracking device gizmo
-
-
+- Update target colour palette values for JointOcclusion to account for unexpected changes when rendered to the render texture
 
 ## [6.14.0] - 24/01/24
 


### PR DESCRIPTION
…in the render texture as they appear altered from the expected values

## Summary

When investigating the Lumi work, it appeared that the joint values calculated in the render texture, which are used as the target pixel colours for counting / calculating joint visibility do not match the source values used to render the capsule hands. This is unexpected but several days of looking for potential causes failed to determine the issue. This code contains new target values, based on the pixel colours in the rendertexture and also some code that can be used to log out the colours, which is useful in checking if this is an issue that occurs across multiple systems/versions/platforms.

## Contributor Tasks

- [ ] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [ ] Add a CHANGELOG entry for this change.
- [ ] Ensure documentation requirements are met e.g., public API is commented.
- [ ] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Test Cycle

_Link to the test cycle here._

## Reviewer Tasks

- [ ] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [ ] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_

## Pull Request Templates

Switch template by going to preview and clicking the link - note it will not work if you've made any changes to the description.

- [default.md](?expand=1) - for contributions to stable packages.
- [release.md](?expand=1&template=release.md) - for release merge requests.

**You are currently using: default.md**

Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.
