### PR TITLE
Undoing capsule hand fingertip adjustments and OpenXR related changes…

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -10,12 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added a warning to Physical Buttons when no Physical Hands Manager is in the scene
-- Added a checkbox to enable offsetting fingertip capsules in CapsuleHand
 - Added a checkbox to enable fiducial marker tracking within the LeapC service
 
 ### Changed
 - Non-convex MeshColliders are skipped when processing Physical Hands
-- Adjusted OpenXR fingertip data to match LeapC more closely
 - Removed old conditional support for Unity 2021.3.18 since 2022 is the oldest LTS version we support
 
 ### Fixed

--- a/Packages/Tracking/Core/Runtime/Scripts/Hands/CapsuleHand.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Hands/CapsuleHand.cs
@@ -73,9 +73,6 @@ namespace Leap
         [SerializeField]
         private bool _joinThumbProximal = true;
 
-        [Space, SerializeField, Tooltip("If enabled, this will back-offset the fingertip spheres to better represent actual tips.")]
-        private bool _offsetTipSphere = false;
-
         [Space, SerializeField]
         private bool _castShadows = true;
 
@@ -382,11 +379,6 @@ namespace Leap
                     else
                     {
                         position = finger.GetBone((Bone.BoneType)j).NextJoint;
-                        if (j == 3 && _offsetTipSphere)
-                        {
-                            // Fingertips need to be adjusted back by a radii to account for sphere drawing.
-                            position -= finger.GetBone((Bone.BoneType)j).Direction * _jointRadius;
-                        }
                     }
 
                     _spherePositions[key] = position;

--- a/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
+++ b/Packages/Tracking/OpenXR/Runtime/Scripts/OpenXRLeapProvider.cs
@@ -220,23 +220,14 @@ namespace Leap.Tracking.OpenXR
                         continue;
                     }
 
-                    var prevJointPosition = prevJoint.Pose.position;
-                    var nextJointPosition = nextJoint.Pose.position;
-                    
-                    // Adjust the fingertip positions forward by a radius to match LeapC data.
-                    if (boneIndex == 3)
-                    {
-                        nextJointPosition += prevJoint.Pose.forward * nextJoint.Radius;
-                    }
-
                     // Populate the finger bone information
                     var bone = hand.fingers[fingerIndex].bones[boneIndex];
                     bone.Fill(
-                        prevJointPosition,
-                        nextJointPosition,
-                        ((prevJointPosition + nextJointPosition) / 2f),
+                        prevJoint.Pose.position,
+                        nextJoint.Pose.position,
+                        ((prevJoint.Pose.position + nextJoint.Pose.position) / 2f),
                         prevJoint.Pose.forward,
-                        (prevJointPosition - nextJointPosition).magnitude,
+                        (prevJoint.Pose.position - nextJoint.Pose.position).magnitude,
                         prevJoint.Radius * 1.5f, // 1.5 to convert from joint radius to bone width (joints bigger than bones)
                         (Bone.BoneType)boneIndex,
                         prevJoint.Pose.rotation);


### PR DESCRIPTION
… - see PR1658

## Summary

Undoing the fingertip capsule adjustments and OpenXR changes, originally committed in https://github.com/ultraleap/UnityPlugin/pull/1658/files

## Contributor Tasks

- [X] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [X] Add a CHANGELOG entry for this change.
- [X] Ensure documentation requirements are met e.g., public API is commented.
- [X] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Test Cycle

_Link to the test cycle here._

## Reviewer Tasks

- [ ] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [ ] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_

## Pull Request Templates

Switch template by going to preview and clicking the link - note it will not work if you've made any changes to the description.

- [default.md](?expand=1) - for contributions to stable packages.
- [release.md](?expand=1&template=release.md) - for release merge requests.

**You are currently using: default.md**

Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.
