### PR TITLE
floats in Physical Hands Settings should use localized values to account for comma decimals

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use of Device Transforms does not apply rotations
 - OpenXR API Layer Service query intent was missing sometimes, preventing API layers functioning correctly
 - OpenXR checks minSdkVersion rather than targetSdkVersion for query intents
+- (Physical Hands) PhysHands Settings are not localized when using decimals
 
 
 ## [6.14.0] - 24/01/24

--- a/Packages/Tracking/Physical Hands/Editor/Scripts/PhysicalHandsSettings.cs
+++ b/Packages/Tracking/Physical Hands/Editor/Scripts/PhysicalHandsSettings.cs
@@ -67,7 +67,7 @@ namespace Leap.Unity.PhysicalHands
                     new RecommendedSetting()
                     {
                         property = _physicsManager.FindProperty(ID_SLEEP_THRESHOLD),
-                        recommended = "0.001",
+                        recommended = 0.001f.ToString(),
                         description = "Increases the realism of your physics objects e.g. allows objects to correctly rest"
                     }
                 },
@@ -85,7 +85,7 @@ namespace Leap.Unity.PhysicalHands
                     new RecommendedSetting()
                     {
                         property = _physicsManager.FindProperty(ID_DEFAULT_CONTACT_OFFSET),
-                        recommended = "0.001",
+                        recommended = 0.001f.ToString(),
                         description = "Distance used by physics sim to generate collision contacts. "
                     }
                 },
@@ -198,7 +198,7 @@ namespace Leap.Unity.PhysicalHands
                     new RecommendedSetting()
                     {
                         property = _timeManager.FindProperty(ID_FIXED_TIMESTEP),
-                        recommended = "0.011111",
+                        recommended = 0.011111f.ToString(),
                         description = "Makes your app physics run smoother.",
                         impactsPerformance = true
                     }


### PR DESCRIPTION
Addresses [this issue](https://github.com/ultraleap/UnityPlugin/issues/1593)

## Contributor Tasks

- [x] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [x] Add a CHANGELOG entry for this change.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Test Cycle

[_Link to the test cycle here._](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testPlayer/UNITY-R138)

## Reviewer Tasks

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [x] Documentation has been reviewed.
- [x] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

Closes [UNITY-1504](https://ultrahaptics.atlassian.net/browse/UNITY-1504)
