### PR TITLE
New downstream test apps

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -107,8 +107,9 @@ check-formatting:
 # Unity Builds
 # -----------------------------------------------------------------------------
 #
-# This job will trigger various apps to build using the plugin commit that started this pipeline.
+# This job will trigger Unity 2021/2022 test apps to build using the plugin commit that started this pipeline.
 # A failure in a build likely represents a breaking plugin change and should be addressed, but will not fail the whole pipeline.
+# The resulting builds will contain every sample scene, and should be used for manual testing.
 #
 unity-builds:
   stage: test
@@ -117,7 +118,7 @@ unity-builds:
   rules:
     - when: manual
   trigger:
-    project: xr/rad/triggers/unityplugin-tests
+    project: xr/integrations/unity/unityplugin-tests
     branch: main
   variables:
     PLUGIN_COMMIT_BRANCH: $CI_COMMIT_BRANCH

--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [docs-website]: https://docs.ultraleap.com/unity-api/ "Ultraleap Docs"
 
+## [NEXT]
+
+### Fixed
+- GrabHelper handles null ContactHand objects more gracefully
+
+
 ## [7.0.0] - 22/07/2024
 
 ### Tracking Client versions

--- a/Packages/Tracking/Physical Hands/Runtime/Scripts/Helpers/GrabHelper.cs
+++ b/Packages/Tracking/Physical Hands/Runtime/Scripts/Helpers/GrabHelper.cs
@@ -25,8 +25,8 @@ namespace Leap.PhysicalHands
                 "\n\nWarning: Hard Contact hands can jitter when moving a kinematic object")]
         public bool useNonKinematicMovementOnly = true;
 
-        private ContactHand _leftContactHand { get { return physicalHandsManager.ContactParent.LeftHand; } }
-        private ContactHand _rightContactHand { get { return physicalHandsManager.ContactParent.RightHand; } }
+        private ContactHand _leftContactHand { get { return physicalHandsManager?.ContactParent?.LeftHand; } }
+        private ContactHand _rightContactHand { get { return physicalHandsManager?.ContactParent?.RightHand; } }
 
         private Collider[] _colliderCache = new Collider[128];
 
@@ -54,6 +54,11 @@ namespace Leap.PhysicalHands
 
         private void OnEnable()
         {
+            if (physicalHandsManager == null)
+            {
+                physicalHandsManager = GetComponent<PhysicalHandsManager>();
+            }
+
             if (physicalHandsManager != null)
             {
                 physicalHandsManager.OnPrePhysicsUpdate -= OnPrePhysicsUpdate;
@@ -114,12 +119,12 @@ namespace Leap.PhysicalHands
         #region Hand Updating
         private void UpdateHandHeuristics()
         {
-            if (_leftContactHand.tracked)
+            if (_leftContactHand != null && _leftContactHand.tracked)
             {
                 UpdateFingerStrengthValues(_leftContactHand);
             }
 
-            if (_rightContactHand.tracked)
+            if (_rightContactHand != null && _rightContactHand.tracked)
             {
                 UpdateFingerStrengthValues(_rightContactHand);
             }
@@ -238,6 +243,9 @@ namespace Leap.PhysicalHands
 
         void UpdatePrimaryHoverForHand(ref GrabHelperObject prevPrimaryHoverObject, ContactHand contactHand)
         {
+            if (contactHand == null)
+                return;
+
             // If we are contacting or grabbing, we are still primary hovering the same object. break out
             if (prevPrimaryHoverObject != null && contactHand.IsContacting &&
                 (prevPrimaryHoverObject.GrabState == GrabHelperObject.State.Contact ||


### PR DESCRIPTION
## Summary

Following on from my prev MR fixing the fomatting job...

- Fixed the previously broken downstream `unity-builds` pipeline. Now builds an application which includes the samples folder for the plugin commit that triggered the pipeline using Unity 2021 and Unity 2022. Running the application from either Unity version allows you to hop through every scene and validate that it is working as expected. A fail on the build should highlight a breaking code change.
- Fixed the libtrack dependencies job (updated API secret in GitLab).

All CI jobs should now be back to working order 👍 

Additionally:
- Fixed some handling of `ContactHand` in `GrabHelper` to prevent errors if it is ever null (spotted when building the test apps)

## Contributor Tasks

- [ ] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [ ] Add a CHANGELOG entry for this change.
- [ ] Ensure documentation requirements are met e.g., public API is commented.
- [ ] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Test Cycle

_Link to the test cycle here._

## Reviewer Tasks

- [ ] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [ ] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_

## Pull Request Templates

Switch template by going to preview and clicking the link - note it will not work if you've made any changes to the description.

- [default.md](?expand=1) - for contributions to stable packages.
- [release.md](?expand=1&template=release.md) - for release merge requests.

**You are currently using: default.md**

Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.
