### PR TITLE
Bug/fix pinch and grab detection event subscription and grab detection logic

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed some warnings around runtime variables that were only used in editor mode
 - Fixed an issue with Physical Hands and Unity 6 due to the physics Contact Generation setting being removed
 - (UI Input Preview) Added explicit missing dependancy on the "Unity UI" package
+- Clients were not able to subscribe to the events on the PinchDetector and GrabDetector scripts as the properties were exposed as readonly. 
+- GrabDetector detection logic was inverted, so open hands were interpreted as grabs. Now fixed.
 
 ### Changed
 - Updated all custom shaders to support the Universal Render Pipeline concurrently with the Built-in Render Pipeline

--- a/Packages/Tracking/Core/Runtime/Scripts/ActionDetectors/GrabDetector.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/ActionDetectors/GrabDetector.cs
@@ -34,9 +34,44 @@ namespace Leap
         public bool IsGrabbing => IsDoingAction;
 
         // Accessor actions for readability
-        public Action<Hand> OnGrabStart => onActionStart;
-        public Action<Hand> OnGrabEnd => onActionEnd;
-        public Action<Hand> OnGrabbing => onAction;
+        public Action<Hand> OnGrabStart
+        {
+            get
+            {
+                return onActionStart;
+            }
+
+            set
+            {
+                onActionStart = value;
+            }
+        }
+
+        public Action<Hand> OnGrabEnd
+        {
+            get
+            {
+                return onActionEnd;
+            }
+
+            set
+            {
+                onActionEnd = value;
+            }
+        }
+
+        public Action<Hand> OnGrabbing
+        {
+            get
+            {
+                return onAction;
+            }
+
+            set
+            {
+                onAction = value;
+            }
+        }
 
         /// <summary>
         /// Updates the grab status based on the hand data.
@@ -50,7 +85,8 @@ namespace Leap
             }
 
             float _grabStrength = _hand.GrabStrength;
-            if (_grabStrength < activateStrength)
+
+            if (_grabStrength > activateStrength)
             {
                 if (!IsDoingAction)
                 {
@@ -64,7 +100,7 @@ namespace Leap
 
                 IsDoingAction = true;
             }
-            else if (_grabStrength > deactivateStrength)
+            else if (_grabStrength < deactivateStrength)
             {
                 if (IsDoingAction)
                 {

--- a/Packages/Tracking/Core/Runtime/Scripts/ActionDetectors/PinchDetector.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/ActionDetectors/PinchDetector.cs
@@ -55,9 +55,45 @@ namespace Leap
         public bool IsPinching => IsDoingAction;
 
         // Accessor actions for readability
-        public Action<Hand> OnPinchStart => onActionStart;
-        public Action<Hand> OnPinchEnd => onActionEnd;
-        public Action<Hand> OnPinching => onAction;
+        public Action<Hand> OnPinchStart
+        {
+            get
+            {
+                return onActionStart;
+            }
+
+            set
+            {
+                onActionStart = value;
+            }
+        }
+
+        public Action<Hand> OnPinchEnd
+        {
+            get
+            {
+                return onActionEnd;
+            }
+
+            set
+            {
+                onActionEnd = value;
+            }
+        }
+
+        public Action<Hand> OnPinching
+        {
+            get
+            {
+                return onAction;
+            }
+
+            set
+            {
+                onAction = value;
+            }
+
+        }
 
         /// <summary>
         /// Updates the pinch status based on the hand data.


### PR DESCRIPTION
## Summary

Please do this before merging https://github.com/ultraleap/UnityPlugin/pull/1685

The PinchDetector and GrabDetector scripts were exposing properties for OnGrabStart/OnGrabbing/OnGrabEnd (same for pinch equivalents) as readonly. These could not be subscribed to. 

Also the grab detection logic was inverted. 

## Contributor Tasks

- [ ] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [X] Add a CHANGELOG entry for this change.
- [X] Ensure documentation requirements are met e.g., public API is commented.
- [X] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.


## Reviewer Tasks

- [ ] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [ ] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_

## Pull Request Templates

Switch template by going to preview and clicking the link - note it will not work if you've made any changes to the description.

- [default.md](?expand=1) - for contributions to stable packages.
- [release.md](?expand=1&template=release.md) - for release merge requests.

**You are currently using: default.md**

Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.
