### PR TITLE
Added default constructor to LeapXRHandProvider with [Preserve] attri…

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [docs-website]: https://docs.ultraleap.com/unity-api/ "Ultraleap Docs"
 
+## [NEXT]
+
+### Added
+
+### Changed
+
+### Fixed
+- Fixed issue with LeapXRHandProvider not working on Quest devices when using XRI/XR Hands and Ultraleap tracking in direct (non OpenXR) mode, due to default constructor being optimized away.
+
 ## [7.1.0] - 04/09/2024
 
 ### Tracking Client versions

--- a/Packages/Tracking/Core/Runtime/Scripts/XRHandsSubsystem/LeapHandsSubsystem.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/XRHandsSubsystem/LeapHandsSubsystem.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using Unity.Collections;
 
 using UnityEngine;
+using UnityEngine.Scripting;
 using UnityEngine.XR.Hands;
 using UnityEngine.XR.Hands.ProviderImplementation;
 
@@ -36,6 +37,11 @@ namespace Leap
             {
                 trackingProvider = value;
             }
+        }
+
+        [Preserve]
+        public LeapXRHandProvider()
+        {
         }
 
         public override void Start()


### PR DESCRIPTION
…bute to fix issue using XRHands with Ultraleap data on Quest

## Summary

Attempting to use XRI with XRHands and a Leap2 on a Quest can cause issues. The XR Hands subsystem bridge to pipe data from the LeapXRProvider to the XR Hands subsystem fails, the attempt to call Activate.CreateInstance for the LeapXRHandProvider type throws as a default constructor cannot be found. It appears an empty constructor is needed with the [Preserve] attribute.

## Contributor Tasks

- [ ] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [x] Add a CHANGELOG entry for this change.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Test Cycle

_Link to the test cycle here._

## Reviewer Tasks

- [x] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [ ] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_

## Pull Request Templates

Switch template by going to preview and clicking the link - note it will not work if you've made any changes to the description.

- [default.md](?expand=1) - for contributions to stable packages.
- [release.md](?expand=1&template=release.md) - for release merge requests.

**You are currently using: default.md**

Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.
