### PR TITLE
Fix Physical Hands null reference exceptions on Unity 6

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed some warnings around runtime variables that were only used in editor mode
+- Fixed an issue with Physical Hands and Unity 6 due to the physics Contact Generation setting being removed
 
 ## [7.2.0] - 17/01/2025
 

--- a/Packages/Tracking/Physical Hands/Editor/Scripts/PhysicalHandsSettings.cs
+++ b/Packages/Tracking/Physical Hands/Editor/Scripts/PhysicalHandsSettings.cs
@@ -98,15 +98,17 @@ namespace Leap.PhysicalHands
                         description = "Automatically update transform positions and rotations in the physics sim. If enabled, may cause jitter on rigidbodies when grabbed."
                     }
                 },
+#if !UNITY_6000_0_OR_NEWER
                 {
                     ID_CONTACTS_GENERATION,
                     new RecommendedSetting()
                     {
                         property = _physicsManager.FindProperty(ID_CONTACTS_GENERATION),
                         recommended = "Persistent Contact Manifold",
-                        description = "Recommended default by unity for?generating contacts every physics frame."
+                        description = "Recommended default by unity for generating contacts every physics frame."
                     }
                 },
+#endif
                 {
                     ID_GRAVITY,
                     new RecommendedSetting()


### PR DESCRIPTION
## Summary

Fixes a null reference exception when accessing Physcial Hands settings on Unity 6 due to Contacts Generation setting being removed. This resolves #1672.

## Contributor Tasks

- [ ] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [x] Add a CHANGELOG entry for this change.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Test Cycle

_Link to the test cycle here._

## Reviewer Tasks

- [ ] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [ ] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_

## Pull Request Templates

Switch template by going to preview and clicking the link - note it will not work if you've made any changes to the description.

- [default.md](?expand=1) - for contributions to stable packages.
- [release.md](?expand=1&template=release.md) - for release merge requests.

**You are currently using: default.md**

Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.
