### PR TITLE
Add ApiLayerService intent when missing for OpenXR hand-tracking

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (Physical Hands) Errors when destroying objects that are grabbed
 - (Physical Hands) Errors when adding Physical Hands Manager prefab for the first time
 - Use of Device Transforms does not apply rotations
+- OpenXR API Layer Service query intent was missing sometimes, preventing API layers functioning correctly
 
 
 ## [6.14.0] - 24/01/24

--- a/Packages/Tracking/OpenXR/Editor/Scripts/HandTrackingFeatureBuildHooks.cs
+++ b/Packages/Tracking/OpenXR/Editor/Scripts/HandTrackingFeatureBuildHooks.cs
@@ -10,6 +10,7 @@ namespace Ultraleap.Tracking.OpenXR
     public partial class HandTrackingFeatureBuildHooks : OpenXRFeatureBuildHooks
     {
         private const string OpenXRPackageRuntimeService = "org.khronos.openxr.OpenXRRuntimeService";
+        private const string OpenXRPackageApiLayerService = "org.khronos.openxr.OpenXRApiLayerService";
 
         private const string MetaHandTrackingFeature = "oculus.software.handtracking";
         private const string MetaHandTrackingPermission = "com.oculus.permission.HAND_TRACKING";
@@ -29,8 +30,10 @@ namespace Ultraleap.Tracking.OpenXR
 
             if (PlayerSettings.Android.minSdkVersion >= AndroidSdkVersions.AndroidApiLevel30)
             {
-                // Intent query is required for OpenXR to work correctly.
+                // These intent queries are required for OpenXR runtimes and API layers to operate correctly, not all
+                // loaders correctly include them so add them if they are missing to ensure applications work correctly.
                 manifest.AddQueriesIntentAction(OpenXRPackageRuntimeService);
+                manifest.AddQueriesIntentAction(OpenXRPackageApiLayerService);
             }
 
             if (feature.metaPermissions)


### PR DESCRIPTION
## Summary

This fixes a possibly missing API Layer Service android intent request which some platform support features miss out.

## Contributor Tasks

- [ ] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [x] Add a CHANGELOG entry for this change.
- [ ] Ensure documentation requirements are met e.g., public API is commented.
- [ ] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Test Cycle

_Link to the test cycle here._

## Reviewer Tasks

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [ ] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_

## Pull Request Templates

Switch template by going to preview and clicking the link - note it will not work if you've made any changes to the description.

- [default.md](?expand=1) - for contributions to stable packages.
- [release.md](?expand=1&template=release.md) - for release merge requests.

**You are currently using: default.md**

Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.
