### PR TITLE
add utils for trygetcomponents and make GrabHelperObject use TryGetComponents instead of TryGetComponent

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Turntable and Pullcord example scene now uses Physical Hands
 - Physical Hands Playground uses new PhysicalHandsButtons and Toggles
 - Grab Ball uses Physical Hands rather than Interaction Engine
+- Physical Hands events are sent to all event interfaces attached to the interacted rigidbody
 
 ### Fixed
 - 

--- a/Packages/Tracking/Core/Runtime/Scripts/Utils/Utils.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Utils/Utils.cs
@@ -1198,6 +1198,111 @@ namespace Leap.Unity
 #endif
         }
 
+        /// <summary>
+        /// Try to get all components of type from the provided Component's GameObject
+        /// </summary>
+        public static bool TryGetComponents<T>(this Component source, out T[] components)
+        {
+            if(source.TryGetComponent<T>(out _))
+            {
+                components = source.GetComponents<T>();
+                return true;
+            }
+
+            components = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Try to get the given component of type from the provided Component's Parent
+        /// </summary>
+        public static bool TryGetComponentInParent<T>(this Component source, out T component)
+        {
+            if(source.transform.parent != null)
+            {
+                return source.transform.parent.TryGetComponent(out component);
+            }
+
+            component = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Try to get the given components of type from the provided Component's Parent
+        /// </summary>
+        public static bool TryGetComponentsInParent<T>(this Component source, out T[] components)
+        {
+            if (source.transform.parent != null)
+            {
+                return source.transform.parent.TryGetComponents(out components);
+            }
+
+            components = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Try to get the given component of type from the provided Component's self or children
+        /// </summary>
+        public static bool TryGetComponentInChildren<T>(this Component source, out T component, bool includeSelf = true, bool includeInactive = false)
+        {
+            if(!source.gameObject.activeInHierarchy && !includeInactive) // No children can be active either
+            {
+                component = default;
+                return false;
+            }
+
+            if(includeSelf && source.TryGetComponent(out component))
+            {
+                return true;
+            }
+            else
+            {
+                foreach(Transform child in source.transform)
+                {
+                    component = child.GetComponentInChildren<T>(includeInactive);
+
+                    if(component != null)
+                    {
+                        return true;
+                    }
+                }
+            }    
+
+            component = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Try to get the given component of type from the provided Component's self or children
+        /// </summary>
+        public static bool TryGetComponentsInChildren<T>(this Component source, out T[] components, bool includeSelf = true, bool includeInactive = false)
+        {
+            if(includeSelf)
+            {
+                components = source.GetComponentsInChildren<T>(includeInactive);
+                return components != null;
+            }
+            else
+            {
+                List<T> componentList = new List<T>();
+
+                foreach (Transform child in source.transform)
+                {
+                    componentList.AddRange(child.GetComponentsInChildren<T>(includeInactive));
+                }
+
+                if(componentList.Count > 0)
+                {
+                    components = componentList.ToArray();
+                    return true;
+                }
+            }
+
+            components = default;
+            return false;
+        }
+
         #endregion
 
         #region Transform Utils

--- a/Packages/Tracking/Physical Hands/Runtime/Scripts/Helpers/GrabHelperObject.cs
+++ b/Packages/Tracking/Physical Hands/Runtime/Scripts/Helpers/GrabHelperObject.cs
@@ -252,17 +252,23 @@ namespace Leap.Unity.PhysicalHands
                 {
                     if (_grabbableHandsValues[i].isContacting)
                     {
-                        if (_rigid.TryGetComponent<IPhysicalHandContact>(out var physicalHandContact))
+                        if(_rigid.TryGetComponents<IPhysicalHandContact>(out var physicalHandContacts))
                         {
-                            physicalHandContact.OnHandContactExit(_grabbableHands[i]);
+                            foreach(var contactEventReceiver in physicalHandContacts)
+                            {
+                                contactEventReceiver.OnHandContactExit(_grabbableHands[i]);
+                            }
                         }
 
                         _grabbableHands[i].physicalHandsManager.OnHandContactExit(_grabbableHands[i], _rigid);
                     }
 
-                    if (_rigid.TryGetComponent<IPhysicalHandHover>(out var physicalHandHover))
+                    if (_rigid.TryGetComponents<IPhysicalHandHover>(out var physicalHandHovers))
                     {
-                        physicalHandHover.OnHandHoverExit(_grabbableHands[i]);
+                        foreach (var hoverEventReceiver in physicalHandHovers)
+                        {
+                            hoverEventReceiver.OnHandHoverExit(_grabbableHands[i]);
+                        }
                     }
 
                     _grabbableHands[i].physicalHandsManager.OnHandHoverExit(_grabbableHands[i], _rigid);
@@ -314,9 +320,12 @@ namespace Leap.Unity.PhysicalHands
                 _grabbableHands.RemoveAt(index);
                 _grabbableHandsValues.RemoveAt(index);
 
-                if (_rigid != null && _rigid.TryGetComponent<IPhysicalHandHover>(out var physicalHandHover))
+                if (_rigid != null && _rigid.TryGetComponents<IPhysicalHandHover>(out var physicalHandHovers))
                 {
-                    physicalHandHover.OnHandHoverExit(hand);
+                    foreach (var hoverEventReceiver in physicalHandHovers)
+                    {
+                        hoverEventReceiver.OnHandHoverExit(hand);
+                    }
                 }
 
                 hand.physicalHandsManager.OnHandHoverExit(hand, _rigid);
@@ -449,9 +458,12 @@ namespace Leap.Unity.PhysicalHands
             // Fire the contacting event whether it changed or not
             if (_grabbableHandsValues[handIndex].isContacting)
             {
-                if (_rigid.TryGetComponent<IPhysicalHandContact>(out var handContactEvent))
+                if (_rigid.TryGetComponents<IPhysicalHandContact>(out var physicalHandContacts))
                 {
-                    handContactEvent.OnHandContact(_grabbableHands[handIndex]);
+                    foreach (var contactEventReceiver in physicalHandContacts)
+                    {
+                        contactEventReceiver.OnHandContact(_grabbableHands[handIndex]);
+                    }
                 }
 
                 _grabbableHands[handIndex].physicalHandsManager.OnHandContact(_grabbableHands[handIndex], _rigid);
@@ -459,18 +471,24 @@ namespace Leap.Unity.PhysicalHands
             else if (_grabbableHandsValues[handIndex].wasContacting)
             {
                 // We stopped contacting, so fire the contact exit event
-                if (_rigid.TryGetComponent<IPhysicalHandContact>(out var handContactEvent))
+                if (_rigid.TryGetComponents<IPhysicalHandContact>(out var physicalHandContacts))
                 {
-                    handContactEvent.OnHandContactExit(_grabbableHands[handIndex]);
+                    foreach (var contactEventReceiver in physicalHandContacts)
+                    {
+                        contactEventReceiver.OnHandContactExit(_grabbableHands[handIndex]);
+                    }
                 }
 
                 _grabbableHands[handIndex].physicalHandsManager.OnHandContactExit(_grabbableHands[handIndex], _rigid);
             }
 
             // Fire the hovering event
-            if (_rigid.TryGetComponent<IPhysicalHandHover>(out var physicalHandHover))
+            if (_rigid.TryGetComponents<IPhysicalHandHover>(out var physicalHandHovers))
             {
-                physicalHandHover.OnHandHover(_grabbableHands[handIndex]);
+                foreach (var hoverEventReceiver in physicalHandHovers)
+                {
+                    hoverEventReceiver.OnHandHover(_grabbableHands[handIndex]);
+                }
             }
 
             _grabbableHands[handIndex].physicalHandsManager.OnHandHover(_grabbableHands[handIndex], _rigid);
@@ -481,9 +499,12 @@ namespace Leap.Unity.PhysicalHands
             // Send any active grabbing events
             foreach (var hand in _grabbingHands)
             {
-                if (_rigid.TryGetComponent<IPhysicalHandGrab>(out var physicalHandGrab))
+                if (_rigid.TryGetComponents<IPhysicalHandGrab>(out var physicalHandGrabs))
                 {
-                    physicalHandGrab.OnHandGrab(hand);
+                    foreach (var grabEventReceiver in physicalHandGrabs)
+                    {
+                        grabEventReceiver.OnHandGrab(hand);
+                    }
                 }
 
                 hand.physicalHandsManager.OnHandGrab(hand, _rigid);
@@ -494,9 +515,12 @@ namespace Leap.Unity.PhysicalHands
             {
                 if (!_grabbingHands.Contains(prev))
                 {
-                    if (_rigid.TryGetComponent<IPhysicalHandGrab>(out var physicalHandGrab))
+                    if (_rigid.TryGetComponents<IPhysicalHandGrab>(out var physicalHandGrabs))
                     {
-                        physicalHandGrab.OnHandGrabExit(prev);
+                        foreach (var grabEventReceiver in physicalHandGrabs)
+                        {
+                            grabEventReceiver.OnHandGrabExit(prev);
+                        }
                     }
 
                     prev.physicalHandsManager.OnHandGrabExit(prev, _rigid);
@@ -759,9 +783,12 @@ namespace Leap.Unity.PhysicalHands
                 return;
             }
 
-            if (_rigid != null && _rigid.TryGetComponent<IPhysicalHandGrab>(out var physicalHandGrab))
+            if (_rigid != null && _rigid.TryGetComponents<IPhysicalHandGrab>(out var physicalHandGrabs))
             {
-                physicalHandGrab.OnHandGrabExit(hand);
+                foreach (var grabEventReceiver in physicalHandGrabs)
+                {
+                    grabEventReceiver.OnHandGrabExit(hand);
+                }
             }
 
             hand.physicalHandsManager.OnHandGrabExit(hand, _rigid);


### PR DESCRIPTION
## Contributor Tasks

- [ ] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [ ] Add a CHANGELOG entry for this change.
- [ ] Ensure documentation requirements are met e.g., public API is commented.
- [ ] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Test Cycle

_Link to the test cycle here._

## Reviewer Tasks

- [ ] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [ ] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

Closes [UNITY-1479](https://ultrahaptics.atlassian.net/browse/UNITY-1479)

[UNITY-1479]: https://ultrahaptics.atlassian.net/browse/UNITY-1479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ