### PR TITLE
Add fiducial flag

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added a warning to Physical Buttons when no Physical Hands Manager is in the scene
 - Added a checkbox to enable offsetting fingertip capsules in CapsuleHand
+- Added a checkbox to enable fiducial marker tracking within the LeapC service
 
 ### Changed
 - Non-convex MeshColliders are skipped when processing Physical Hands
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed issue with LeapXRHandProvider not working on Quest devices when using XRI/XR Hands and Ultraleap tracking in direct (non OpenXR) mode, due to default constructor being optimized away.
+- Multi device mode will no longer be requested on Connection if arg is set to false
 
 ## [7.1.0] - 04/09/2024
 

--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Connection.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Connection.cs
@@ -174,11 +174,15 @@ namespace LeapInternal
 
         private LEAP_ALLOCATOR _pLeapAllocator = new LEAP_ALLOCATOR();
 
-        public void Start(string serverNamespace = "Leap Service", bool multiDeviceAware = true)
+        public void Start(string serverNamespace = "Leap Service", bool multiDeviceAware = true, bool enableFiducialMarkers = false)
         {
             LEAP_CONNECTION_CONFIG config = new LEAP_CONNECTION_CONFIG();
             config.server_namespace = Marshal.StringToHGlobalAnsi(serverNamespace);
-            config.flags = (uint)eLeapConnectionFlag.eLeapConnectionFlag_MultipleDevicesAware;
+            config.flags = 0;
+            if (multiDeviceAware)
+                config.flags |= (uint)eLeapConnectionFlag.eLeapConnectionFlag_MultipleDevicesAware;
+            if (enableFiducialMarkers)
+                config.flags |= (uint)eLeapConnectionFlag.eLeapConnectionFlag_FiducialTracking;
             config.size = (uint)Marshal.SizeOf(config);
             Start(config);
         }

--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Controller.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Controller.cs
@@ -43,6 +43,8 @@ namespace Leap
         Connection _connection;
         bool _disposed = false;
         string _serverNamespace = "Leap Service";
+        bool _supportsMultipleDevices = true;
+        bool _supportsFiducialMarkers = false;
 
         /// <summary>
         /// The SynchronizationContext used for dispatching events.
@@ -457,7 +459,7 @@ namespace Leap
         /// Otherwise, a new connection is created.
         /// @since 3.0
         /// </summary>
-        public Controller(int connectionKey, string serverNamespace = "Leap Service", bool supportsMultipleDevices = true)
+        public Controller(int connectionKey, string serverNamespace = "Leap Service", bool supportsMultipleDevices = true, bool supportsFiducialMarkers = false)
         {
             _connection = Connection.GetConnection(new Connection.Key(connectionKey, serverNamespace));
             _connection.EventContext = SynchronizationContext.Current;
@@ -470,6 +472,8 @@ namespace Leap
             _connection.LeapConnectionLost += OnDisconnect;
 
             _serverNamespace = serverNamespace;
+            _supportsMultipleDevices = supportsMultipleDevices;
+            _supportsFiducialMarkers = supportsFiducialMarkers;
 
             StartConnection();
         }
@@ -485,7 +489,7 @@ namespace Leap
         /// </summary>
         public void StartConnection()
         {
-            _connection.Start(_serverNamespace);
+            _connection.Start(_serverNamespace, _supportsMultipleDevices, _supportsFiducialMarkers);
         }
 
         /// <summary>

--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/LeapC.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/LeapC.cs
@@ -18,6 +18,10 @@ namespace LeapInternal
         /// Allows subscription to multiple devices
         /// </summary>
         eLeapConnectionFlag_MultipleDevicesAware = 0x00000001,
+        /// <summary>
+        /// Enables fiducial marker tracking (warning: may degrade tracking performance)
+        /// </summary>
+        eLeapConnectionFlag_FiducialTracking = 0x00000002,
     };
 
     public enum eLeapConnectionStatus : uint

--- a/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
@@ -290,6 +290,24 @@ namespace Leap
         [SerializeField, Min(1), Tooltip("The interval in frames between service connection attempts.")]
         public int _reconnectionInterval = RECONNECTION_INTERVAL;
 
+
+        /// <summary>
+        /// Check this option to enable AprilTag fiducial marker tracking within the Ultraleap service.
+        /// Be aware that fiducial markers may degrade runtime performance, and are not recommended for use on mobile platforms.
+        /// 
+        /// Fiducial configuration is available within: %ProgramData%/Ultraleap/HandTracker/hand_tracker_config.json.
+        /// You are required to set the fiducial family and size:
+        ///   "fiducial_tracker": {
+        ///     "family": "xxx",     <-- This is the family of fiducials you're using (e.g. Tag25h9). You can use any ID from within the family.
+        ///     "size": 0.0          <-- This is the width of your printed fiducial. Ensure this value is correct to prevent incorrect transforms.
+        ///   }
+        /// You can also specify a few other options within the "fiducial_tracker" object, the most impactful for performance being:
+        ///  - "frequency" -> A value of 3 indicates that the detector is run every third frame, 1 every frame, etc (default: 3)
+        ///  - "decimate" -> Trades detection distance for performance (default: 2.0)
+        /// Outside the "fiducial_marker" object, you can also specify "full_res_fiducials", which decreases performance but boosts range.
+        /// 
+        /// Check out TrackingMarkerObject to see how to subscribe to fiducial events and retrieve their transforms!
+        /// </summary>
         [SerializeField, Tooltip("Check this to enable fiducial markers (warning: may degrade tracking performance)")]
         public bool _trackFiducialMarkers = false;
 

--- a/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/LeapServiceProvider.cs
@@ -290,6 +290,9 @@ namespace Leap
         [SerializeField, Min(1), Tooltip("The interval in frames between service connection attempts.")]
         public int _reconnectionInterval = RECONNECTION_INTERVAL;
 
+        [SerializeField, Tooltip("Check this to enable fiducial markers (warning: may degrade tracking performance)")]
+        public bool _trackFiducialMarkers = false;
+
         #endregion
 
         #region Internal Settings & Memory
@@ -907,11 +910,11 @@ namespace Leap
 
             if (_multipleDeviceMode == MultipleDeviceMode.Disabled)
             {
-                _leapController = new Controller(0, _serverNameSpace);
+                _leapController = new Controller(0, _serverNameSpace, true, _trackFiducialMarkers);
             }
             else
             {
-                _leapController = new Controller(SpecificSerialNumber.GetHashCode(), _serverNameSpace);
+                _leapController = new Controller(SpecificSerialNumber.GetHashCode(), _serverNameSpace, true, _trackFiducialMarkers);
             }
 
             _leapController.Device += (s, e) =>


### PR DESCRIPTION
## Summary

Fixes fiducial markers! 

The service requires a fiducial flag to be sent to enable marker tracking as of v6.1: this is possible now via a checkbox on the LeapServiceProvider.

I've also fixed the multi device flag: it will now correctly not be sent if the user requests multi device to be off.

## Contributor Tasks

- [ ] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [ ] Add a CHANGELOG entry for this change.
- [ ] Ensure documentation requirements are met e.g., public API is commented.
- [ ] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Test Cycle

_Link to the test cycle here._

## Reviewer Tasks

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [x] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [x] Documentation has been reviewed.
- [x] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_

## Pull Request Templates

Switch template by going to preview and clicking the link - note it will not work if you've made any changes to the description.

- [default.md](?expand=1) - for contributions to stable packages.
- [release.md](?expand=1&template=release.md) - for release merge requests.

**You are currently using: default.md**

Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.
