### PR TITLE
added option to not show the attachment hand warning again

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (Physical Hands) Ability to ignore collisions on single object or all children
 - (Physical Hands) Added toggle to GrabHelper to allow kinematic object movement
 - (Physical Hands) Ignore Physical hands component can now choose which hand(s) it should be applied to
+- (Attachment Hands) Do not show warning again this session when deleting attachment points
 
 ### Changed
 - (Config) Additional uses of Config marked as Obsolete

--- a/Packages/Tracking/Core/Editor/Scripts/AttachmentHandsEditor.cs
+++ b/Packages/Tracking/Core/Editor/Scripts/AttachmentHandsEditor.cs
@@ -109,7 +109,7 @@ namespace Leap.Unity.Attachments
             {
                 if (EditorUtility.DisplayDialog("Delete all attachments?",
                                                    "Doing so will destroy all child GameObjects of " + target.gameObject.name + ".",
-                                                   "Delete", "Cancel"))
+                                                   "Delete", "Cancel", DialogOptOutDecisionType.ForThisMachine, "UL attachment hands popup"))
                 {
                     target.attachmentPoints = AttachmentPointFlags.None;
                     GUIUtility.ExitGUI();
@@ -142,7 +142,7 @@ namespace Leap.Unity.Attachments
                                                    "Deleting the " + flag + " attachment point will destroy "
                                                  + "its GameObject and any of its non-Attachment-Point children, "
                                                  + "and will remove any components attached to it.",
-                                                   "Delete " + flag + " Attachment Point", "Cancel"))
+                                                   "Delete " + flag + " Attachment Point", "Cancel", DialogOptOutDecisionType.ForThisMachine, "UL attachment hands popup"))
                 {
                     target.attachmentPoints = attachmentPoints & (~flag); // Set flag bit to 0.
                     GUIUtility.ExitGUI();

--- a/Packages/Tracking/Core/Runtime/Scripts/UltraleapSettings.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/UltraleapSettings.cs
@@ -127,11 +127,18 @@ namespace Leap.Unity
 
             using (new EditorGUI.IndentLevelScope())
             {
+                // Android Build Warnings
                 SerializedProperty showAndroidBuildArchitectureWarning = settings.FindProperty("showAndroidBuildArchitectureWarning");
                 showAndroidBuildArchitectureWarning.boolValue = EditorGUILayout.ToggleLeft("Show Android Architecture build warning", showAndroidBuildArchitectureWarning.boolValue);
 
+                // Physical Hands Settings Warnings
                 SerializedProperty showPhysicalHandsPhysicsSettingsWarning = settings.FindProperty("showPhysicalHandsPhysicsSettingsWarning");
                 showPhysicalHandsPhysicsSettingsWarning.boolValue = EditorGUILayout.ToggleLeft("Show Physical Hands settings warning", showPhysicalHandsPhysicsSettingsWarning.boolValue);
+
+                // Attachment Hands delete content warnings
+                bool curValue = !EditorUtility.GetDialogOptOutDecision(DialogOptOutDecisionType.ForThisMachine, "UL attachment hands popup");
+                curValue = EditorGUILayout.ToggleLeft("Show clear Attachment Hands deletes content warning", curValue);
+                EditorUtility.SetDialogOptOutDecision(DialogOptOutDecisionType.ForThisMachine, "UL attachment hands popup", !curValue);
             }
 
             EditorGUILayout.Space(30);


### PR DESCRIPTION
## Contributor Tasks

- [x] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [x] Add a CHANGELOG entry for this change.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Test Cycle

[_Link to the test cycle here._](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testPlayer/UNITY-R115)

## Reviewer Tasks

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [x] Documentation has been reviewed.
- [x] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

Closes [UNITY-1443](https://ultrahaptics.atlassian.net/browse/UNITY-1443)


[UNITY-1443]: https://ultrahaptics.atlassian.net/browse/UNITY-1443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ