### PR TITLE
Unity 6 compatibility

### DIFF
--- a/Packages/Tracking Preview/AggregationProviders/Runtime/Scripts/JointOcclusion.cs
+++ b/Packages/Tracking Preview/AggregationProviders/Runtime/Scripts/JointOcclusion.cs
@@ -28,11 +28,7 @@ public class JointOcclusion : MonoBehaviour
     /// </summary>
     public void Setup()
     {
-#if UNITY_2021_3_18_OR_NEWER
         List<JointOcclusion> allJointOcclusions = FindObjectsByType<JointOcclusion>(FindObjectsSortMode.None).ToList();
-#else
-        List<JointOcclusion> allJointOcclusions = FindObjectsOfType<JointOcclusion>().ToList();
-#endif
         layerName = "JointOcclusion" + allJointOcclusions.IndexOf(this).ToString();
 
         cam = GetComponent<Camera>();

--- a/Packages/Tracking Preview/AggregationProviders/Runtime/Ultraleap.Tracking.Aggregation.asmdef
+++ b/Packages/Tracking Preview/AggregationProviders/Runtime/Ultraleap.Tracking.Aggregation.asmdef
@@ -12,12 +12,5 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [
-        {
-            "name": "Unity",
-            "expression": "2021.3.18f1",
-            "define": "UNITY_2021_3_18_OR_NEWER"
-        }
-    ],
     "noEngineReferences": false
 }

--- a/Packages/Tracking Preview/Examples~/XRControllerSupport/ControllerModelEnableDisable.cs
+++ b/Packages/Tracking Preview/Examples~/XRControllerSupport/ControllerModelEnableDisable.cs
@@ -20,11 +20,7 @@ public class ControllerModelEnableDisable : MonoBehaviour
     {
         if (controllerPostProcess == null)
         {
-#if UNITY_2021_3_18_OR_NEWER
             controllerPostProcess = FindAnyObjectByType<ControllerPostProcess>();
-#else
-            controllerPostProcess = FindObjectOfType<ControllerPostProcess>();
-#endif
         }
         controllerPostProcess.OnHandInputTypeChange += OnHandInputTypeChange;
 

--- a/Packages/Tracking Preview/HandRays/Runtime/Scripts/FarFieldLayerManager.cs
+++ b/Packages/Tracking Preview/HandRays/Runtime/Scripts/FarFieldLayerManager.cs
@@ -65,12 +65,7 @@ namespace Leap.Preview.HandRays
 
         protected void AssignLayers()
         {
-#if UNITY_2021_3_18_OR_NEWER
             FarFieldObject[] farFieldObjects = FindObjectsByType<FarFieldObject>(FindObjectsInactive.Include, FindObjectsSortMode.None);
-#else
-            FarFieldObject[] farFieldObjects = FindObjectsOfType<FarFieldObject>(true);
-#endif
-
             foreach (FarFieldObject ffo in farFieldObjects)
             {
                 ffo.gameObject.layer = FarFieldObjectLayer;

--- a/Packages/Tracking Preview/HandRays/Runtime/Scripts/InferredBodyPositions/InferredBodyPositions.cs
+++ b/Packages/Tracking Preview/HandRays/Runtime/Scripts/InferredBodyPositions/InferredBodyPositions.cs
@@ -165,11 +165,7 @@ namespace Leap.Preview.HandRays
 
         private void Start()
         {
-#if UNITY_2021_3_18_OR_NEWER
             LeapXRServiceProvider leapXRServiceProvider = FindAnyObjectByType<LeapXRServiceProvider>();
-#else
-            LeapXRServiceProvider leapXRServiceProvider = FindObjectOfType<LeapXRServiceProvider>();
-#endif
             if (leapXRServiceProvider != null)
             {
                 Head = leapXRServiceProvider.mainCamera.transform;

--- a/Packages/Tracking Preview/HandRays/Runtime/Scripts/RayInteractors/HandRayInteractor.cs
+++ b/Packages/Tracking Preview/HandRays/Runtime/Scripts/RayInteractors/HandRayInteractor.cs
@@ -47,11 +47,7 @@ namespace Leap.Preview.HandRays
         {
             if (farFieldLayerManager == null)
             {
-#if UNITY_2021_3_18_OR_NEWER
                 farFieldLayerManager = FindAnyObjectByType<FarFieldLayerManager>();
-#else
-                farFieldLayerManager = FindObjectOfType<FarFieldLayerManager>();
-#endif
             }
 
             layerMask |= farFieldLayerManager.FarFieldObjectLayer.layerMask;
@@ -65,11 +61,7 @@ namespace Leap.Preview.HandRays
         {
             if (farFieldLayerManager == null)
             {
-#if UNITY_2021_3_18_OR_NEWER
                 farFieldLayerManager = FindAnyObjectByType<FarFieldLayerManager>();
-#else
-                farFieldLayerManager = FindObjectOfType<FarFieldLayerManager>();
-#endif
             }
         }
 
@@ -77,11 +69,7 @@ namespace Leap.Preview.HandRays
         {
             if (_handRay == null)
             {
-#if UNITY_2021_3_18_OR_NEWER
                 _handRay = FindAnyObjectByType<WristShoulderHandRay>();
-#else
-                _handRay = FindObjectOfType<WristShoulderHandRay>();
-#endif
 
                 if (_handRay == null)
                 {

--- a/Packages/Tracking Preview/HandRays/Ultraleap.Tracking.HandRays.asmdef
+++ b/Packages/Tracking Preview/HandRays/Ultraleap.Tracking.HandRays.asmdef
@@ -15,12 +15,5 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [
-        {
-            "name": "Unity",
-            "expression": "2021.3.18f1",
-            "define": "UNITY_2021_3_18_OR_NEWER"
-        }
-    ],
     "noEngineReferences": false
 }

--- a/Packages/Tracking Preview/InfraredImageDistort/LeapDistortImage.cs
+++ b/Packages/Tracking Preview/InfraredImageDistort/LeapDistortImage.cs
@@ -53,7 +53,11 @@ public class LeapDistortImage : MonoBehaviour
     // Start is called before the first frame update
     void OnEnable()
     {
+#if UNITY_6000_0_OR_NEWER
+        if (GraphicsSettings.defaultRenderPipeline != null)
+#else
         if (GraphicsSettings.renderPipelineAsset != null)
+#endif 
         {
             RenderPipelineManager.beginCameraRendering -= onBeginRendering;
             RenderPipelineManager.beginCameraRendering += onBeginRendering;
@@ -67,7 +71,11 @@ public class LeapDistortImage : MonoBehaviour
 
     private void OnDisable()
     {
+#if UNITY_6000_0_OR_NEWER
+        if (GraphicsSettings.defaultRenderPipeline != null)
+#else
         if (GraphicsSettings.renderPipelineAsset != null)
+#endif 
         {
             RenderPipelineManager.beginCameraRendering -= onBeginRendering;
         }

--- a/Packages/Tracking Preview/Locomotion/Runtime/Scripts/Teleportation/Teleport Action/Jump Gem Teleport/JumpGem.cs
+++ b/Packages/Tracking Preview/Locomotion/Runtime/Scripts/Teleportation/Teleport Action/Jump Gem Teleport/JumpGem.cs
@@ -173,11 +173,8 @@ namespace Leap.Preview.Locomotion
             {
                 leapProvider = Hands.Provider;
             }
-#if UNITY_2021_3_18_OR_NEWER
             _jumpGemTeleport = FindAnyObjectByType<JumpGemTeleport>(FindObjectsInactive.Include);
-#else
-            _jumpGemTeleport = FindObjectOfType<JumpGemTeleport>(true);
-#endif
+
             if (_audioSource == null)
             {
                 _audioSource = GetComponentInChildren<AudioSource>(true);

--- a/Packages/Tracking Preview/Locomotion/Runtime/Scripts/Teleportation/Teleport Action/Jump Gem Teleport/JumpGemTeleport.cs
+++ b/Packages/Tracking Preview/Locomotion/Runtime/Scripts/Teleportation/Teleport Action/Jump Gem Teleport/JumpGemTeleport.cs
@@ -48,11 +48,7 @@ namespace Leap.Preview.Locomotion
 
         private void Awake()
         {
-#if UNITY_2021_3_18_OR_NEWER
             _jumpGems = FindObjectsByType<JumpGem>(FindObjectsInactive.Include, FindObjectsSortMode.None).ToList();
-#else
-            _jumpGems = FindObjectsOfType<JumpGem>(true).ToList();
-#endif
             for (int i = 0; i < _jumpGems.Count; i++)
             {
                 int j = i;

--- a/Packages/Tracking Preview/Locomotion/Runtime/Scripts/Teleportation/Teleport Action/TeleportActionBase.cs
+++ b/Packages/Tracking Preview/Locomotion/Runtime/Scripts/Teleportation/Teleport Action/TeleportActionBase.cs
@@ -101,11 +101,7 @@ namespace Leap.Preview.Locomotion
             if (Player == null) Player = Head.parent.gameObject == null ? Head.gameObject : Head.parent.gameObject;
             if (farFieldLayerManager == null)
             {
-#if UNITY_2021_3_18_OR_NEWER
                 farFieldLayerManager = FindAnyObjectByType<FarFieldLayerManager>();
-#else
-                farFieldLayerManager = FindObjectOfType<FarFieldLayerManager>();
-#endif
             }
 
             if (handRayInteractor != null)
@@ -115,11 +111,7 @@ namespace Leap.Preview.Locomotion
 
             if (findTeleportAnchorsOnStart)
             {
-#if UNITY_2021_3_18_OR_NEWER
                 _teleportAnchors = new List<TeleportAnchor>(FindObjectsByType<TeleportAnchor>(FindObjectsInactive.Include, FindObjectsSortMode.None));
-#else
-                _teleportAnchors = new List<TeleportAnchor>(FindObjectsOfType<TeleportAnchor>(true));
-#endif
             }
 
             if (freeTeleportAnchor.TryGetComponent(out MeshCollider anchorCollider))
@@ -153,11 +145,7 @@ namespace Leap.Preview.Locomotion
 
             if (farFieldLayerManager == null)
             {
-#if UNITY_2021_3_18_OR_NEWER
                 farFieldLayerManager = FindAnyObjectByType<FarFieldLayerManager>();
-#else
-                farFieldLayerManager = FindObjectOfType<FarFieldLayerManager>();
-#endif
             }
         }
 

--- a/Packages/Tracking Preview/Locomotion/Runtime/Scripts/Teleportation/Utilities/IsFacingObject.cs
+++ b/Packages/Tracking Preview/Locomotion/Runtime/Scripts/Teleportation/Utilities/IsFacingObject.cs
@@ -55,23 +55,15 @@ namespace Leap.Preview.Locomotion
         private void SetLayerMask()
         {
             _layerMask = -1;
-
-#if UNITY_2021_3_18_OR_NEWER
+            
             PhysicalHandsManager _physicalHandsManager = FindAnyObjectByType<PhysicalHandsManager>();
-#else
-            PhysicalHandsManager physicalHandsManager = FindObjectOfType<PhysicalHandsManager>();
-#endif
             if (_physicalHandsManager != null)
             {
                 _layerMask ^= _physicalHandsManager.HandsLayer.layerMask;
                 _layerMask ^= _physicalHandsManager.HandsResetLayer.layerMask;
             }
-
-#if UNITY_2021_3_18_OR_NEWER
+            
             FarFieldLayerManager _farFieldLayerManager = FindAnyObjectByType<FarFieldLayerManager>();
-#else
-            FarFieldLayerManager farFieldLayerManager = FindObjectOfType<FarFieldLayerManager>();
-#endif
             if (_farFieldLayerManager != null)
             {
                 _layerMask ^= _farFieldLayerManager.FarFieldObjectLayer.layerMask;

--- a/Packages/Tracking Preview/Locomotion/Ultraleap.Tracking.Locomotion.asmdef
+++ b/Packages/Tracking Preview/Locomotion/Ultraleap.Tracking.Locomotion.asmdef
@@ -16,12 +16,5 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [
-        {
-            "name": "Unity",
-            "expression": "2021.3.18f1",
-            "define": "UNITY_2021_3_18_OR_NEWER"
-        }
-    ],
     "noEngineReferences": false
 }

--- a/Packages/Tracking Preview/UI Input/Runtime/Scripts/PhysicsUI.cs
+++ b/Packages/Tracking Preview/UI Input/Runtime/Scripts/PhysicsUI.cs
@@ -74,7 +74,11 @@ namespace Leap.InputModule
             {
                 physicsOccurred = true;
                 body.position = PhysicsPosition;
+#if UNITY_6000_0_OR_NEWER
+                body.linearVelocity = PhysicsVelocity;
+#else
                 body.velocity = PhysicsVelocity;
+#endif
             }
         }
 
@@ -90,7 +94,11 @@ namespace Leap.InputModule
                 Vector3 newWorldPhysicsPosition = transform.TransformPoint(localPhysicsPosition);
                 PhysicsPosition = newWorldPhysicsPosition;
 
+#if UNITY_6000_0_OR_NEWER
+                Vector3 localPhysicsVelocity = transform.InverseTransformDirection(body.linearVelocity);
+#else
                 Vector3 localPhysicsVelocity = transform.InverseTransformDirection(body.velocity);
+#endif 
                 localPhysicsVelocity = new Vector3(0f, 0f, localPhysicsVelocity.z);
                 Vector3 newWorldPhysicsVelocity = transform.TransformDirection(localPhysicsVelocity);
                 PhysicsVelocity = newWorldPhysicsVelocity;

--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed issue with LeapXRHandProvider not working on Quest devices when using XRI/XR Hands and Ultraleap tracking in direct (non OpenXR) mode, due to default constructor being optimized away.
 - Multi device mode will no longer be requested on Connection if arg is set to false
+- Fixed issue with Unity 6 triggering warnings for scripts that need to be upgraded due to Unity 6 API changes. 
 
 ## [7.1.0] - 04/09/2024
 

--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -16,11 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Non-convex MeshColliders are skipped when processing Physical Hands
 - Adjusted OpenXR fingertip data to match LeapC more closely
+- Removed old conditional support for Unity 2021.3.18 since 2022 is the oldest LTS version we support
 
 ### Fixed
-- Fixed issue with LeapXRHandProvider not working on Quest devices when using XRI/XR Hands and Ultraleap tracking in direct (non OpenXR) mode, due to default constructor being optimized away.
+- Fixed issue with LeapXRHandProvider not working on Quest devices when using XRI/XR Hands and Ultraleap tracking in direct (non OpenXR) mode, due to default constructor being optimized away
 - Multi device mode will no longer be requested on Connection if arg is set to false
-- Fixed issue with Unity 6 triggering warnings for scripts that need to be upgraded due to Unity 6 API changes. 
+- Fixed issue with Unity 6 triggering warnings for scripts that need to be upgraded due to Unity 6 API changes
+- Fixed a broken meta file in Physical Hands XR Examples
 
 ## [7.1.0] - 04/09/2024
 

--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed issue with Unity 6 triggering warnings for scripts that need to be upgraded due to Unity 6 API changes
 - Fixed a broken meta file in Physical Hands XR Examples
 
+  ### Known issues
+- The Unity editor will become slow or unresposive with a scene containing a Leap Provider (XR), which has had the multiple device mode enabled and if the tracking service is not running
+
 ## [7.1.0] - 04/09/2024
 
 ### Tracking Client versions

--- a/Packages/Tracking/Core/Editor/Scripts/CombinablePropertyDrawer.cs
+++ b/Packages/Tracking/Core/Editor/Scripts/CombinablePropertyDrawer.cs
@@ -6,6 +6,7 @@
  * between Ultraleap and you, your company or other organization.             *
  ******************************************************************************/
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -70,6 +71,9 @@ namespace Leap.Attributes
             return EditorGUI.GetPropertyHeight(property, includeChildren: true);
         }
 
+#if UNITY_6000_0_OR_NEWER
+        [Obsolete("CanCacheInspectorGUI has been deprecated and is no longer used.", false)]
+#endif
         public override bool CanCacheInspectorGUI(SerializedProperty property)
         {
             return false;

--- a/Packages/Tracking/Core/Runtime/Scripts/Anchors/AnchorableBehaviour.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Anchors/AnchorableBehaviour.cs
@@ -644,7 +644,12 @@ namespace Leap
         private float getAnchorScore(Anchor anchor)
         {
             Vector3 pos = _rigidbody == null ? transform.position : _rigidbody.position;
+
+#if UNITY_6000_0_OR_NEWER
+            Vector3 velocity = _rigidbody == null ? Vector3.zero : _rigidbody.linearVelocity;
+#else
             Vector3 velocity = _rigidbody == null ? Vector3.zero : _rigidbody.velocity;
+#endif 
 
             return GetAnchorScore(pos,
                                   velocity,

--- a/Packages/Tracking/Core/Runtime/Scripts/Fiducial Markers/TrackingMarkerObject.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Fiducial Markers/TrackingMarkerObject.cs
@@ -36,7 +36,11 @@ namespace Leap
             // Ensure the LeapServiceProvider exists for us to position the device in world space
             if (leapServiceProvider == null)
             {
+#if UNITY_6000_0_OR_NEWER
+                leapServiceProvider = FindFirstObjectByType<LeapServiceProvider>();
+#else
                 leapServiceProvider = FindObjectOfType<LeapServiceProvider>();
+#endif
             }
 
             // Listen to events for the new marker poses

--- a/Packages/Tracking/Core/Runtime/Scripts/HandPoses/HandPoseValidator.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/HandPoses/HandPoseValidator.cs
@@ -32,11 +32,7 @@ public class HandPoseValidator : MonoBehaviour
     {
         if (poseDetector == null)
         {
-#if UNITY_2021_3_18_OR_NEWER
             poseDetector = FindAnyObjectByType<HandPoseDetector>();
-#else
-            poseDetector = FindObjectOfType<HandPoseDetector>();
-#endif
         }
 
         poseDetector.EnablePoseCaching();

--- a/Packages/Tracking/Core/Runtime/Scripts/LeapImageRetriever.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/LeapImageRetriever.cs
@@ -443,9 +443,7 @@ namespace Leap
             Camera.onPreRender -= OnCameraPreRender;
             Camera.onPreRender += OnCameraPreRender;
 
-#if UNITY_2019_3_OR_NEWER
             //SRP require subscribing to RenderPipelineManagers
-
 #if UNITY_6000_0_OR_NEWER 
             if (UnityEngine.Rendering.GraphicsSettings.defaultRenderPipeline != null)
 #else
@@ -455,7 +453,6 @@ namespace Leap
                 UnityEngine.Rendering.RenderPipelineManager.beginCameraRendering -= onBeginRendering;
                 UnityEngine.Rendering.RenderPipelineManager.beginCameraRendering += onBeginRendering;
             }
-#endif
         }
 
         private void OnDisable()
@@ -463,8 +460,7 @@ namespace Leap
             unsubscribeFromService();
 
             Camera.onPreRender -= OnCameraPreRender;
-
-#if UNITY_2019_3_OR_NEWER
+            
             //SRP require subscribing to RenderPipelineManagers
 #if UNITY_6000_0_OR_NEWER
             if (UnityEngine.Rendering.GraphicsSettings.defaultRenderPipeline != null)
@@ -474,7 +470,6 @@ namespace Leap
             {
                 UnityEngine.Rendering.RenderPipelineManager.beginCameraRendering -= onBeginRendering;
             }
-#endif
         }
 
         private void OnApplicationQuit()
@@ -500,8 +495,7 @@ namespace Leap
             }
 
             Camera.onPreRender -= OnCameraPreRender;
-
-#if UNITY_2019_3_OR_NEWER
+            
             //SRP require subscribing to RenderPipelineManagers
 #if UNITY_6000_0_OR_NEWER 
             if (UnityEngine.Rendering.GraphicsSettings.defaultRenderPipeline != null)
@@ -511,7 +505,6 @@ namespace Leap
             {
                 UnityEngine.Rendering.RenderPipelineManager.beginCameraRendering -= onBeginRendering;
             }
-#endif
         }
 
         private void LateUpdate()
@@ -605,12 +598,10 @@ namespace Leap
             }
         }
 
-#if UNITY_2019_3_OR_NEWER
         private void onBeginRendering(UnityEngine.Rendering.ScriptableRenderContext scriptableRenderContext, Camera camera)
         {
             OnCameraPreRender(camera);
         }
-#endif
 
         private void subscribeToService()
         {

--- a/Packages/Tracking/Core/Runtime/Scripts/LeapImageRetriever.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/LeapImageRetriever.cs
@@ -445,7 +445,12 @@ namespace Leap
 
 #if UNITY_2019_3_OR_NEWER
             //SRP require subscribing to RenderPipelineManagers
+
+#if UNITY_6000_0_OR_NEWER 
+            if (UnityEngine.Rendering.GraphicsSettings.defaultRenderPipeline != null)
+#else
             if (UnityEngine.Rendering.GraphicsSettings.renderPipelineAsset != null)
+#endif 
             {
                 UnityEngine.Rendering.RenderPipelineManager.beginCameraRendering -= onBeginRendering;
                 UnityEngine.Rendering.RenderPipelineManager.beginCameraRendering += onBeginRendering;
@@ -461,7 +466,11 @@ namespace Leap
 
 #if UNITY_2019_3_OR_NEWER
             //SRP require subscribing to RenderPipelineManagers
+#if UNITY_6000_0_OR_NEWER
+            if (UnityEngine.Rendering.GraphicsSettings.defaultRenderPipeline != null)
+#else
             if (UnityEngine.Rendering.GraphicsSettings.renderPipelineAsset != null)
+#endif 
             {
                 UnityEngine.Rendering.RenderPipelineManager.beginCameraRendering -= onBeginRendering;
             }
@@ -494,7 +503,11 @@ namespace Leap
 
 #if UNITY_2019_3_OR_NEWER
             //SRP require subscribing to RenderPipelineManagers
+#if UNITY_6000_0_OR_NEWER 
+            if (UnityEngine.Rendering.GraphicsSettings.defaultRenderPipeline != null)
+#else
             if (UnityEngine.Rendering.GraphicsSettings.renderPipelineAsset != null)
+#endif 
             {
                 UnityEngine.Rendering.RenderPipelineManager.beginCameraRendering -= onBeginRendering;
             }

--- a/Packages/Tracking/Core/Runtime/Scripts/LeapXRServiceProvider.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/LeapXRServiceProvider.cs
@@ -329,7 +329,11 @@ namespace Leap
                 mainCamera.AddTrackedPoseDriverToCamera();
             }
 
+#if UNITY_6000_0_OR_NEWER
+            if (GraphicsSettings.defaultRenderPipeline != null)
+#else
             if (GraphicsSettings.renderPipelineAsset != null)
+#endif            
             {
                 RenderPipelineManager.beginCameraRendering -= onBeginRendering;
                 RenderPipelineManager.beginCameraRendering += onBeginRendering;
@@ -356,7 +360,11 @@ namespace Leap
         {
             resetShaderTransforms();
 
+#if UNITY_6000_0_OR_NEWER
+            if (GraphicsSettings.defaultRenderPipeline != null)
+#else
             if (GraphicsSettings.renderPipelineAsset != null)
+#endif
             {
                 RenderPipelineManager.beginCameraRendering -= onBeginRendering;
             }

--- a/Packages/Tracking/Core/Runtime/Scripts/Utils/HandTrackingHintManager.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Utils/HandTrackingHintManager.cs
@@ -147,7 +147,12 @@ namespace Leap
             {
                 if (_leapController == null) // Find any existing controller
                 {
+#if UNITY_6000_0_OR_NEWER
+                    LeapServiceProvider provider =
+                        UnityEngine.Object.FindFirstObjectByType<LeapServiceProvider>(FindObjectsInactive.Include);
+#else
                     LeapServiceProvider provider = UnityEngine.Object.FindObjectOfType<LeapServiceProvider>(true);
+#endif
 
                     if (provider != null && provider.GetLeapController() != null)
                     {

--- a/Packages/Tracking/Core/Runtime/Scripts/Utils/HandUtils.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Utils/HandUtils.cs
@@ -39,7 +39,6 @@ namespace Leap
             // Fall through to the best available Leap Provider if none is assigned
             if (s_provider == null)
             {
-#if UNITY_2021_3_18_OR_NEWER
                 s_provider = UnityEngine.Object.FindAnyObjectByType<PostProcessProvider>();
 
                 if (s_provider == null)
@@ -56,23 +55,6 @@ namespace Leap
                         }
                     }
                 }
-#else
-                s_provider = UnityEngine.Object.FindObjectOfType<PostProcessProvider>();
-
-                if (s_provider == null)
-                {
-                    s_provider = UnityEngine.Object.FindObjectOfType<XRLeapProviderManager>();
-                    if (s_provider == null)
-                    {
-                        s_provider = UnityEngine.Object.FindObjectOfType<LeapProvider>();
-                        if (s_provider == null)
-                        {
-                            Debug.Log("There are no Leap Providers in the scene, please assign one manually");
-                            return;
-                        }
-                    }
-                }
-#endif
             }
 
             Debug.Log("LeapProvider was not assigned. Auto assigning: " + s_provider);

--- a/Packages/Tracking/Core/Runtime/Scripts/Utils/ServiceCallbacks.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Utils/ServiceCallbacks.cs
@@ -19,17 +19,10 @@ public class ServiceCallbacks : AndroidJavaProxy
         // Ensure we disconnect if the service becomes unbound to prevent
         // a TIME_WAIT state on the Service TCP socket/address
 
-#if UNITY_2021_3_18_OR_NEWER
         foreach (var provider in GameObject.FindObjectsByType<Leap.LeapServiceProvider>(FindObjectsSortMode.None))
         {
             provider.destroyController();
         }
-#else
-        foreach (var provider in GameObject.FindObjectsOfType< Leap.LeapServiceProvider>())
-        {
-            provider.destroyController();
-        }
-#endif
     }
 }
 #endif

--- a/Packages/Tracking/Core/Runtime/Scripts/Utils/ServiceCallbacks.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Utils/ServiceCallbacks.cs
@@ -20,7 +20,7 @@ public class ServiceCallbacks : AndroidJavaProxy
         // a TIME_WAIT state on the Service TCP socket/address
 
 #if UNITY_2021_3_18_OR_NEWER
-        foreach (var provider in GameObject.FindObjectsByType< Leap.LeapServiceProvider>(FindObjectsSortMode.None))
+        foreach (var provider in GameObject.FindObjectsByType<Leap.LeapServiceProvider>(FindObjectsSortMode.None))
         {
             provider.destroyController();
         }

--- a/Packages/Tracking/Core/Runtime/Scripts/XRHandsSubsystem/SubsystemStarter.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/XRHandsSubsystem/SubsystemStarter.cs
@@ -89,11 +89,8 @@ namespace Leap
             {
                 return;
             }
-#if UNITY_2021_3_18_OR_NEWER
             LeapProvider leapProvider = GameObject.FindAnyObjectByType<LeapXRServiceProvider>();
-#else
-            LeapProvider leapProvider = GameObject.FindObjectOfType<LeapXRServiceProvider>();
-#endif
+
             // If there is no leap provider in the scene
             if (leapProvider == null)
             {

--- a/Packages/Tracking/Core/Runtime/Scripts/XRHandsSubsystem/Ultraleap.Tracking.XRHands.asmdef
+++ b/Packages/Tracking/Core/Runtime/Scripts/XRHandsSubsystem/Ultraleap.Tracking.XRHands.asmdef
@@ -29,11 +29,6 @@
             "name": "com.unity.inputsystem",
             "expression": "1.5.0",
             "define": "INPUT_SYSTEM"
-        },
-        {
-            "name": "Unity",
-            "expression": "2021.3.18f1",
-            "define": "UNITY_2021_3_18_OR_NEWER"
         }
     ],
     "noEngineReferences": false

--- a/Packages/Tracking/Core/Runtime/Ultraleap.Tracking.Core.asmdef
+++ b/Packages/Tracking/Core/Runtime/Ultraleap.Tracking.Core.asmdef
@@ -20,11 +20,6 @@
             "define": "XR_MANAGEMENT_AVAILABLE"
         },
         {
-            "name": "Unity",
-            "expression": "2021.3.18f1",
-            "define": "UNITY_2021_3_18_OR_NEWER"
-        },
-        {
             "name": "com.unity.inputsystem",
             "expression": "1.0",
             "define": "INPUT_SYSTEM_AVAILABLE"

--- a/Packages/Tracking/Examples~/Shared Example Assets REQUIRED/Scripts/CycleHandPairs.cs
+++ b/Packages/Tracking/Examples~/Shared Example Assets REQUIRED/Scripts/CycleHandPairs.cs
@@ -22,11 +22,7 @@ namespace Leap.HandsModule.Examples
         {
             if (handModelManager == null)
             {
-#if UNITY_2021_3_18_OR_NEWER
                 handModelManager = FindAnyObjectByType<HandModelManager>();
-#else
-                handModelManager = FindObjectOfType<HandModelManager>();
-#endif
                 if (handModelManager == null)
                 {
                     Debug.LogWarning("CycleHandPairs needs a HandModelManager in the scene");

--- a/Packages/Tracking/Examples~/XR Examples/Example Assets/Anchors/scripts/WorkstationBehaviourExample.cs
+++ b/Packages/Tracking/Examples~/XR Examples/Example Assets/Anchors/scripts/WorkstationBehaviourExample.cs
@@ -103,7 +103,11 @@ namespace Leap.Examples
         {
             // If the velocity of the object while grasped is too large, exit workstation mode.
             if (workstationState == WorkstationState.Open
-                && (_rigidbody.velocity.magnitude > MAX_SPEED_AS_WORKSTATION))
+#if UNITY_6000_0_OR_NEWER
+                && _rigidbody.linearVelocity.magnitude > MAX_SPEED_AS_WORKSTATION)
+#else
+                && _rigidbody.velocity.magnitude > MAX_SPEED_AS_WORKSTATION)
+#endif
             {
                 DeactivateWorkstation();
             }

--- a/Packages/Tracking/Examples~/XR Examples/Example Assets/Physical Hands/Scripts/Editor/Leap.Unity.PhysicalHandsExamples.Editor.asmdef.meta
+++ b/Packages/Tracking/Examples~/XR Examples/Example Assets/Physical Hands/Scripts/Editor/Leap.Unity.PhysicalHandsExamples.Editor.asmdef.meta
@@ -1,12 +1,6 @@
 fileFormatVersion: 2
-<<<<<<<< HEAD:Packages/Tracking/Examples~/XR Examples/Example Assets Old/Scripts/Editor.meta
-guid: c9b610b08f9944b4cbbc0125124f50b8
-folderAsset: yes
-DefaultImporter:
-========
 guid: b46db0e2b3f8a96409ba2864150e2888
 AssemblyDefinitionImporter:
->>>>>>>> PhysicalHandsCombinedSystems:Packages/Tracking/Examples~/XR Examples/Example Assets/Physical Hands/Scripts/Editor/Leap.Unity.PhysicalHandsExamples.Editor.asmdef.meta
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/Packages/Tracking/Examples~/XR Examples/Example Assets/Physical Hands/Scripts/HandGrabHighlighter.cs
+++ b/Packages/Tracking/Examples~/XR Examples/Example Assets/Physical Hands/Scripts/HandGrabHighlighter.cs
@@ -51,7 +51,11 @@ namespace Leap.PhysicalHands.Examples
 
             if (automaticEvents)
             {
+#if UNITY_6000_0_OR_NEWER
+                PhysicalHandsManager physManager = FindFirstObjectByType<PhysicalHandsManager>();
+#else
                 PhysicalHandsManager physManager = FindObjectOfType<PhysicalHandsManager>();
+#endif
 
                 if (physManager != null)
                 {

--- a/Packages/Tracking/Examples~/XR Examples/Example Assets/Physical Hands/Scripts/ObjectResetter.cs
+++ b/Packages/Tracking/Examples~/XR Examples/Example Assets/Physical Hands/Scripts/ObjectResetter.cs
@@ -55,7 +55,11 @@ namespace Leap.Examples
                 {
                     for (int i = 0; i < rbs.Length; i++)
                     {
+#if UNITY_6000_0_OR_NEWER
+                        rbs[i].linearVelocity = Vector3.zero;
+#else
                         rbs[i].velocity = Vector3.zero;
+#endif
                         rbs[i].angularVelocity = Vector3.zero;
                         rbs[i].MovePosition(rbPositions[i]);
                         rbs[i].MoveRotation(rbRotations[i]);

--- a/Packages/Tracking/Examples~/XR Examples/Example Assets/Physical Hands/Scripts/PhysicalHandsRocket.cs
+++ b/Packages/Tracking/Examples~/XR Examples/Example Assets/Physical Hands/Scripts/PhysicalHandsRocket.cs
@@ -63,7 +63,11 @@ namespace Leap.PhysicalHands.Examples
                 _particleSystem.Play();
             }
 
+#if UNITY_6000_0_OR_NEWER
+            _rigidbody.angularDamping = 20;
+#else
             _rigidbody.angularDrag = 20;
+#endif
             _rigidbody.useGravity = true;
             float timePassed = 0;
             while (timePassed < burnTime)

--- a/Packages/Tracking/Examples~/XR Examples/Example Assets/Physical Hands/Scripts/TwoDimensionalPhysicalHandsSlider.cs
+++ b/Packages/Tracking/Examples~/XR Examples/Example Assets/Physical Hands/Scripts/TwoDimensionalPhysicalHandsSlider.cs
@@ -255,7 +255,11 @@ namespace Leap.PhysicalHandsExamples
 
 
             // Reset velocity to zero and update the position of the slider object
+#if UNITY_6000_0_OR_NEWER
+            _slideableObjectRigidbody.linearVelocity = Vector3.zero;
+#else
             _slideableObjectRigidbody.velocity = Vector3.zero;
+#endif
             _slideableObjectRigidbody.transform.localPosition = slidePos;
             // Calculate the slider value based on the change in position
 
@@ -378,7 +382,11 @@ namespace Leap.PhysicalHandsExamples
             slidePos.z = Utils.Map(twoDimValue.y, 0, 1, 0, _localTwoDimSliderTravelDistanceHalf.y * 2) + _sliderZZeroPos;
 
             // Reset velocity to zero and update the position of the slider object
+#if UNITY_6000_0_OR_NEWER
+            _slideableObjectRigidbody.linearVelocity = Vector3.zero;
+#else
             _slideableObjectRigidbody.velocity = Vector3.zero;
+#endif
             _slideableObjectRigidbody.transform.localPosition = slidePos;
         }
 

--- a/Packages/Tracking/Examples~/XR Examples/Example Assets/Physical Hands/Scripts/Ultraleap.Tracking.PhysicalHandsExamples.asmdef
+++ b/Packages/Tracking/Examples~/XR Examples/Example Assets/Physical Hands/Scripts/Ultraleap.Tracking.PhysicalHandsExamples.asmdef
@@ -22,11 +22,6 @@
             "name": "com.unity.xr.core-utils",
             "expression": "1.0",
             "define": "XR_UTILS_AVAILABLE"
-        },
-        {
-            "name": "Unity",
-            "expression": "2021.3.18f1",
-            "define": "UNITY_2021_3_18_OR_NEWER"
         }
     ],
     "noEngineReferences": false

--- a/Packages/Tracking/Examples~/XR Examples/Example Assets/Physical Hands/Scripts/XRSceneHeadOrigin.cs
+++ b/Packages/Tracking/Examples~/XR Examples/Example Assets/Physical Hands/Scripts/XRSceneHeadOrigin.cs
@@ -54,11 +54,7 @@ namespace Leap.Examples
 
 #if XR_UTILS_AVAILABLE
             // Look for an XROrigin
-#if UNITY_2021_3_18_OR_NEWER
             XROrigin xROrigin = FindAnyObjectByType<XROrigin>();
-#else
-            XROrigin xROrigin = FindObjectOfType<XROrigin>();
-#endif
             if (xROrigin != null)
             {
                 // use the XROrigin and exit out

--- a/Packages/Tracking/Hands/Runtime/Scripts/HandModelManager.cs
+++ b/Packages/Tracking/Hands/Runtime/Scripts/HandModelManager.cs
@@ -43,11 +43,7 @@ namespace Leap.HandsModule
         /// </summary>
         public void RegisterAllUnregisteredHandModels()
         {
-#if UNITY_2021_3_18_OR_NEWER
             HandModelBase[] potentiallyUnpairedHandModels = FindObjectsByType<HandModelBase>(FindObjectsInactive.Include, FindObjectsSortMode.None);
-#else
-            HandModelBase[] potentiallyUnpairedHandModels = FindObjectsOfType<HandModelBase>(true);
-#endif
             for (int i = 0; i < potentiallyUnpairedHandModels.Length; i++)
             {
                 if (!IsRegistered(potentiallyUnpairedHandModels[i]))

--- a/Packages/Tracking/Hands/Runtime/Ultraleap.Tracking.Hands.asmdef
+++ b/Packages/Tracking/Hands/Runtime/Ultraleap.Tracking.Hands.asmdef
@@ -12,12 +12,5 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [
-        {
-            "name": "Unity",
-            "expression": "2021.3.18f1",
-            "define": "UNITY_2021_3_18_OR_NEWER"
-        }
-    ],
     "noEngineReferences": false
 }

--- a/Packages/Tracking/Physical Hands/Editor/Scripts/PhysicalHandsSettingsPopup.cs
+++ b/Packages/Tracking/Physical Hands/Editor/Scripts/PhysicalHandsSettingsPopup.cs
@@ -39,7 +39,11 @@ namespace Leap.PhysicalHands
 
         private static void ShowPopupIfRequired()
         {
-            if (GameObject.FindObjectOfType<PhysicalHandsManager>() != null
+#if UNITY_6000_0_OR_NEWER
+            if (Object.FindFirstObjectByType<PhysicalHandsManager>() != null
+#else
+            if (Object.FindObjectOfType<PhysicalHandsManager>() != null
+#endif
                 && UltraleapSettings.Instance.showPhysicalHandsPhysicsSettingsWarning == true
                 && !PhysicalHandsSettings.AllSettingsApplied())
             {

--- a/Packages/Tracking/Physical Hands/Editor/Ultraleap.Tracking.PhysicalHands.Editor.asmdef
+++ b/Packages/Tracking/Physical Hands/Editor/Ultraleap.Tracking.PhysicalHands.Editor.asmdef
@@ -21,11 +21,6 @@
             "name": "com.unity.burst",
             "expression": "",
             "define": "BURST_AVAILABLE"
-        },
-        {
-            "name": "Unity",
-            "expression": "2021.3.18f1",
-            "define": "UNITY_2021_3_18_OR_NEWER"
         }
     ],
     "noEngineReferences": false

--- a/Packages/Tracking/Physical Hands/Runtime/Scripts/ContactHand.cs
+++ b/Packages/Tracking/Physical Hands/Runtime/Scripts/ContactHand.cs
@@ -275,12 +275,20 @@ namespace Leap.PhysicalHands
 
             if (palmBone.rigid != null)
             {
+#if UNITY_6000_0_OR_NEWER
+                _velocity = palmBone.rigid.linearVelocity;
+#else
                 _velocity = palmBone.rigid.velocity;
+#endif 
                 _angularVelocity = palmBone.rigid.angularVelocity;
             }
             else if (palmBone.articulation != null)
             {
+#if UNITY_6000_0_OR_NEWER
+                _velocity = palmBone.articulation.linearVelocity;
+#else
                 _velocity = palmBone.articulation.velocity;
+#endif 
                 _angularVelocity = palmBone.articulation.angularVelocity;
             }
         }

--- a/Packages/Tracking/Physical Hands/Runtime/Scripts/Hard Contact/HardContactBone.cs
+++ b/Packages/Tracking/Physical Hands/Runtime/Scripts/Hard Contact/HardContactBone.cs
@@ -191,7 +191,11 @@ namespace Leap.PhysicalHands
             delta = delta / Time.fixedDeltaTime;
             delta = delta * hardContactHand.contactForceModifier;
 
+#if UNITY_6000_0_OR_NEWER 
+            articulation.linearVelocity = delta;
+#else
             articulation.velocity = delta;
+#endif 
 
             Quaternion rotationDelta = Quaternion.Normalize(Quaternion.Slerp(Quaternion.identity, hand.Rotation * Quaternion.Inverse(transform.rotation), hardContactHand.contactForceModifier));
 

--- a/Packages/Tracking/Physical Hands/Runtime/Scripts/Hard Contact/HardContactHand.cs
+++ b/Packages/Tracking/Physical Hands/Runtime/Scripts/Hard Contact/HardContactHand.cs
@@ -152,7 +152,11 @@ namespace Leap.PhysicalHands
 
         internal override void PostFixedUpdateHandLogic()
         {
+#if UNITY_6000_0_OR_NEWER
+            _velocity = ((HardContactBone)palmBone).articulation.linearVelocity;
+#else
             _velocity = ((HardContactBone)palmBone).articulation.velocity;
+#endif 
             _angularVelocity = ((HardContactBone)palmBone).articulation.angularVelocity;
             CalculateDisplacementsAndLimits();
         }

--- a/Packages/Tracking/Physical Hands/Runtime/Scripts/Hard Contact/HardContactParent.cs
+++ b/Packages/Tracking/Physical Hands/Runtime/Scripts/Hard Contact/HardContactParent.cs
@@ -12,7 +12,11 @@ namespace Leap.PhysicalHands
 {
     public class HardContactParent : ContactParent
     {
+#if UNITY_6000_0_OR_NEWER
+        public PhysicsMaterial physicsMaterial;
+#else
         public PhysicMaterial physicsMaterial;
+#endif 
 
         #region Settings
         public float maxPalmVelocity = 300f;
@@ -37,15 +41,22 @@ namespace Leap.PhysicalHands
             GenerateHandsObjects(typeof(HardContactHand));
         }
 
+#if UNITY_6000_0_OR_NEWER
+        private static PhysicsMaterial CreateHandPhysicsMaterial()
+        {
+            PhysicsMaterial material = new PhysicsMaterial("HandPhysics");
+            material.frictionCombine = PhysicsMaterialCombine.Average;
+            material.bounceCombine = PhysicsMaterialCombine.Minimum;
+#else
         private static PhysicMaterial CreateHandPhysicsMaterial()
         {
             PhysicMaterial material = new PhysicMaterial("HandPhysics");
-
-            material.dynamicFriction = 1f;
-            material.staticFriction = 1f;
             material.frictionCombine = PhysicMaterialCombine.Average;
             material.bounceCombine = PhysicMaterialCombine.Minimum;
-
+#endif
+            material.dynamicFriction = 1f;
+            material.staticFriction = 1f;
+           
             return material;
         }
     }

--- a/Packages/Tracking/Physical Hands/Runtime/Scripts/Helpers/GrabHelperObject.cs
+++ b/Packages/Tracking/Physical Hands/Runtime/Scripts/Helpers/GrabHelperObject.cs
@@ -211,9 +211,14 @@ namespace Leap.PhysicalHands
 
             wasKinematic = _rigid.isKinematic;
             usedGravity = _rigid.useGravity;
+#if UNITY_6000_0_OR_NEWER
+            oldDrag = _rigid.linearDamping;
+            oldAngularDrag = _rigid.angularDamping;
+#else
             oldDrag = _rigid.drag;
-            oldMass = _rigid.mass;
             oldAngularDrag = _rigid.angularDrag;
+#endif 
+            oldMass = _rigid.mass;
             _rigid.TryGetComponents<IPhysicalHandGrab>(out _physicalHandGrabs);
             _rigid.TryGetComponents<IPhysicalHandHover>(out _physicalHandHovers);
             _rigid.TryGetComponents<IPhysicalHandPrimaryHover>(out _physicalHandPrimaryHovers);
@@ -236,8 +241,14 @@ namespace Leap.PhysicalHands
                 }
 
                 _rigid.useGravity = false;
+
+#if UNITY_6000_0_OR_NEWER
+                _rigid.linearDamping = 0f;
+                _rigid.angularDamping = 0f;
+#else
                 _rigid.drag = 0f;
                 _rigid.angularDrag = 0f;
+#endif 
                 _rigid.mass = 1f;
             }
         }
@@ -248,8 +259,14 @@ namespace Leap.PhysicalHands
             {
                 _rigid.isKinematic = wasKinematic;
                 _rigid.useGravity = usedGravity;
+
+#if UNITY_6000_0_OR_NEWER
+                _rigid.linearDamping = oldDrag;
+                _rigid.angularDamping = oldAngularDrag;
+#else
                 _rigid.drag = oldDrag;
                 _rigid.angularDrag = oldAngularDrag;
+#endif 
                 _rigid.mass = oldMass;
             }
         }
@@ -1111,7 +1128,11 @@ namespace Leap.PhysicalHands
                 targetVelocity *= targetPercent;
             }
 
+#if UNITY_6000_0_OR_NEWER
+            _rigid.linearVelocity = targetVelocity;
+#else
             _rigid.velocity = targetVelocity;
+#endif 
             if (targetAngularVelocity.IsValid())
             {
                 _rigid.angularVelocity = targetAngularVelocity;
@@ -1146,8 +1167,11 @@ namespace Leap.PhysicalHands
 
         private void TrackThrowingVelocities()
         {
-            _velocityQueue.Enqueue(new VelocitySample(_rigid.velocity,
-                                                      Time.time + VELOCITY_HISTORY_LENGTH));
+#if UNITY_6000_0_OR_NEWER
+            _velocityQueue.Enqueue(new VelocitySample(_rigid.linearVelocity, Time.time + VELOCITY_HISTORY_LENGTH));
+#else
+            _velocityQueue.Enqueue(new VelocitySample(_rigid.velocity, Time.time + VELOCITY_HISTORY_LENGTH));
+#endif 
 
             while (true)
             {
@@ -1207,11 +1231,19 @@ namespace Leap.PhysicalHands
                 ignoreGrabTime = Time.time + THOWN_GRAB_COOLDOWNTIME;
 
                 // Set the new velocty. Allow physics to solve for rotational change
+#if UNITY_6000_0_OR_NEWER
+                _rigid.linearVelocity = averageVelocity;
+#else
                 _rigid.velocity = averageVelocity;
+#endif
             }
             else
             {
+#if UNITY_6000_0_OR_NEWER
+                _rigid.linearVelocity = Vector3.zero;
+#else
                 _rigid.velocity = Vector3.zero;
+#endif 
                 _rigid.angularVelocity = Vector3.zero;
             }
         }

--- a/Packages/Tracking/Physical Hands/Runtime/Scripts/Soft Contact/SoftContactBone.cs
+++ b/Packages/Tracking/Physical Hands/Runtime/Scripts/Soft Contact/SoftContactBone.cs
@@ -58,7 +58,11 @@ namespace Leap.PhysicalHands
                 Collider.attachedRigidbody.rotation = targetRotation;
                 gameObject.layer = contactParent.physicalHandsManager.HandsResetLayer;
 
+#if UNITY_6000_0_OR_NEWER
+                Collider.attachedRigidbody.linearVelocity = Vector3.zero;
+#else
                 Collider.attachedRigidbody.velocity = Vector3.zero;
+#endif 
                 Collider.attachedRigidbody.angularVelocity = Vector3.zero;
                 lastTargetPosition = Collider.attachedRigidbody.position;
                 return;
@@ -82,7 +86,11 @@ namespace Leap.PhysicalHands
 
             if (deltaMag <= DEAD_ZONE)
             {
+#if UNITY_6000_0_OR_NEWER
+                Collider.attachedRigidbody.linearVelocity = Vector3.zero;
+#else
                 Collider.attachedRigidbody.velocity = Vector3.zero;
+#endif
                 lastTargetPosition = Collider.attachedRigidbody.position;
             }
             else
@@ -91,7 +99,12 @@ namespace Leap.PhysicalHands
                 lastTargetPosition = Collider.attachedRigidbody.position + delta;
 
                 Vector3 targetVelocity = delta / Time.fixedDeltaTime;
+
+#if UNITY_6000_0_OR_NEWER
+                Collider.attachedRigidbody.linearVelocity = targetVelocity;
+#else
                 Collider.attachedRigidbody.velocity = targetVelocity;
+#endif
             }
 
             Quaternion deltaRot = targetRotation * Quaternion.Inverse(Collider.attachedRigidbody.rotation);

--- a/Packages/Tracking/Physical Hands/Runtime/Scripts/Soft Contact/SoftContactParent.cs
+++ b/Packages/Tracking/Physical Hands/Runtime/Scripts/Soft Contact/SoftContactParent.cs
@@ -13,8 +13,13 @@ namespace Leap.PhysicalHands
     public class SoftContactParent : ContactParent
     {
         [SerializeField, HideInInspector]
+#if UNITY_6000_0_OR_NEWER
+        private PhysicsMaterial _physicsMaterial;
+        internal PhysicsMaterial PhysicsMaterial => _physicsMaterial;
+#else
         private PhysicMaterial _physicsMaterial;
         internal PhysicMaterial PhysicsMaterial => _physicsMaterial;
+#endif
 
         internal override void GenerateHands()
         {
@@ -22,15 +27,21 @@ namespace Leap.PhysicalHands
             GenerateHandsObjects(typeof(SoftContactHand));
         }
 
+#if UNITY_6000_0_OR_NEWER
+        private static PhysicsMaterial CreateHandPhysicsMaterial()
+        {
+            PhysicsMaterial material = new PhysicsMaterial("HandPhysics");
+            material.frictionCombine = PhysicsMaterialCombine.Average;
+            material.bounceCombine = PhysicsMaterialCombine.Minimum;
+#else
         private static PhysicMaterial CreateHandPhysicsMaterial()
         {
             PhysicMaterial material = new PhysicMaterial("HandPhysics");
-
-            material.dynamicFriction = 1f;
-            material.staticFriction = 1f;
             material.frictionCombine = PhysicMaterialCombine.Average;
             material.bounceCombine = PhysicMaterialCombine.Minimum;
-
+#endif 
+            material.dynamicFriction = 1f;
+            material.staticFriction = 1f;
             return material;
         }
 

--- a/Packages/Tracking/Physical Hands/Runtime/Scripts/UI/PhysicalHandsSlider.cs
+++ b/Packages/Tracking/Physical Hands/Runtime/Scripts/UI/PhysicalHandsSlider.cs
@@ -308,7 +308,11 @@ namespace Leap.PhysicalHands
             slidePos = _slideableObject.transform.localRotation * slidePos;
 
             // Reset velocity to zero and update the position of the slider object
+#if UNITY_6000_0_OR_NEWER
+            _slideableObjectRigidbody.linearVelocity = Vector3.zero;
+#else
             _slideableObjectRigidbody.velocity = Vector3.zero;
+#endif 
             _slideableObjectRigidbody.transform.localPosition = slidePos;
 
             // Calculate the slider value based on the change in position
@@ -451,7 +455,11 @@ namespace Leap.PhysicalHands
             }
 
             // Reset velocity to zero and update the position of the slider object
+#if UNITY_6000_0_OR_NEWER
+            _slideableObjectRigidbody.linearVelocity = Vector3.zero;
+#else
             _slideableObjectRigidbody.velocity = Vector3.zero;
+#endif
             _slideableObjectRigidbody.transform.localPosition = slidePos;
         }
 

--- a/Packages/Tracking/Physical Hands/Runtime/Scripts/Utils/ContactUtils.cs
+++ b/Packages/Tracking/Physical Hands/Runtime/Scripts/Utils/ContactUtils.cs
@@ -29,7 +29,11 @@ namespace Leap.PhysicalHands
             return new Vector3(hand.PalmWidth, hand.fingers[2].GetBone(0).Width, Vector3.Distance(CalculateAverageKnucklePosition(hand), hand.WristPosition));
         }
 
+#if UNITY_6000_0_OR_NEWER
+        internal static void SetupPalmCollider(BoxCollider collider, CapsuleCollider[] palmEdges, Hand hand, PhysicsMaterial material = null)
+#else
         internal static void SetupPalmCollider(BoxCollider collider, CapsuleCollider[] palmEdges, Hand hand, PhysicMaterial material = null)
+#endif 
         {
             Vector3 palmSize = CalculatePalmSize(hand);
             if (palmEdges != null)
@@ -100,7 +104,11 @@ namespace Leap.PhysicalHands
             }
         }
 
+#if UNITY_6000_0_OR_NEWER
+        internal static void SetupBoneCollider(CapsuleCollider collider, Bone bone, PhysicsMaterial material = null)
+#else
         internal static void SetupBoneCollider(CapsuleCollider collider, Bone bone, PhysicMaterial material = null)
+#endif 
         {
             collider.direction = 2;
             if (bone.Width <= 0) { bone.Width = 0.01f; }

--- a/Packages/Tracking/Physical Hands/Runtime/Scripts/Utils/HandFadeInAtDistanceFromRealData.cs
+++ b/Packages/Tracking/Physical Hands/Runtime/Scripts/Utils/HandFadeInAtDistanceFromRealData.cs
@@ -71,7 +71,11 @@ namespace Leap.PhysicalHands
 
             if (physManager == null)
             {
+#if UNITY_6000_0_OR_NEWER
+                physManager = FindFirstObjectByType<PhysicalHandsManager>();
+#else
                 physManager = FindObjectOfType<PhysicalHandsManager>();
+#endif
             }
 
             if (physManager != null)

--- a/Packages/Tracking/Physical Hands/Runtime/Ultraleap.Tracking.PhysicalHands.asmdef
+++ b/Packages/Tracking/Physical Hands/Runtime/Ultraleap.Tracking.PhysicalHands.asmdef
@@ -10,15 +10,5 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [
-        "UNITY_2021_3_OR_NEWER"
-    ],
-    "versionDefines": [
-        {
-            "name": "Unity",
-            "expression": "2021.3.18f1",
-            "define": "UNITY_2021_3_18_OR_NEWER"
-        }
-    ],
     "noEngineReferences": false
 }


### PR DESCRIPTION
## Summary

Fixes up script changes that will be requested by Unity when using the plugin in Unity 6, due to breaking Unity API changes. Does not attempt to fix issues with the move to SRP from BiRP and the effect that has on the sample scenes/materials. At some stage we should split the samples into BiRP and SRP. However, there are two URP samples and I checked that worked with 6.

## Contributor Tasks

- [ ] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [X] Add a CHANGELOG entry for this change.
- [X] Ensure documentation requirements are met e.g., public API is commented.
- [X] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Test Cycle

_Link to the test cycle here._

## Reviewer Tasks

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [ ] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_

## Pull Request Templates

Switch template by going to preview and clicking the link - note it will not work if you've made any changes to the description.

- [default.md](?expand=1) - for contributions to stable packages.
- [release.md](?expand=1&template=release.md) - for release merge requests.

**You are currently using: default.md**

Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.
