### PR TITLE
Add missing Unity UI dependency to preview package

### DIFF
--- a/Packages/Tracking Preview/package.json
+++ b/Packages/Tracking Preview/package.json
@@ -7,7 +7,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "com.ultraleap.tracking": "7.2.0",
-    "com.unity.inputsystem": "1.5.0"
+    "com.unity.inputsystem": "1.5.0",
+    "com.unity.ugui": "2.0.0"
   },
   "keywords": [
     "ultraleap",

--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed some warnings around runtime variables that were only used in editor mode
 - Fixed an issue with Physical Hands and Unity 6 due to the physics Contact Generation setting being removed
+- (UI Input Preview) Added explicit missing dependancy on the "Unity UI" package.
 
 ## [7.2.0] - 17/01/2025
 


### PR DESCRIPTION
## Summary

While importing the Tracking Preview package into an project with minimal packages, I realised that large portions of the Tracking Preview package (and specifically the UI Input module) depend on the "Unity UI" (`com.unity.ugui`) package. This change adds that as an explicit dependency so it's automatically satisfied.

We could alternatively use a version define and `#if def` out the module components to make it work either way (like we do with OpenXR), but this seemed the cleaner approach for now.

## Contributor Tasks

- [ ] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [ ] Add a CHANGELOG entry for this change.
- [ ] Ensure documentation requirements are met e.g., public API is commented.
- [ ] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Test Cycle

_Link to the test cycle here._

## Reviewer Tasks

- [ ] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [ ] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_

## Pull Request Templates

Switch template by going to preview and clicking the link - note it will not work if you've made any changes to the description.

- [default.md](?expand=1) - for contributions to stable packages.
- [release.md](?expand=1&template=release.md) - for release merge requests.

**You are currently using: default.md**

Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.
