### PR TITLE
ServerStatus checks on a thread

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multi device mode will no longer be requested on Connection if arg is set to false
 - Fixed issue with Unity 6 triggering warnings for scripts that need to be upgraded due to Unity 6 API changes
 - Fixed a broken meta file in Physical Hands XR Examples
+- Fixed a frequent editor freeze that would occur when the Leap service is stopped/uninstalled 
 
   ### Known issues
 - The Unity editor will become slow or unresposive with a scene containing a Leap Provider (XR), which has had the multiple device mode enabled and if the tracking service is not running

--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/ServerStatus.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/ServerStatus.cs
@@ -24,7 +24,6 @@ namespace LeapInternal
 
         public static void GetStatus()
         {
-            Debug.Log(lastStatus.version);
             if (isCheckingStatus)
                 return;
 

--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/ServerStatus.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/ServerStatus.cs
@@ -9,65 +9,101 @@
 namespace LeapInternal
 {
     using System;
-    using System.Linq.Expressions;
     using System.Runtime.InteropServices;
     using System.Threading;
-    using UnityEngine;
 
     public static class ServerStatus
     {
-        static LeapC.LEAP_SERVER_STATUS lastStatus;
-        static LeapC.LEAP_SERVER_STATUS_DEVICE[] lastDevices;
-
-        static readonly object lockObject = new object();
-        static bool isCheckingStatus = false;
-
-        public static void GetStatus()
+        private static class ServerStatusChecker
         {
-            if (isCheckingStatus)
-                return;
-
-            Thread thread = new Thread(() =>
+            public static LeapC.LEAP_SERVER_STATUS LastStatus
             {
-                isCheckingStatus = true;
-                while (true)
+                get
                 {
-                    UpdateStatus();
-                    Thread.Sleep(10000);
+                    GetStatus();
+                    LeapC.LEAP_SERVER_STATUS status;
+                    lock (lockObject)
+                        status = lastStatus;
+                    return status;
                 }
-            });
-            thread.IsBackground = true;
-            thread.Start();
-        }
+            }
+            static LeapC.LEAP_SERVER_STATUS lastStatus;
 
-        private static void UpdateStatus()
-        {
-            IntPtr statusPtr = new IntPtr();
-            LeapC.GetServerStatus(1500, ref statusPtr);
-
-            if (statusPtr != IntPtr.Zero)
+            public static LeapC.LEAP_SERVER_STATUS_DEVICE[] LastDevices
             {
-                var status = Marshal.PtrToStructure<LeapC.LEAP_SERVER_STATUS>(statusPtr);
-                LeapC.LEAP_SERVER_STATUS_DEVICE[] devices;
-                MarshalUnmananagedArray2Struct(status.devices, (int)status.device_count, out devices);
-
-                lock (lockObject)
+                get
                 {
-                    lastStatus = status;
-                    lastDevices = devices;
+                    GetStatus();
+                    LeapC.LEAP_SERVER_STATUS_DEVICE[] devices;
+                    lock (lockObject)
+                        devices = lastDevices;
+                    return devices;
                 }
+            }
+            static LeapC.LEAP_SERVER_STATUS_DEVICE[] lastDevices;
 
-                LeapC.ReleaseServerStatus(ref status);
+            static readonly object lockObject = new object();
+            static bool isCheckingStatus = false;
+
+            private static void GetStatus()
+            {
+                if (isCheckingStatus)
+                    return;
+
+                UpdateStatus();
+
+                Thread thread = new Thread(() =>
+                {
+                    isCheckingStatus = true;
+                    while (true)
+                    {
+                        UpdateStatus();
+                        Thread.Sleep(10000);
+                    }
+                });
+                thread.IsBackground = true;
+                thread.Start();
+            }
+
+            private static void UpdateStatus()
+            {
+                IntPtr statusPtr = new IntPtr();
+                LeapC.GetServerStatus(1500, ref statusPtr);
+
+                if (statusPtr != IntPtr.Zero)
+                {
+                    var status = Marshal.PtrToStructure<LeapC.LEAP_SERVER_STATUS>(statusPtr);
+                    LeapC.LEAP_SERVER_STATUS_DEVICE[] devices;
+                    MarshalUnmananagedArray2Struct(status.devices, (int)status.device_count, out devices);
+
+                    lock (lockObject)
+                    {
+                        lastStatus = status;
+                        lastDevices = devices;
+                    }
+
+                    LeapC.ReleaseServerStatus(ref status);
+                }
+            }
+
+            private static void MarshalUnmananagedArray2Struct<T>(IntPtr unmanagedArray, int length, out T[] mangagedArray)
+            {
+                var size = Marshal.SizeOf(typeof(T));
+                mangagedArray = new T[length];
+
+                for (int i = 0; i < length; i++)
+                {
+                    IntPtr ins = new IntPtr(unmanagedArray.ToInt64() + i * size);
+                    mangagedArray[i] = Marshal.PtrToStructure<T>(ins);
+                }
             }
         }
 
         public static bool IsServiceVersionValid(LEAP_VERSION _requiredVersion)
         {
-            GetStatus();
-
-            if (lastStatus.version != null)
+            if (ServerStatusChecker.LastStatus.version != null)
             {
-                string[] versions = lastStatus.version.Split('v')[1].Split('-')[0].Split('.');
+                string[] versions = ServerStatusChecker.LastStatus.version.Split('v')[1].Split('-')[0].Split('.');
                 LEAP_VERSION curVersion = new LEAP_VERSION { major = int.Parse(versions[0]), minor = int.Parse(versions[1]), patch = int.Parse(versions[2]) };
 
                 if (curVersion.major > _requiredVersion.major)
@@ -91,15 +127,13 @@ namespace LeapInternal
 
         public static string[] GetSerialNumbers()
         {
-            GetStatus();
-
             string[] serials = new string[0];
-            if (lastDevices != null)
+            if (ServerStatusChecker.LastDevices != null)
             {
-                serials = new string[lastDevices.Length];
-                for (int i = 0; i < lastDevices.Length; i++)
+                serials = new string[ServerStatusChecker.LastDevices.Length];
+                for (int i = 0; i < ServerStatusChecker.LastDevices.Length; i++)
                 {
-                    serials[i] = lastDevices[i].serial;
+                    serials[i] = ServerStatusChecker.LastDevices[i].serial;
                 }
             }
 
@@ -108,32 +142,18 @@ namespace LeapInternal
 
         public static string GetDeviceType(string _serial)
         {
-            GetStatus();
-
-            if (lastDevices != null)
+            if (ServerStatusChecker.LastDevices != null)
             {
-                for (int i = 0; i < lastDevices.Length; i++)
+                for (int i = 0; i < ServerStatusChecker.LastDevices.Length; i++)
                 {
-                    if (_serial == "" || _serial == lastDevices[i].serial)
+                    if (_serial == "" || _serial == ServerStatusChecker.LastDevices[i].serial)
                     {
-                        return lastDevices[i].type;
+                        return ServerStatusChecker.LastDevices[i].type;
                     }
                 }
             }
 
             return "";
-        }
-
-        static void MarshalUnmananagedArray2Struct<T>(IntPtr unmanagedArray, int length, out T[] mangagedArray)
-        {
-            var size = Marshal.SizeOf(typeof(T));
-            mangagedArray = new T[length];
-
-            for (int i = 0; i < length; i++)
-            {
-                IntPtr ins = new IntPtr(unmanagedArray.ToInt64() + i * size);
-                mangagedArray[i] = Marshal.PtrToStructure<T>(ins);
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Modified `ServerStatus` so that it now checks the status on a thread every 10 seconds, rather than the previous method which checked on the main thread if 5 seconds had passed since the previous check.

This fixes a hang in editor when interacting with a LeapXRServiceProvider or LeapServiceProvider while the Leap service is stopped or uninstalled.

## Contributor Tasks

- [ ] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [ ] Add a CHANGELOG entry for this change.
- [ ] Ensure documentation requirements are met e.g., public API is commented.
- [ ] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Test Cycle

_Link to the test cycle here._

## Reviewer Tasks

- [x] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [ ] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_

## Pull Request Templates

Switch template by going to preview and clicking the link - note it will not work if you've made any changes to the description.

- [default.md](?expand=1) - for contributions to stable packages.
- [release.md](?expand=1&template=release.md) - for release merge requests.

**You are currently using: default.md**

Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.
