### PR TITLE
Feature/physical warnings

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [NEXT]
 
 ### Added
+- Added a warning to Physical Buttons when no Physical Hands Manager is in the scene
 
 ### Changed
+- Non-convex MeshColliders are skipped when processing Physical Hands
 
 ### Fixed
 - Fixed issue with LeapXRHandProvider not working on Quest devices when using XRI/XR Hands and Ultraleap tracking in direct (non OpenXR) mode, due to default constructor being optimized away.

--- a/Packages/Tracking/Physical Hands/Editor/Scripts/PhysicalHandsButtonEditor.cs
+++ b/Packages/Tracking/Physical Hands/Editor/Scripts/PhysicalHandsButtonEditor.cs
@@ -21,6 +21,8 @@ namespace Leap.PhysicalHands
         {
             EditorUtils.DrawScriptField((MonoBehaviour)target);
 
+            WarningsSection();
+
             EditorGUILayout.PropertyField(serializedObject.FindProperty("_pressableObject"), new GUIContent("Pressable Object", "The GameObject representing the button that can be pressed."));
 
             EditorGUILayout.Space(5);
@@ -87,6 +89,26 @@ namespace Leap.PhysicalHands
 
             serializedObject.ApplyModifiedProperties();
             target.UpdateInspectorValues();
+        }
+
+        private void WarningsSection()
+        {
+            var physicalHandsManager = GameObject.FindFirstObjectByType<PhysicalHandsManager>(FindObjectsInactive.Include);
+            if (physicalHandsManager == null)
+            {
+                EditorGUILayout.HelpBox($"There is no Physical Hands Manager in your scene.\nThis button will not work correctly.", MessageType.Warning);
+                EditorGUILayout.Space(5);
+            }
+            else if(GameObject.FindFirstObjectByType<GrabHelper>(FindObjectsInactive.Include) == null)
+            {
+                EditorGUILayout.HelpBox($"There is no Grab Helper on your Physical Hands Manager.\nThis button will not work correctly.", MessageType.Warning);
+                if(GUILayout.Button("Add Grab Helper"))
+                {
+                    physicalHandsManager.gameObject.AddComponent<GrabHelper>();
+                }
+                EditorGUILayout.Space(5);
+            }
+
         }
     }
 }

--- a/Packages/Tracking/Physical Hands/Runtime/Scripts/ContactBone.cs
+++ b/Packages/Tracking/Physical Hands/Runtime/Scripts/ContactBone.cs
@@ -218,6 +218,12 @@ namespace Leap.PhysicalHands
             {
                 collider = colliderCache[i];
 
+                if(collider is MeshCollider && (collider is MeshCollider meshCollider && !meshCollider.convex))
+                {
+                    // Can't process non-solid/concave collider
+                    continue;
+                }
+
                 Vector3 colliderTransformPosition = collider.transform.position;
                 Vector3 boneTransformPosition = transform.position;
 

--- a/Packages/Tracking/Physical Hands/Runtime/Scripts/Helpers/GrabHelperObject.cs
+++ b/Packages/Tracking/Physical Hands/Runtime/Scripts/Helpers/GrabHelperObject.cs
@@ -98,7 +98,7 @@ namespace Leap.PhysicalHands
 
         private bool wasKinematic;
         private bool usedGravity;
-        private float oldDrag;
+        private float oldDrag, oldMass;
         private float oldAngularDrag;
 
         internal IgnorePhysicalHands _ignorePhysicalHands;
@@ -212,6 +212,7 @@ namespace Leap.PhysicalHands
             wasKinematic = _rigid.isKinematic;
             usedGravity = _rigid.useGravity;
             oldDrag = _rigid.drag;
+            oldMass = _rigid.mass;
             oldAngularDrag = _rigid.angularDrag;
             _rigid.TryGetComponents<IPhysicalHandGrab>(out _physicalHandGrabs);
             _rigid.TryGetComponents<IPhysicalHandHover>(out _physicalHandHovers);
@@ -237,6 +238,7 @@ namespace Leap.PhysicalHands
                 _rigid.useGravity = false;
                 _rigid.drag = 0f;
                 _rigid.angularDrag = 0f;
+                _rigid.mass = 1f;
             }
         }
 
@@ -248,6 +250,7 @@ namespace Leap.PhysicalHands
                 _rigid.useGravity = usedGravity;
                 _rigid.drag = oldDrag;
                 _rigid.angularDrag = oldAngularDrag;
+                _rigid.mass = oldMass;
             }
         }
 
@@ -367,6 +370,7 @@ namespace Leap.PhysicalHands
         internal void ReleaseObject()
         {
             GrabState = State.Hover;
+            _rigid.mass = oldMass;
 
             HandleReleasedRigidbody();
             ThrowingOnRelease();

--- a/Packages/Tracking/Physical Hands/Runtime/Scripts/UI/PhysicalHandsButton.cs
+++ b/Packages/Tracking/Physical Hands/Runtime/Scripts/UI/PhysicalHandsButton.cs
@@ -57,6 +57,7 @@ namespace Leap.PhysicalHands
         protected bool _isButtonPressed = false;
         protected Rigidbody _pressableObjectRB = null;
         protected ConfigurableJoint _configurableJoint;
+        protected IgnorePhysicalHands _pressableIgnore = null;
 
 
         /// <summary>
@@ -269,6 +270,14 @@ namespace Leap.PhysicalHands
             {
                 _buttonHelper = _pressableObject.AddComponent<PhysicalHandsButtonHelper>();
             }
+
+            if(!_pressableObject.TryGetComponent<IgnorePhysicalHands>(out _pressableIgnore))
+            {
+                _pressableIgnore = _pressableObject.AddComponent<IgnorePhysicalHands>();
+            }
+
+            _pressableIgnore.DisableAllGrabbing = true;
+            _pressableIgnore.DisableAllHandCollisions = false;
 
             // Subscribe to events from the button helper
             _buttonHelper._onHandContact -= OnHandContactPO;


### PR DESCRIPTION
## Summary

MR for Rory's final Physical Hands changes:
-  Added a warning to Physical Buttons when no Physical Hands Manager is in the scene
- Non-convex MeshColliders are skipped when processing Physical Hands

## Contributor Tasks

- [ ] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [x] Add a CHANGELOG entry for this change.
- [ ] Ensure documentation requirements are met e.g., public API is commented.
- [ ] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Test Cycle

_Link to the test cycle here._

## Reviewer Tasks

- [ ] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [ ] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_

## Pull Request Templates

Switch template by going to preview and clicking the link - note it will not work if you've made any changes to the description.

- [default.md](?expand=1) - for contributions to stable packages.
- [release.md](?expand=1&template=release.md) - for release merge requests.

**You are currently using: default.md**

Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.
