### PR TITLE
Add extra check when we unvalidate hover rigids to make sure grab is dropped when object is disabled

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ThreadAbort when changing scenes in editor that use multidevice or display the tracking device gizmo
 - (Hand Binder) incorrect upperArm name definition for elbow joint
 - (Physical Hands) Soft Contact NAN collider error when using OpenXR tracking on Android devices
+- (Physical Hands) Hand stuck in pose, unable to grab if object is disabled while grabbing
 
 
 ## [6.14.0] - 24/01/24

--- a/Packages/Tracking/Physical Hands/Runtime/Scripts/Helpers/GrabHelper.cs
+++ b/Packages/Tracking/Physical Hands/Runtime/Scripts/Helpers/GrabHelper.cs
@@ -278,6 +278,15 @@ namespace Leap.Unity.PhysicalHands
                     {
                         // Ensure we release the object first
                         _grabHelperObjects[rigid].ReleaseObject();
+
+                        foreach (var bone in _leftContactHand.bones)
+                        {
+                            bone.RemoveGrabbing(rigid);
+                        }
+                        foreach (var bone in _rightContactHand.bones)
+                        {
+                            bone.RemoveGrabbing(rigid);
+                        }
                     }
                     _grabHelperObjects[rigid].ReleaseHelper();
                     _grabHelperObjects.Remove(rigid);


### PR DESCRIPTION
…lost if not hovering anymore

## Summary

_Add a Summary here._

## Contributor Tasks

- [x] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [x] Add a CHANGELOG entry for this change.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Test Cycle

_Link to the test cycle here._

## Reviewer Tasks

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [x] Documentation has been reviewed.
- [x] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_

## Pull Request Templates

Switch template by going to preview and clicking the link - note it will not work if you've made any changes to the description.

- [default.md](?expand=1) - for contributions to stable packages.
- [release.md](?expand=1&template=release.md) - for release merge requests.

**You are currently using: default.md**

Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.
