### PR TITLE
Fix some assigned by not used variable warnings

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [docs-website]: https://docs.ultraleap.com/unity-api/ "Ultraleap Docs"
 
+## [NEXT]
+
+### Fixed
+- Fixed some warnings around runtime variables that were only used in editor mode
+
 ## [7.2.0] - 17/01/2025
 
 ### Added

--- a/Packages/Tracking/Core/Runtime/Scripts/Attachments/AttachmentHand.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Attachments/AttachmentHand.cs
@@ -136,15 +136,14 @@ namespace Leap.Attachments
             initializeAttachmentPointFlagConstants();
         }
 
-#if !UNITY_EDITOR
-#endif
+#if UNITY_EDITOR
         private bool _isBeingDestroyed = false;
-#if !UNITY_EDITOR
-#endif
+
         void OnDestroy()
         {
             _isBeingDestroyed = true;
         }
+#endif
 
         /// <summary>
         /// Returns the AttachmentPointBehaviour child object of this AttachmentHand given a

--- a/Packages/Tracking/Core/Runtime/Scripts/Attributes/Indent.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Attributes/Indent.cs
@@ -15,10 +15,9 @@ namespace Leap.Attributes
 {
     public class IndentAttribute : CombinablePropertyAttribute, IBeforeLabelAdditiveDrawer
     {
-        float width = 20;
-
-
 #if UNITY_EDITOR
+        private float width;
+
         public IndentAttribute()
         {
             width = 20;
@@ -38,7 +37,6 @@ namespace Leap.Attributes
         {
             return width;
         }
-
 #endif
     }
 }


### PR DESCRIPTION
## Summary

Some variables were existing in runtime/editor mode but only being used in editor mode resulting in spurious warnings.

## Contributor Tasks

- [ ] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [x] Add a CHANGELOG entry for this change.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Test Cycle

_Link to the test cycle here._

## Reviewer Tasks

- [x] Code reviewed.
- [x] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [ ] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_

## Pull Request Templates

Switch template by going to preview and clicking the link - note it will not work if you've made any changes to the description.

- [default.md](?expand=1) - for contributions to stable packages.
- [release.md](?expand=1&template=release.md) - for release merge requests.

**You are currently using: default.md**

Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.
