### PR TITLE
Check targetSdkVersion not minSdkVersion for Android OpenXR

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (Physical Hands) Errors when adding Physical Hands Manager prefab for the first time
 - Use of Device Transforms does not apply rotations
 - OpenXR API Layer Service query intent was missing sometimes, preventing API layers functioning correctly
+- OpenXR checks minSdkVersion rather than targetSdkVersion for query intents
 
 
 ## [6.14.0] - 24/01/24

--- a/Packages/Tracking/OpenXR/Editor/Scripts/HandTrackingFeatureBuildHooks.cs
+++ b/Packages/Tracking/OpenXR/Editor/Scripts/HandTrackingFeatureBuildHooks.cs
@@ -28,7 +28,7 @@ namespace Ultraleap.Tracking.OpenXR
             var manifest = new AndroidManifest(GetAndroidManifestPath(path));
             var feature = OpenXRSettings.ActiveBuildTargetInstance.GetFeature<HandTrackingFeature>();
 
-            if (PlayerSettings.Android.minSdkVersion >= AndroidSdkVersions.AndroidApiLevel30)
+            if (PlayerSettings.Android.targetSdkVersion >= AndroidSdkVersions.AndroidApiLevel30)
             {
                 // These intent queries are required for OpenXR runtimes and API layers to operate correctly, not all
                 // loaders correctly include them so add them if they are missing to ensure applications work correctly.

--- a/Packages/Tracking/OpenXR/Runtime/Scripts/HandTrackingFeature.cs
+++ b/Packages/Tracking/OpenXR/Runtime/Scripts/HandTrackingFeature.cs
@@ -226,32 +226,6 @@ namespace Ultraleap.Tracking.OpenXR
 #if UNITY_EDITOR
         protected override void GetValidationChecks(List<ValidationRule> rules, BuildTargetGroup targetGroup)
         {
-#if UNITY_ANDROID
-            // If building for Android, check that we are targeting Android API 29 for maximum compatibility.
-            rules.Add(new ValidationRule(this)
-            {
-                message = "Android target SDK version is not set to 29, hand-tracking may not work on devices " +
-                          "running Android 11 or higher",
-                helpLink = "https://registry.khronos.org/OpenXR/specs/1.0/loader.html#android-active-runtime-location",
-                helpText = "OpenXR applications should not target API levels higher than 29 for maximum " +
-                           "compatibility, as runtimes may need to query and load classes from their own packages, " +
-                           "which are necessarily not listed in the <queries> tag above.",
-                checkPredicate = () => PlayerSettings.Android.targetSdkVersion == AndroidSdkVersions.AndroidApiLevel29,
-                error = false,
-                fixItAutomatic = true,
-                fixItMessage = "Set the Android target SDK version to 29",
-                fixIt = () =>
-                {
-                    if (PlayerSettings.Android.minSdkVersion > AndroidSdkVersions.AndroidApiLevel29)
-                    {
-                        PlayerSettings.Android.minSdkVersion = AndroidSdkVersions.AndroidApiLevel29;
-                    }
-
-                    PlayerSettings.Android.targetSdkVersion = AndroidSdkVersions.AndroidApiLevel29;
-                },
-            });
-#endif
-
             // Check the active input handling supports New (for OpenXR) and Legacy (for Ultraleap Plugin support).
             rules.Add(new ValidationRule(this)
             {


### PR DESCRIPTION
## Summary

This changes the check in the manifest modifications to check `targetSdkVersion` not `minSdkVersion` for whether or not to add the package query statements. This was incorrect and `targetSdkVersion` should be used according to the [Android Documentation](https://developer.android.com/training/package-visibility).

This also means we can remove the warning for target/min sdk version that was previously required, as we now add the required statements if they are missing.

## Contributor Tasks

- [ ] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [ ] Add a CHANGELOG entry for this change.
- [ ] Ensure documentation requirements are met e.g., public API is commented.
- [ ] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Test Cycle

_Link to the test cycle here._

## Reviewer Tasks

- [x] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [ ] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_

## Pull Request Templates

Switch template by going to preview and clicking the link - note it will not work if you've made any changes to the description.

- [default.md](?expand=1) - for contributions to stable packages.
- [release.md](?expand=1&template=release.md) - for release merge requests.

**You are currently using: default.md**

Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.
