### PR TITLE
Fingertip drawing fixes 

### DIFF
--- a/Packages/Tracking/Core/Runtime/Scripts/Hands/CapsuleHand.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Hands/CapsuleHand.cs
@@ -380,6 +380,11 @@ namespace Leap
                     else
                     {
                         position = finger.GetBone((Bone.BoneType)j).NextJoint;
+                        if (j == 3)
+                        {
+                            // Fingertips need to be adjusted back by a radii to account for sphere drawing.
+                            position -= finger.GetBone((Bone.BoneType)j).Direction * _jointRadius;
+                        }
                     }
 
                     _spherePositions[key] = position;

--- a/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
+++ b/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
@@ -220,14 +220,23 @@ namespace Leap.Tracking.OpenXR
                         continue;
                     }
 
+                    var prevJointPosition = prevJoint.Pose.position;
+                    var nextJointPosition = nextJoint.Pose.position;
+                    
+                    // Adjust the fingertip positions forward by a radius to match LeapC data.
+                    if (boneIndex == 3)
+                    {
+                        nextJointPosition += prevJoint.Pose.forward * nextJoint.Radius;
+                    }
+
                     // Populate the finger bone information
                     var bone = hand.fingers[fingerIndex].bones[boneIndex];
                     bone.Fill(
-                        prevJoint.Pose.position,
-                        nextJoint.Pose.position,
-                        ((prevJoint.Pose.position + nextJoint.Pose.position) / 2f),
+                        prevJointPosition,
+                        nextJointPosition,
+                        ((prevJointPosition + nextJointPosition) / 2f),
                         prevJoint.Pose.forward,
-                        (prevJoint.Pose.position - nextJoint.Pose.position).magnitude,
+                        (prevJointPosition - nextJointPosition).magnitude,
                         prevJoint.Radius * 1.5f, // 1.5 to convert from joint radius to bone width (joints bigger than bones)
                         (Bone.BoneType)boneIndex,
                         prevJoint.Pose.rotation);


### PR DESCRIPTION
## Summary

This adjusts the finger tip positions of capsule hands so that the surface of the tip spheres should match the skin surface of the detected finger. It also corrects for OpenXR data being different in this regard to LeapC data.

## Contributor Tasks

- [ ] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [ ] Add a CHANGELOG entry for this change.
- [ ] Ensure documentation requirements are met e.g., public API is commented.
- [ ] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Test Cycle

_Link to the test cycle here._

## Reviewer Tasks

- [ ] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [ ] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_

## Pull Request Templates

Switch template by going to preview and clicking the link - note it will not work if you've made any changes to the description.

- [default.md](?expand=1) - for contributions to stable packages.
- [release.md](?expand=1&template=release.md) - for release merge requests.

**You are currently using: default.md**

Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.
