### PR TITLE
Feature/unity 685 allow over 6 device reconnections for imagretriever

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Support for reading the camera matrix
+- ImageRetriever allows more than 6 reconnections
 
 ### Changed
 - Improved XRHands support for Meta Aim Input Actions

--- a/Packages/Tracking/Core/Runtime/Scripts/LeapImageRetriever.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/LeapImageRetriever.cs
@@ -570,21 +570,24 @@ namespace Leap.Unity
 
             if (_currentImage != null)
             {
+                int deviceIndex = _provider.GetLeapController().Devices.IndexOf(_provider.CurrentDevice);
+
+
                 if (_eyeTextureData.CheckStale(_currentImage))
                 {
                     _needQueueReset = true;
 
-                    _eyeTextureData.Reconstruct(_currentImage, (int)_provider.CurrentDevice.DeviceID);
+                    _eyeTextureData.Reconstruct(_currentImage, deviceIndex);
 
                     // if there is a quad that renders the infrared image, set the correct deviceID on its material
                     Renderer quadRenderer = GetComponentInChildren<Renderer>();
                     if (quadRenderer != null)
                     {
-                        quadRenderer.material.SetFloat("_DeviceID", _provider.CurrentDevice.DeviceID);
+                        quadRenderer.material.SetFloat("_DeviceID", deviceIndex);
                     }
                 }
 
-                _eyeTextureData.UpdateTextures(_currentImage, (int)_provider.CurrentDevice.DeviceID, _provider?.GetLeapController());
+                _eyeTextureData.UpdateTextures(_currentImage, deviceIndex, _provider?.GetLeapController());
             }
         }
 


### PR DESCRIPTION
## Contributor Tasks

- [ ] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [ ] Add a CHANGELOG entry for this change.
- [ ] Ensure documentation requirements are met e.g., public API is commented.
- [ ] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Test Cycle

_Link to the test cycle here._

## Reviewer Tasks

- [ ] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [ ] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

Closes [UNITY-685](https://ultrahaptics.atlassian.net/browse/UNITY-685)


[UNITY-685]: https://ultrahaptics.atlassian.net/browse/UNITY-685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ